### PR TITLE
Allow build for perl 5.26.1

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use 5.028002;
+use 5.026001;
 use ExtUtils::MakeMaker;
 
 WriteMakefile(

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -1,6 +1,6 @@
 package OPCUA::Open62541;
 
-use 5.028002;
+use 5.026001;
 use strict;
 use warnings;
 


### PR DESCRIPTION
This allows building the XS wrapper on the current Ubuntu 18.04.4 LTS release.