### PR TITLE
Second fix for calls to Perl API when Perl is compiled with IMPLICIT_…

### DIFF
--- a/Open62541-packed.xsh
+++ b/Open62541-packed.xsh
@@ -108,11 +108,13 @@ static void XS_pack_UA_ExtensionObject(SV *out, UA_ExtensionObject in)  __attrib
 static UA_ExtensionObject XS_unpack_UA_ExtensionObject(SV *in)  __attribute__((unused));
 static void XS_pack_UA_ExtensionObject(SV *out, UA_ExtensionObject in)
 {
+    dTHX;
 	/* TODO Implement builtin type conversion */
 }
 static UA_ExtensionObject
 XS_unpack_UA_ExtensionObject(SV *in)
 {
+    dTHX;
 	/* TODO Implement builtin type conversion */
 }
 
@@ -136,6 +138,7 @@ static void XS_pack_UA_NodeClass(SV *out, UA_NodeClass in)  __attribute__((unuse
 static void
 XS_pack_UA_NodeClass(SV *out, UA_NodeClass in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -143,6 +146,7 @@ static UA_NodeClass XS_unpack_UA_NodeClass(SV *in)  __attribute__((unused));
 static UA_NodeClass
 XS_unpack_UA_NodeClass(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -151,6 +155,7 @@ static void XS_pack_UA_Argument(SV *out, UA_Argument in)  __attribute__((unused)
 static void
 XS_pack_UA_Argument(SV *out, UA_Argument in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -188,6 +193,7 @@ static UA_Argument XS_unpack_UA_Argument(SV *in)  __attribute__((unused));
 static UA_Argument
 XS_unpack_UA_Argument(SV *in)
 {
+    dTHX;
 	UA_Argument out;
 	SV **svp;
 	AV *av;
@@ -245,6 +251,7 @@ static void XS_pack_UA_EnumValueType(SV *out, UA_EnumValueType in)  __attribute_
 static void
 XS_pack_UA_EnumValueType(SV *out, UA_EnumValueType in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -267,6 +274,7 @@ static UA_EnumValueType XS_unpack_UA_EnumValueType(SV *in)  __attribute__((unuse
 static UA_EnumValueType
 XS_unpack_UA_EnumValueType(SV *in)
 {
+    dTHX;
 	UA_EnumValueType out;
 	SV **svp;
 	HV *hv;
@@ -298,6 +306,7 @@ static void XS_pack_UA_Duration(SV *out, UA_Duration in)  __attribute__((unused)
 static void
 XS_pack_UA_Duration(SV *out, UA_Duration in)
 {
+    dTHX;
 	XS_pack_UA_Double(out, in);
 }
 
@@ -305,6 +314,7 @@ static UA_Duration XS_unpack_UA_Duration(SV *in)  __attribute__((unused));
 static UA_Duration
 XS_unpack_UA_Duration(SV *in)
 {
+    dTHX;
 	return XS_unpack_UA_Double(in);
 }
 
@@ -313,6 +323,7 @@ static void XS_pack_UA_UtcTime(SV *out, UA_UtcTime in)  __attribute__((unused));
 static void
 XS_pack_UA_UtcTime(SV *out, UA_UtcTime in)
 {
+    dTHX;
 	XS_pack_UA_DateTime(out, in);
 }
 
@@ -320,6 +331,7 @@ static UA_UtcTime XS_unpack_UA_UtcTime(SV *in)  __attribute__((unused));
 static UA_UtcTime
 XS_unpack_UA_UtcTime(SV *in)
 {
+    dTHX;
 	return XS_unpack_UA_DateTime(in);
 }
 
@@ -328,6 +340,7 @@ static void XS_pack_UA_LocaleId(SV *out, UA_LocaleId in)  __attribute__((unused)
 static void
 XS_pack_UA_LocaleId(SV *out, UA_LocaleId in)
 {
+    dTHX;
 	XS_pack_UA_String(out, in);
 }
 
@@ -335,6 +348,7 @@ static UA_LocaleId XS_unpack_UA_LocaleId(SV *in)  __attribute__((unused));
 static UA_LocaleId
 XS_unpack_UA_LocaleId(SV *in)
 {
+    dTHX;
 	return XS_unpack_UA_String(in);
 }
 
@@ -343,6 +357,7 @@ static void XS_pack_UA_ApplicationType(SV *out, UA_ApplicationType in)  __attrib
 static void
 XS_pack_UA_ApplicationType(SV *out, UA_ApplicationType in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -350,6 +365,7 @@ static UA_ApplicationType XS_unpack_UA_ApplicationType(SV *in)  __attribute__((u
 static UA_ApplicationType
 XS_unpack_UA_ApplicationType(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -358,6 +374,7 @@ static void XS_pack_UA_ApplicationDescription(SV *out, UA_ApplicationDescription
 static void
 XS_pack_UA_ApplicationDescription(SV *out, UA_ApplicationDescription in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -403,6 +420,7 @@ static UA_ApplicationDescription XS_unpack_UA_ApplicationDescription(SV *in)  __
 static UA_ApplicationDescription
 XS_unpack_UA_ApplicationDescription(SV *in)
 {
+    dTHX;
 	UA_ApplicationDescription out;
 	SV **svp;
 	AV *av;
@@ -468,6 +486,7 @@ static void XS_pack_UA_RequestHeader(SV *out, UA_RequestHeader in)  __attribute_
 static void
 XS_pack_UA_RequestHeader(SV *out, UA_RequestHeader in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -506,6 +525,7 @@ static UA_RequestHeader XS_unpack_UA_RequestHeader(SV *in)  __attribute__((unuse
 static UA_RequestHeader
 XS_unpack_UA_RequestHeader(SV *in)
 {
+    dTHX;
 	UA_RequestHeader out;
 	SV **svp;
 	HV *hv;
@@ -553,6 +573,7 @@ static void XS_pack_UA_ResponseHeader(SV *out, UA_ResponseHeader in)  __attribut
 static void
 XS_pack_UA_ResponseHeader(SV *out, UA_ResponseHeader in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -594,6 +615,7 @@ static UA_ResponseHeader XS_unpack_UA_ResponseHeader(SV *in)  __attribute__((unu
 static UA_ResponseHeader
 XS_unpack_UA_ResponseHeader(SV *in)
 {
+    dTHX;
 	UA_ResponseHeader out;
 	SV **svp;
 	AV *av;
@@ -655,6 +677,7 @@ static void XS_pack_UA_ServiceFault(SV *out, UA_ServiceFault in)  __attribute__(
 static void
 XS_pack_UA_ServiceFault(SV *out, UA_ServiceFault in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -669,6 +692,7 @@ static UA_ServiceFault XS_unpack_UA_ServiceFault(SV *in)  __attribute__((unused)
 static UA_ServiceFault
 XS_unpack_UA_ServiceFault(SV *in)
 {
+    dTHX;
 	UA_ServiceFault out;
 	SV **svp;
 	HV *hv;
@@ -692,6 +716,7 @@ static void XS_pack_UA_FindServersRequest(SV *out, UA_FindServersRequest in)  __
 static void
 XS_pack_UA_FindServersRequest(SV *out, UA_FindServersRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -730,6 +755,7 @@ static UA_FindServersRequest XS_unpack_UA_FindServersRequest(SV *in)  __attribut
 static UA_FindServersRequest
 XS_unpack_UA_FindServersRequest(SV *in)
 {
+    dTHX;
 	UA_FindServersRequest out;
 	SV **svp;
 	AV *av;
@@ -799,6 +825,7 @@ static void XS_pack_UA_FindServersResponse(SV *out, UA_FindServersResponse in)  
 static void
 XS_pack_UA_FindServersResponse(SV *out, UA_FindServersResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -824,6 +851,7 @@ static UA_FindServersResponse XS_unpack_UA_FindServersResponse(SV *in)  __attrib
 static UA_FindServersResponse
 XS_unpack_UA_FindServersResponse(SV *in)
 {
+    dTHX;
 	UA_FindServersResponse out;
 	SV **svp;
 	AV *av;
@@ -869,6 +897,7 @@ static void XS_pack_UA_ServerOnNetwork(SV *out, UA_ServerOnNetwork in)  __attrib
 static void
 XS_pack_UA_ServerOnNetwork(SV *out, UA_ServerOnNetwork in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -902,6 +931,7 @@ static UA_ServerOnNetwork XS_unpack_UA_ServerOnNetwork(SV *in)  __attribute__((u
 static UA_ServerOnNetwork
 XS_unpack_UA_ServerOnNetwork(SV *in)
 {
+    dTHX;
 	UA_ServerOnNetwork out;
 	SV **svp;
 	AV *av;
@@ -955,6 +985,7 @@ static void XS_pack_UA_FindServersOnNetworkRequest(SV *out, UA_FindServersOnNetw
 static void
 XS_pack_UA_FindServersOnNetworkRequest(SV *out, UA_FindServersOnNetworkRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -988,6 +1019,7 @@ static UA_FindServersOnNetworkRequest XS_unpack_UA_FindServersOnNetworkRequest(S
 static UA_FindServersOnNetworkRequest
 XS_unpack_UA_FindServersOnNetworkRequest(SV *in)
 {
+    dTHX;
 	UA_FindServersOnNetworkRequest out;
 	SV **svp;
 	AV *av;
@@ -1041,6 +1073,7 @@ static void XS_pack_UA_FindServersOnNetworkResponse(SV *out, UA_FindServersOnNet
 static void
 XS_pack_UA_FindServersOnNetworkResponse(SV *out, UA_FindServersOnNetworkResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -1070,6 +1103,7 @@ static UA_FindServersOnNetworkResponse XS_unpack_UA_FindServersOnNetworkResponse
 static UA_FindServersOnNetworkResponse
 XS_unpack_UA_FindServersOnNetworkResponse(SV *in)
 {
+    dTHX;
 	UA_FindServersOnNetworkResponse out;
 	SV **svp;
 	AV *av;
@@ -1119,6 +1153,7 @@ static void XS_pack_UA_MessageSecurityMode(SV *out, UA_MessageSecurityMode in)  
 static void
 XS_pack_UA_MessageSecurityMode(SV *out, UA_MessageSecurityMode in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -1126,6 +1161,7 @@ static UA_MessageSecurityMode XS_unpack_UA_MessageSecurityMode(SV *in)  __attrib
 static UA_MessageSecurityMode
 XS_unpack_UA_MessageSecurityMode(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -1134,6 +1170,7 @@ static void XS_pack_UA_UserTokenType(SV *out, UA_UserTokenType in)  __attribute_
 static void
 XS_pack_UA_UserTokenType(SV *out, UA_UserTokenType in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -1141,6 +1178,7 @@ static UA_UserTokenType XS_unpack_UA_UserTokenType(SV *in)  __attribute__((unuse
 static UA_UserTokenType
 XS_unpack_UA_UserTokenType(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -1149,6 +1187,7 @@ static void XS_pack_UA_UserTokenPolicy(SV *out, UA_UserTokenPolicy in)  __attrib
 static void
 XS_pack_UA_UserTokenPolicy(SV *out, UA_UserTokenPolicy in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -1179,6 +1218,7 @@ static UA_UserTokenPolicy XS_unpack_UA_UserTokenPolicy(SV *in)  __attribute__((u
 static UA_UserTokenPolicy
 XS_unpack_UA_UserTokenPolicy(SV *in)
 {
+    dTHX;
 	UA_UserTokenPolicy out;
 	SV **svp;
 	HV *hv;
@@ -1218,6 +1258,7 @@ static void XS_pack_UA_EndpointDescription(SV *out, UA_EndpointDescription in)  
 static void
 XS_pack_UA_EndpointDescription(SV *out, UA_EndpointDescription in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -1267,6 +1308,7 @@ static UA_EndpointDescription XS_unpack_UA_EndpointDescription(SV *in)  __attrib
 static UA_EndpointDescription
 XS_unpack_UA_EndpointDescription(SV *in)
 {
+    dTHX;
 	UA_EndpointDescription out;
 	SV **svp;
 	AV *av;
@@ -1336,6 +1378,7 @@ static void XS_pack_UA_GetEndpointsRequest(SV *out, UA_GetEndpointsRequest in)  
 static void
 XS_pack_UA_GetEndpointsRequest(SV *out, UA_GetEndpointsRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -1374,6 +1417,7 @@ static UA_GetEndpointsRequest XS_unpack_UA_GetEndpointsRequest(SV *in)  __attrib
 static UA_GetEndpointsRequest
 XS_unpack_UA_GetEndpointsRequest(SV *in)
 {
+    dTHX;
 	UA_GetEndpointsRequest out;
 	SV **svp;
 	AV *av;
@@ -1443,6 +1487,7 @@ static void XS_pack_UA_GetEndpointsResponse(SV *out, UA_GetEndpointsResponse in)
 static void
 XS_pack_UA_GetEndpointsResponse(SV *out, UA_GetEndpointsResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -1468,6 +1513,7 @@ static UA_GetEndpointsResponse XS_unpack_UA_GetEndpointsResponse(SV *in)  __attr
 static UA_GetEndpointsResponse
 XS_unpack_UA_GetEndpointsResponse(SV *in)
 {
+    dTHX;
 	UA_GetEndpointsResponse out;
 	SV **svp;
 	AV *av;
@@ -1513,6 +1559,7 @@ static void XS_pack_UA_RegisteredServer(SV *out, UA_RegisteredServer in)  __attr
 static void
 XS_pack_UA_RegisteredServer(SV *out, UA_RegisteredServer in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -1567,6 +1614,7 @@ static UA_RegisteredServer XS_unpack_UA_RegisteredServer(SV *in)  __attribute__(
 static UA_RegisteredServer
 XS_unpack_UA_RegisteredServer(SV *in)
 {
+    dTHX;
 	UA_RegisteredServer out;
 	SV **svp;
 	AV *av;
@@ -1652,6 +1700,7 @@ static void XS_pack_UA_RegisterServerRequest(SV *out, UA_RegisterServerRequest i
 static void
 XS_pack_UA_RegisterServerRequest(SV *out, UA_RegisterServerRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -1670,6 +1719,7 @@ static UA_RegisterServerRequest XS_unpack_UA_RegisterServerRequest(SV *in)  __at
 static UA_RegisterServerRequest
 XS_unpack_UA_RegisterServerRequest(SV *in)
 {
+    dTHX;
 	UA_RegisterServerRequest out;
 	SV **svp;
 	HV *hv;
@@ -1697,6 +1747,7 @@ static void XS_pack_UA_RegisterServerResponse(SV *out, UA_RegisterServerResponse
 static void
 XS_pack_UA_RegisterServerResponse(SV *out, UA_RegisterServerResponse in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -1711,6 +1762,7 @@ static UA_RegisterServerResponse XS_unpack_UA_RegisterServerResponse(SV *in)  __
 static UA_RegisterServerResponse
 XS_unpack_UA_RegisterServerResponse(SV *in)
 {
+    dTHX;
 	UA_RegisterServerResponse out;
 	SV **svp;
 	HV *hv;
@@ -1734,6 +1786,7 @@ static void XS_pack_UA_DiscoveryConfiguration(SV *out, UA_DiscoveryConfiguration
 static void
 XS_pack_UA_DiscoveryConfiguration(SV *out, UA_DiscoveryConfiguration in)
 {
+    dTHX;
 	croak("%s: conversion for type not implemented", __func__);
 }
 
@@ -1741,6 +1794,7 @@ static UA_DiscoveryConfiguration XS_unpack_UA_DiscoveryConfiguration(SV *in)  __
 static UA_DiscoveryConfiguration
 XS_unpack_UA_DiscoveryConfiguration(SV *in)
 {
+    dTHX;
 	croak("%s: conversion for type not implemented", __func__);
 }
 
@@ -1749,6 +1803,7 @@ static void XS_pack_UA_MdnsDiscoveryConfiguration(SV *out, UA_MdnsDiscoveryConfi
 static void
 XS_pack_UA_MdnsDiscoveryConfiguration(SV *out, UA_MdnsDiscoveryConfiguration in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -1774,6 +1829,7 @@ static UA_MdnsDiscoveryConfiguration XS_unpack_UA_MdnsDiscoveryConfiguration(SV 
 static UA_MdnsDiscoveryConfiguration
 XS_unpack_UA_MdnsDiscoveryConfiguration(SV *in)
 {
+    dTHX;
 	UA_MdnsDiscoveryConfiguration out;
 	SV **svp;
 	AV *av;
@@ -1819,6 +1875,7 @@ static void XS_pack_UA_RegisterServer2Request(SV *out, UA_RegisterServer2Request
 static void
 XS_pack_UA_RegisterServer2Request(SV *out, UA_RegisterServer2Request in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -1848,6 +1905,7 @@ static UA_RegisterServer2Request XS_unpack_UA_RegisterServer2Request(SV *in)  __
 static UA_RegisterServer2Request
 XS_unpack_UA_RegisterServer2Request(SV *in)
 {
+    dTHX;
 	UA_RegisterServer2Request out;
 	SV **svp;
 	AV *av;
@@ -1897,6 +1955,7 @@ static void XS_pack_UA_RegisterServer2Response(SV *out, UA_RegisterServer2Respon
 static void
 XS_pack_UA_RegisterServer2Response(SV *out, UA_RegisterServer2Response in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -1931,6 +1990,7 @@ static UA_RegisterServer2Response XS_unpack_UA_RegisterServer2Response(SV *in)  
 static UA_RegisterServer2Response
 XS_unpack_UA_RegisterServer2Response(SV *in)
 {
+    dTHX;
 	UA_RegisterServer2Response out;
 	SV **svp;
 	AV *av;
@@ -1996,6 +2056,7 @@ static void XS_pack_UA_SecurityTokenRequestType(SV *out, UA_SecurityTokenRequest
 static void
 XS_pack_UA_SecurityTokenRequestType(SV *out, UA_SecurityTokenRequestType in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -2003,6 +2064,7 @@ static UA_SecurityTokenRequestType XS_unpack_UA_SecurityTokenRequestType(SV *in)
 static UA_SecurityTokenRequestType
 XS_unpack_UA_SecurityTokenRequestType(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -2011,6 +2073,7 @@ static void XS_pack_UA_ChannelSecurityToken(SV *out, UA_ChannelSecurityToken in)
 static void
 XS_pack_UA_ChannelSecurityToken(SV *out, UA_ChannelSecurityToken in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2037,6 +2100,7 @@ static UA_ChannelSecurityToken XS_unpack_UA_ChannelSecurityToken(SV *in)  __attr
 static UA_ChannelSecurityToken
 XS_unpack_UA_ChannelSecurityToken(SV *in)
 {
+    dTHX;
 	UA_ChannelSecurityToken out;
 	SV **svp;
 	HV *hv;
@@ -2072,6 +2136,7 @@ static void XS_pack_UA_OpenSecureChannelRequest(SV *out, UA_OpenSecureChannelReq
 static void
 XS_pack_UA_OpenSecureChannelRequest(SV *out, UA_OpenSecureChannelRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2106,6 +2171,7 @@ static UA_OpenSecureChannelRequest XS_unpack_UA_OpenSecureChannelRequest(SV *in)
 static UA_OpenSecureChannelRequest
 XS_unpack_UA_OpenSecureChannelRequest(SV *in)
 {
+    dTHX;
 	UA_OpenSecureChannelRequest out;
 	SV **svp;
 	HV *hv;
@@ -2149,6 +2215,7 @@ static void XS_pack_UA_OpenSecureChannelResponse(SV *out, UA_OpenSecureChannelRe
 static void
 XS_pack_UA_OpenSecureChannelResponse(SV *out, UA_OpenSecureChannelResponse in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2175,6 +2242,7 @@ static UA_OpenSecureChannelResponse XS_unpack_UA_OpenSecureChannelResponse(SV *i
 static UA_OpenSecureChannelResponse
 XS_unpack_UA_OpenSecureChannelResponse(SV *in)
 {
+    dTHX;
 	UA_OpenSecureChannelResponse out;
 	SV **svp;
 	HV *hv;
@@ -2210,6 +2278,7 @@ static void XS_pack_UA_CloseSecureChannelRequest(SV *out, UA_CloseSecureChannelR
 static void
 XS_pack_UA_CloseSecureChannelRequest(SV *out, UA_CloseSecureChannelRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2224,6 +2293,7 @@ static UA_CloseSecureChannelRequest XS_unpack_UA_CloseSecureChannelRequest(SV *i
 static UA_CloseSecureChannelRequest
 XS_unpack_UA_CloseSecureChannelRequest(SV *in)
 {
+    dTHX;
 	UA_CloseSecureChannelRequest out;
 	SV **svp;
 	HV *hv;
@@ -2247,6 +2317,7 @@ static void XS_pack_UA_CloseSecureChannelResponse(SV *out, UA_CloseSecureChannel
 static void
 XS_pack_UA_CloseSecureChannelResponse(SV *out, UA_CloseSecureChannelResponse in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2261,6 +2332,7 @@ static UA_CloseSecureChannelResponse XS_unpack_UA_CloseSecureChannelResponse(SV 
 static UA_CloseSecureChannelResponse
 XS_unpack_UA_CloseSecureChannelResponse(SV *in)
 {
+    dTHX;
 	UA_CloseSecureChannelResponse out;
 	SV **svp;
 	HV *hv;
@@ -2284,6 +2356,7 @@ static void XS_pack_UA_SignedSoftwareCertificate(SV *out, UA_SignedSoftwareCerti
 static void
 XS_pack_UA_SignedSoftwareCertificate(SV *out, UA_SignedSoftwareCertificate in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2302,6 +2375,7 @@ static UA_SignedSoftwareCertificate XS_unpack_UA_SignedSoftwareCertificate(SV *i
 static UA_SignedSoftwareCertificate
 XS_unpack_UA_SignedSoftwareCertificate(SV *in)
 {
+    dTHX;
 	UA_SignedSoftwareCertificate out;
 	SV **svp;
 	HV *hv;
@@ -2329,6 +2403,7 @@ static void XS_pack_UA_SignatureData(SV *out, UA_SignatureData in)  __attribute_
 static void
 XS_pack_UA_SignatureData(SV *out, UA_SignatureData in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2347,6 +2422,7 @@ static UA_SignatureData XS_unpack_UA_SignatureData(SV *in)  __attribute__((unuse
 static UA_SignatureData
 XS_unpack_UA_SignatureData(SV *in)
 {
+    dTHX;
 	UA_SignatureData out;
 	SV **svp;
 	HV *hv;
@@ -2374,6 +2450,7 @@ static void XS_pack_UA_CreateSessionRequest(SV *out, UA_CreateSessionRequest in)
 static void
 XS_pack_UA_CreateSessionRequest(SV *out, UA_CreateSessionRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2420,6 +2497,7 @@ static UA_CreateSessionRequest XS_unpack_UA_CreateSessionRequest(SV *in)  __attr
 static UA_CreateSessionRequest
 XS_unpack_UA_CreateSessionRequest(SV *in)
 {
+    dTHX;
 	UA_CreateSessionRequest out;
 	SV **svp;
 	HV *hv;
@@ -2475,6 +2553,7 @@ static void XS_pack_UA_CreateSessionResponse(SV *out, UA_CreateSessionResponse i
 static void
 XS_pack_UA_CreateSessionResponse(SV *out, UA_CreateSessionResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -2537,6 +2616,7 @@ static UA_CreateSessionResponse XS_unpack_UA_CreateSessionResponse(SV *in)  __at
 static UA_CreateSessionResponse
 XS_unpack_UA_CreateSessionResponse(SV *in)
 {
+    dTHX;
 	UA_CreateSessionResponse out;
 	SV **svp;
 	AV *av;
@@ -2630,6 +2710,7 @@ static void XS_pack_UA_UserIdentityToken(SV *out, UA_UserIdentityToken in)  __at
 static void
 XS_pack_UA_UserIdentityToken(SV *out, UA_UserIdentityToken in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2644,6 +2725,7 @@ static UA_UserIdentityToken XS_unpack_UA_UserIdentityToken(SV *in)  __attribute_
 static UA_UserIdentityToken
 XS_unpack_UA_UserIdentityToken(SV *in)
 {
+    dTHX;
 	UA_UserIdentityToken out;
 	SV **svp;
 	HV *hv;
@@ -2667,6 +2749,7 @@ static void XS_pack_UA_AnonymousIdentityToken(SV *out, UA_AnonymousIdentityToken
 static void
 XS_pack_UA_AnonymousIdentityToken(SV *out, UA_AnonymousIdentityToken in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2681,6 +2764,7 @@ static UA_AnonymousIdentityToken XS_unpack_UA_AnonymousIdentityToken(SV *in)  __
 static UA_AnonymousIdentityToken
 XS_unpack_UA_AnonymousIdentityToken(SV *in)
 {
+    dTHX;
 	UA_AnonymousIdentityToken out;
 	SV **svp;
 	HV *hv;
@@ -2704,6 +2788,7 @@ static void XS_pack_UA_UserNameIdentityToken(SV *out, UA_UserNameIdentityToken i
 static void
 XS_pack_UA_UserNameIdentityToken(SV *out, UA_UserNameIdentityToken in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2730,6 +2815,7 @@ static UA_UserNameIdentityToken XS_unpack_UA_UserNameIdentityToken(SV *in)  __at
 static UA_UserNameIdentityToken
 XS_unpack_UA_UserNameIdentityToken(SV *in)
 {
+    dTHX;
 	UA_UserNameIdentityToken out;
 	SV **svp;
 	HV *hv;
@@ -2765,6 +2851,7 @@ static void XS_pack_UA_X509IdentityToken(SV *out, UA_X509IdentityToken in)  __at
 static void
 XS_pack_UA_X509IdentityToken(SV *out, UA_X509IdentityToken in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2783,6 +2870,7 @@ static UA_X509IdentityToken XS_unpack_UA_X509IdentityToken(SV *in)  __attribute_
 static UA_X509IdentityToken
 XS_unpack_UA_X509IdentityToken(SV *in)
 {
+    dTHX;
 	UA_X509IdentityToken out;
 	SV **svp;
 	HV *hv;
@@ -2810,6 +2898,7 @@ static void XS_pack_UA_IssuedIdentityToken(SV *out, UA_IssuedIdentityToken in)  
 static void
 XS_pack_UA_IssuedIdentityToken(SV *out, UA_IssuedIdentityToken in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -2832,6 +2921,7 @@ static UA_IssuedIdentityToken XS_unpack_UA_IssuedIdentityToken(SV *in)  __attrib
 static UA_IssuedIdentityToken
 XS_unpack_UA_IssuedIdentityToken(SV *in)
 {
+    dTHX;
 	UA_IssuedIdentityToken out;
 	SV **svp;
 	HV *hv;
@@ -2863,6 +2953,7 @@ static void XS_pack_UA_ActivateSessionRequest(SV *out, UA_ActivateSessionRequest
 static void
 XS_pack_UA_ActivateSessionRequest(SV *out, UA_ActivateSessionRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -2909,6 +3000,7 @@ static UA_ActivateSessionRequest XS_unpack_UA_ActivateSessionRequest(SV *in)  __
 static UA_ActivateSessionRequest
 XS_unpack_UA_ActivateSessionRequest(SV *in)
 {
+    dTHX;
 	UA_ActivateSessionRequest out;
 	SV **svp;
 	AV *av;
@@ -2986,6 +3078,7 @@ static void XS_pack_UA_ActivateSessionResponse(SV *out, UA_ActivateSessionRespon
 static void
 XS_pack_UA_ActivateSessionResponse(SV *out, UA_ActivateSessionResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -3024,6 +3117,7 @@ static UA_ActivateSessionResponse XS_unpack_UA_ActivateSessionResponse(SV *in)  
 static UA_ActivateSessionResponse
 XS_unpack_UA_ActivateSessionResponse(SV *in)
 {
+    dTHX;
 	UA_ActivateSessionResponse out;
 	SV **svp;
 	AV *av;
@@ -3093,6 +3187,7 @@ static void XS_pack_UA_CloseSessionRequest(SV *out, UA_CloseSessionRequest in)  
 static void
 XS_pack_UA_CloseSessionRequest(SV *out, UA_CloseSessionRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -3111,6 +3206,7 @@ static UA_CloseSessionRequest XS_unpack_UA_CloseSessionRequest(SV *in)  __attrib
 static UA_CloseSessionRequest
 XS_unpack_UA_CloseSessionRequest(SV *in)
 {
+    dTHX;
 	UA_CloseSessionRequest out;
 	SV **svp;
 	HV *hv;
@@ -3138,6 +3234,7 @@ static void XS_pack_UA_CloseSessionResponse(SV *out, UA_CloseSessionResponse in)
 static void
 XS_pack_UA_CloseSessionResponse(SV *out, UA_CloseSessionResponse in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -3152,6 +3249,7 @@ static UA_CloseSessionResponse XS_unpack_UA_CloseSessionResponse(SV *in)  __attr
 static UA_CloseSessionResponse
 XS_unpack_UA_CloseSessionResponse(SV *in)
 {
+    dTHX;
 	UA_CloseSessionResponse out;
 	SV **svp;
 	HV *hv;
@@ -3175,6 +3273,7 @@ static void XS_pack_UA_NodeAttributesMask(SV *out, UA_NodeAttributesMask in)  __
 static void
 XS_pack_UA_NodeAttributesMask(SV *out, UA_NodeAttributesMask in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -3182,6 +3281,7 @@ static UA_NodeAttributesMask XS_unpack_UA_NodeAttributesMask(SV *in)  __attribut
 static UA_NodeAttributesMask
 XS_unpack_UA_NodeAttributesMask(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -3190,6 +3290,7 @@ static void XS_pack_UA_NodeAttributes(SV *out, UA_NodeAttributes in)  __attribut
 static void
 XS_pack_UA_NodeAttributes(SV *out, UA_NodeAttributes in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -3220,6 +3321,7 @@ static UA_NodeAttributes XS_unpack_UA_NodeAttributes(SV *in)  __attribute__((unu
 static UA_NodeAttributes
 XS_unpack_UA_NodeAttributes(SV *in)
 {
+    dTHX;
 	UA_NodeAttributes out;
 	SV **svp;
 	HV *hv;
@@ -3259,6 +3361,7 @@ static void XS_pack_UA_ObjectAttributes(SV *out, UA_ObjectAttributes in)  __attr
 static void
 XS_pack_UA_ObjectAttributes(SV *out, UA_ObjectAttributes in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -3293,6 +3396,7 @@ static UA_ObjectAttributes XS_unpack_UA_ObjectAttributes(SV *in)  __attribute__(
 static UA_ObjectAttributes
 XS_unpack_UA_ObjectAttributes(SV *in)
 {
+    dTHX;
 	UA_ObjectAttributes out;
 	SV **svp;
 	HV *hv;
@@ -3336,6 +3440,7 @@ static void XS_pack_UA_VariableAttributes(SV *out, UA_VariableAttributes in)  __
 static void
 XS_pack_UA_VariableAttributes(SV *out, UA_VariableAttributes in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -3405,6 +3510,7 @@ static UA_VariableAttributes XS_unpack_UA_VariableAttributes(SV *in)  __attribut
 static UA_VariableAttributes
 XS_unpack_UA_VariableAttributes(SV *in)
 {
+    dTHX;
 	UA_VariableAttributes out;
 	SV **svp;
 	AV *av;
@@ -3494,6 +3600,7 @@ static void XS_pack_UA_MethodAttributes(SV *out, UA_MethodAttributes in)  __attr
 static void
 XS_pack_UA_MethodAttributes(SV *out, UA_MethodAttributes in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -3532,6 +3639,7 @@ static UA_MethodAttributes XS_unpack_UA_MethodAttributes(SV *in)  __attribute__(
 static UA_MethodAttributes
 XS_unpack_UA_MethodAttributes(SV *in)
 {
+    dTHX;
 	UA_MethodAttributes out;
 	SV **svp;
 	HV *hv;
@@ -3579,6 +3687,7 @@ static void XS_pack_UA_ObjectTypeAttributes(SV *out, UA_ObjectTypeAttributes in)
 static void
 XS_pack_UA_ObjectTypeAttributes(SV *out, UA_ObjectTypeAttributes in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -3613,6 +3722,7 @@ static UA_ObjectTypeAttributes XS_unpack_UA_ObjectTypeAttributes(SV *in)  __attr
 static UA_ObjectTypeAttributes
 XS_unpack_UA_ObjectTypeAttributes(SV *in)
 {
+    dTHX;
 	UA_ObjectTypeAttributes out;
 	SV **svp;
 	HV *hv;
@@ -3656,6 +3766,7 @@ static void XS_pack_UA_VariableTypeAttributes(SV *out, UA_VariableTypeAttributes
 static void
 XS_pack_UA_VariableTypeAttributes(SV *out, UA_VariableTypeAttributes in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -3713,6 +3824,7 @@ static UA_VariableTypeAttributes XS_unpack_UA_VariableTypeAttributes(SV *in)  __
 static UA_VariableTypeAttributes
 XS_unpack_UA_VariableTypeAttributes(SV *in)
 {
+    dTHX;
 	UA_VariableTypeAttributes out;
 	SV **svp;
 	AV *av;
@@ -3790,6 +3902,7 @@ static void XS_pack_UA_ReferenceTypeAttributes(SV *out, UA_ReferenceTypeAttribut
 static void
 XS_pack_UA_ReferenceTypeAttributes(SV *out, UA_ReferenceTypeAttributes in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -3832,6 +3945,7 @@ static UA_ReferenceTypeAttributes XS_unpack_UA_ReferenceTypeAttributes(SV *in)  
 static UA_ReferenceTypeAttributes
 XS_unpack_UA_ReferenceTypeAttributes(SV *in)
 {
+    dTHX;
 	UA_ReferenceTypeAttributes out;
 	SV **svp;
 	HV *hv;
@@ -3883,6 +3997,7 @@ static void XS_pack_UA_DataTypeAttributes(SV *out, UA_DataTypeAttributes in)  __
 static void
 XS_pack_UA_DataTypeAttributes(SV *out, UA_DataTypeAttributes in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -3917,6 +4032,7 @@ static UA_DataTypeAttributes XS_unpack_UA_DataTypeAttributes(SV *in)  __attribut
 static UA_DataTypeAttributes
 XS_unpack_UA_DataTypeAttributes(SV *in)
 {
+    dTHX;
 	UA_DataTypeAttributes out;
 	SV **svp;
 	HV *hv;
@@ -3960,6 +4076,7 @@ static void XS_pack_UA_ViewAttributes(SV *out, UA_ViewAttributes in)  __attribut
 static void
 XS_pack_UA_ViewAttributes(SV *out, UA_ViewAttributes in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -3998,6 +4115,7 @@ static UA_ViewAttributes XS_unpack_UA_ViewAttributes(SV *in)  __attribute__((unu
 static UA_ViewAttributes
 XS_unpack_UA_ViewAttributes(SV *in)
 {
+    dTHX;
 	UA_ViewAttributes out;
 	SV **svp;
 	HV *hv;
@@ -4045,6 +4163,7 @@ static void XS_pack_UA_AddNodesItem(SV *out, UA_AddNodesItem in)  __attribute__(
 static void
 XS_pack_UA_AddNodesItem(SV *out, UA_AddNodesItem in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -4083,6 +4202,7 @@ static UA_AddNodesItem XS_unpack_UA_AddNodesItem(SV *in)  __attribute__((unused)
 static UA_AddNodesItem
 XS_unpack_UA_AddNodesItem(SV *in)
 {
+    dTHX;
 	UA_AddNodesItem out;
 	SV **svp;
 	HV *hv;
@@ -4130,6 +4250,7 @@ static void XS_pack_UA_AddNodesResult(SV *out, UA_AddNodesResult in)  __attribut
 static void
 XS_pack_UA_AddNodesResult(SV *out, UA_AddNodesResult in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -4148,6 +4269,7 @@ static UA_AddNodesResult XS_unpack_UA_AddNodesResult(SV *in)  __attribute__((unu
 static UA_AddNodesResult
 XS_unpack_UA_AddNodesResult(SV *in)
 {
+    dTHX;
 	UA_AddNodesResult out;
 	SV **svp;
 	HV *hv;
@@ -4175,6 +4297,7 @@ static void XS_pack_UA_AddNodesRequest(SV *out, UA_AddNodesRequest in)  __attrib
 static void
 XS_pack_UA_AddNodesRequest(SV *out, UA_AddNodesRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -4200,6 +4323,7 @@ static UA_AddNodesRequest XS_unpack_UA_AddNodesRequest(SV *in)  __attribute__((u
 static UA_AddNodesRequest
 XS_unpack_UA_AddNodesRequest(SV *in)
 {
+    dTHX;
 	UA_AddNodesRequest out;
 	SV **svp;
 	AV *av;
@@ -4245,6 +4369,7 @@ static void XS_pack_UA_AddNodesResponse(SV *out, UA_AddNodesResponse in)  __attr
 static void
 XS_pack_UA_AddNodesResponse(SV *out, UA_AddNodesResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -4279,6 +4404,7 @@ static UA_AddNodesResponse XS_unpack_UA_AddNodesResponse(SV *in)  __attribute__(
 static UA_AddNodesResponse
 XS_unpack_UA_AddNodesResponse(SV *in)
 {
+    dTHX;
 	UA_AddNodesResponse out;
 	SV **svp;
 	AV *av;
@@ -4344,6 +4470,7 @@ static void XS_pack_UA_AddReferencesItem(SV *out, UA_AddReferencesItem in)  __at
 static void
 XS_pack_UA_AddReferencesItem(SV *out, UA_AddReferencesItem in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -4378,6 +4505,7 @@ static UA_AddReferencesItem XS_unpack_UA_AddReferencesItem(SV *in)  __attribute_
 static UA_AddReferencesItem
 XS_unpack_UA_AddReferencesItem(SV *in)
 {
+    dTHX;
 	UA_AddReferencesItem out;
 	SV **svp;
 	HV *hv;
@@ -4421,6 +4549,7 @@ static void XS_pack_UA_AddReferencesRequest(SV *out, UA_AddReferencesRequest in)
 static void
 XS_pack_UA_AddReferencesRequest(SV *out, UA_AddReferencesRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -4446,6 +4575,7 @@ static UA_AddReferencesRequest XS_unpack_UA_AddReferencesRequest(SV *in)  __attr
 static UA_AddReferencesRequest
 XS_unpack_UA_AddReferencesRequest(SV *in)
 {
+    dTHX;
 	UA_AddReferencesRequest out;
 	SV **svp;
 	AV *av;
@@ -4491,6 +4621,7 @@ static void XS_pack_UA_AddReferencesResponse(SV *out, UA_AddReferencesResponse i
 static void
 XS_pack_UA_AddReferencesResponse(SV *out, UA_AddReferencesResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -4525,6 +4656,7 @@ static UA_AddReferencesResponse XS_unpack_UA_AddReferencesResponse(SV *in)  __at
 static UA_AddReferencesResponse
 XS_unpack_UA_AddReferencesResponse(SV *in)
 {
+    dTHX;
 	UA_AddReferencesResponse out;
 	SV **svp;
 	AV *av;
@@ -4590,6 +4722,7 @@ static void XS_pack_UA_DeleteNodesItem(SV *out, UA_DeleteNodesItem in)  __attrib
 static void
 XS_pack_UA_DeleteNodesItem(SV *out, UA_DeleteNodesItem in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -4608,6 +4741,7 @@ static UA_DeleteNodesItem XS_unpack_UA_DeleteNodesItem(SV *in)  __attribute__((u
 static UA_DeleteNodesItem
 XS_unpack_UA_DeleteNodesItem(SV *in)
 {
+    dTHX;
 	UA_DeleteNodesItem out;
 	SV **svp;
 	HV *hv;
@@ -4635,6 +4769,7 @@ static void XS_pack_UA_DeleteNodesRequest(SV *out, UA_DeleteNodesRequest in)  __
 static void
 XS_pack_UA_DeleteNodesRequest(SV *out, UA_DeleteNodesRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -4660,6 +4795,7 @@ static UA_DeleteNodesRequest XS_unpack_UA_DeleteNodesRequest(SV *in)  __attribut
 static UA_DeleteNodesRequest
 XS_unpack_UA_DeleteNodesRequest(SV *in)
 {
+    dTHX;
 	UA_DeleteNodesRequest out;
 	SV **svp;
 	AV *av;
@@ -4705,6 +4841,7 @@ static void XS_pack_UA_DeleteNodesResponse(SV *out, UA_DeleteNodesResponse in)  
 static void
 XS_pack_UA_DeleteNodesResponse(SV *out, UA_DeleteNodesResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -4739,6 +4876,7 @@ static UA_DeleteNodesResponse XS_unpack_UA_DeleteNodesResponse(SV *in)  __attrib
 static UA_DeleteNodesResponse
 XS_unpack_UA_DeleteNodesResponse(SV *in)
 {
+    dTHX;
 	UA_DeleteNodesResponse out;
 	SV **svp;
 	AV *av;
@@ -4804,6 +4942,7 @@ static void XS_pack_UA_DeleteReferencesItem(SV *out, UA_DeleteReferencesItem in)
 static void
 XS_pack_UA_DeleteReferencesItem(SV *out, UA_DeleteReferencesItem in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -4834,6 +4973,7 @@ static UA_DeleteReferencesItem XS_unpack_UA_DeleteReferencesItem(SV *in)  __attr
 static UA_DeleteReferencesItem
 XS_unpack_UA_DeleteReferencesItem(SV *in)
 {
+    dTHX;
 	UA_DeleteReferencesItem out;
 	SV **svp;
 	HV *hv;
@@ -4873,6 +5013,7 @@ static void XS_pack_UA_DeleteReferencesRequest(SV *out, UA_DeleteReferencesReque
 static void
 XS_pack_UA_DeleteReferencesRequest(SV *out, UA_DeleteReferencesRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -4898,6 +5039,7 @@ static UA_DeleteReferencesRequest XS_unpack_UA_DeleteReferencesRequest(SV *in)  
 static UA_DeleteReferencesRequest
 XS_unpack_UA_DeleteReferencesRequest(SV *in)
 {
+    dTHX;
 	UA_DeleteReferencesRequest out;
 	SV **svp;
 	AV *av;
@@ -4943,6 +5085,7 @@ static void XS_pack_UA_DeleteReferencesResponse(SV *out, UA_DeleteReferencesResp
 static void
 XS_pack_UA_DeleteReferencesResponse(SV *out, UA_DeleteReferencesResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -4977,6 +5120,7 @@ static UA_DeleteReferencesResponse XS_unpack_UA_DeleteReferencesResponse(SV *in)
 static UA_DeleteReferencesResponse
 XS_unpack_UA_DeleteReferencesResponse(SV *in)
 {
+    dTHX;
 	UA_DeleteReferencesResponse out;
 	SV **svp;
 	AV *av;
@@ -5042,6 +5186,7 @@ static void XS_pack_UA_BrowseDirection(SV *out, UA_BrowseDirection in)  __attrib
 static void
 XS_pack_UA_BrowseDirection(SV *out, UA_BrowseDirection in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -5049,6 +5194,7 @@ static UA_BrowseDirection XS_unpack_UA_BrowseDirection(SV *in)  __attribute__((u
 static UA_BrowseDirection
 XS_unpack_UA_BrowseDirection(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -5057,6 +5203,7 @@ static void XS_pack_UA_ViewDescription(SV *out, UA_ViewDescription in)  __attrib
 static void
 XS_pack_UA_ViewDescription(SV *out, UA_ViewDescription in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -5079,6 +5226,7 @@ static UA_ViewDescription XS_unpack_UA_ViewDescription(SV *in)  __attribute__((u
 static UA_ViewDescription
 XS_unpack_UA_ViewDescription(SV *in)
 {
+    dTHX;
 	UA_ViewDescription out;
 	SV **svp;
 	HV *hv;
@@ -5110,6 +5258,7 @@ static void XS_pack_UA_BrowseDescription(SV *out, UA_BrowseDescription in)  __at
 static void
 XS_pack_UA_BrowseDescription(SV *out, UA_BrowseDescription in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -5144,6 +5293,7 @@ static UA_BrowseDescription XS_unpack_UA_BrowseDescription(SV *in)  __attribute_
 static UA_BrowseDescription
 XS_unpack_UA_BrowseDescription(SV *in)
 {
+    dTHX;
 	UA_BrowseDescription out;
 	SV **svp;
 	HV *hv;
@@ -5187,6 +5337,7 @@ static void XS_pack_UA_BrowseResultMask(SV *out, UA_BrowseResultMask in)  __attr
 static void
 XS_pack_UA_BrowseResultMask(SV *out, UA_BrowseResultMask in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -5194,6 +5345,7 @@ static UA_BrowseResultMask XS_unpack_UA_BrowseResultMask(SV *in)  __attribute__(
 static UA_BrowseResultMask
 XS_unpack_UA_BrowseResultMask(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -5202,6 +5354,7 @@ static void XS_pack_UA_ReferenceDescription(SV *out, UA_ReferenceDescription in)
 static void
 XS_pack_UA_ReferenceDescription(SV *out, UA_ReferenceDescription in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -5240,6 +5393,7 @@ static UA_ReferenceDescription XS_unpack_UA_ReferenceDescription(SV *in)  __attr
 static UA_ReferenceDescription
 XS_unpack_UA_ReferenceDescription(SV *in)
 {
+    dTHX;
 	UA_ReferenceDescription out;
 	SV **svp;
 	HV *hv;
@@ -5287,6 +5441,7 @@ static void XS_pack_UA_BrowseResult(SV *out, UA_BrowseResult in)  __attribute__(
 static void
 XS_pack_UA_BrowseResult(SV *out, UA_BrowseResult in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -5316,6 +5471,7 @@ static UA_BrowseResult XS_unpack_UA_BrowseResult(SV *in)  __attribute__((unused)
 static UA_BrowseResult
 XS_unpack_UA_BrowseResult(SV *in)
 {
+    dTHX;
 	UA_BrowseResult out;
 	SV **svp;
 	AV *av;
@@ -5365,6 +5521,7 @@ static void XS_pack_UA_BrowseRequest(SV *out, UA_BrowseRequest in)  __attribute_
 static void
 XS_pack_UA_BrowseRequest(SV *out, UA_BrowseRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -5398,6 +5555,7 @@ static UA_BrowseRequest XS_unpack_UA_BrowseRequest(SV *in)  __attribute__((unuse
 static UA_BrowseRequest
 XS_unpack_UA_BrowseRequest(SV *in)
 {
+    dTHX;
 	UA_BrowseRequest out;
 	SV **svp;
 	AV *av;
@@ -5451,6 +5609,7 @@ static void XS_pack_UA_BrowseResponse(SV *out, UA_BrowseResponse in)  __attribut
 static void
 XS_pack_UA_BrowseResponse(SV *out, UA_BrowseResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -5485,6 +5644,7 @@ static UA_BrowseResponse XS_unpack_UA_BrowseResponse(SV *in)  __attribute__((unu
 static UA_BrowseResponse
 XS_unpack_UA_BrowseResponse(SV *in)
 {
+    dTHX;
 	UA_BrowseResponse out;
 	SV **svp;
 	AV *av;
@@ -5550,6 +5710,7 @@ static void XS_pack_UA_BrowseNextRequest(SV *out, UA_BrowseNextRequest in)  __at
 static void
 XS_pack_UA_BrowseNextRequest(SV *out, UA_BrowseNextRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -5579,6 +5740,7 @@ static UA_BrowseNextRequest XS_unpack_UA_BrowseNextRequest(SV *in)  __attribute_
 static UA_BrowseNextRequest
 XS_unpack_UA_BrowseNextRequest(SV *in)
 {
+    dTHX;
 	UA_BrowseNextRequest out;
 	SV **svp;
 	AV *av;
@@ -5628,6 +5790,7 @@ static void XS_pack_UA_BrowseNextResponse(SV *out, UA_BrowseNextResponse in)  __
 static void
 XS_pack_UA_BrowseNextResponse(SV *out, UA_BrowseNextResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -5662,6 +5825,7 @@ static UA_BrowseNextResponse XS_unpack_UA_BrowseNextResponse(SV *in)  __attribut
 static UA_BrowseNextResponse
 XS_unpack_UA_BrowseNextResponse(SV *in)
 {
+    dTHX;
 	UA_BrowseNextResponse out;
 	SV **svp;
 	AV *av;
@@ -5727,6 +5891,7 @@ static void XS_pack_UA_RelativePathElement(SV *out, UA_RelativePathElement in)  
 static void
 XS_pack_UA_RelativePathElement(SV *out, UA_RelativePathElement in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -5753,6 +5918,7 @@ static UA_RelativePathElement XS_unpack_UA_RelativePathElement(SV *in)  __attrib
 static UA_RelativePathElement
 XS_unpack_UA_RelativePathElement(SV *in)
 {
+    dTHX;
 	UA_RelativePathElement out;
 	SV **svp;
 	HV *hv;
@@ -5788,6 +5954,7 @@ static void XS_pack_UA_RelativePath(SV *out, UA_RelativePath in)  __attribute__(
 static void
 XS_pack_UA_RelativePath(SV *out, UA_RelativePath in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -5809,6 +5976,7 @@ static UA_RelativePath XS_unpack_UA_RelativePath(SV *in)  __attribute__((unused)
 static UA_RelativePath
 XS_unpack_UA_RelativePath(SV *in)
 {
+    dTHX;
 	UA_RelativePath out;
 	SV **svp;
 	AV *av;
@@ -5850,6 +6018,7 @@ static void XS_pack_UA_BrowsePath(SV *out, UA_BrowsePath in)  __attribute__((unu
 static void
 XS_pack_UA_BrowsePath(SV *out, UA_BrowsePath in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -5868,6 +6037,7 @@ static UA_BrowsePath XS_unpack_UA_BrowsePath(SV *in)  __attribute__((unused));
 static UA_BrowsePath
 XS_unpack_UA_BrowsePath(SV *in)
 {
+    dTHX;
 	UA_BrowsePath out;
 	SV **svp;
 	HV *hv;
@@ -5895,6 +6065,7 @@ static void XS_pack_UA_BrowsePathTarget(SV *out, UA_BrowsePathTarget in)  __attr
 static void
 XS_pack_UA_BrowsePathTarget(SV *out, UA_BrowsePathTarget in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -5913,6 +6084,7 @@ static UA_BrowsePathTarget XS_unpack_UA_BrowsePathTarget(SV *in)  __attribute__(
 static UA_BrowsePathTarget
 XS_unpack_UA_BrowsePathTarget(SV *in)
 {
+    dTHX;
 	UA_BrowsePathTarget out;
 	SV **svp;
 	HV *hv;
@@ -5940,6 +6112,7 @@ static void XS_pack_UA_BrowsePathResult(SV *out, UA_BrowsePathResult in)  __attr
 static void
 XS_pack_UA_BrowsePathResult(SV *out, UA_BrowsePathResult in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -5965,6 +6138,7 @@ static UA_BrowsePathResult XS_unpack_UA_BrowsePathResult(SV *in)  __attribute__(
 static UA_BrowsePathResult
 XS_unpack_UA_BrowsePathResult(SV *in)
 {
+    dTHX;
 	UA_BrowsePathResult out;
 	SV **svp;
 	AV *av;
@@ -6010,6 +6184,7 @@ static void XS_pack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *out, UA_Translat
 static void
 XS_pack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *out, UA_TranslateBrowsePathsToNodeIdsRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6035,6 +6210,7 @@ static UA_TranslateBrowsePathsToNodeIdsRequest XS_unpack_UA_TranslateBrowsePaths
 static UA_TranslateBrowsePathsToNodeIdsRequest
 XS_unpack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *in)
 {
+    dTHX;
 	UA_TranslateBrowsePathsToNodeIdsRequest out;
 	SV **svp;
 	AV *av;
@@ -6080,6 +6256,7 @@ static void XS_pack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *out, UA_Transla
 static void
 XS_pack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *out, UA_TranslateBrowsePathsToNodeIdsResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6114,6 +6291,7 @@ static UA_TranslateBrowsePathsToNodeIdsResponse XS_unpack_UA_TranslateBrowsePath
 static UA_TranslateBrowsePathsToNodeIdsResponse
 XS_unpack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *in)
 {
+    dTHX;
 	UA_TranslateBrowsePathsToNodeIdsResponse out;
 	SV **svp;
 	AV *av;
@@ -6179,6 +6357,7 @@ static void XS_pack_UA_RegisterNodesRequest(SV *out, UA_RegisterNodesRequest in)
 static void
 XS_pack_UA_RegisterNodesRequest(SV *out, UA_RegisterNodesRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6204,6 +6383,7 @@ static UA_RegisterNodesRequest XS_unpack_UA_RegisterNodesRequest(SV *in)  __attr
 static UA_RegisterNodesRequest
 XS_unpack_UA_RegisterNodesRequest(SV *in)
 {
+    dTHX;
 	UA_RegisterNodesRequest out;
 	SV **svp;
 	AV *av;
@@ -6249,6 +6429,7 @@ static void XS_pack_UA_RegisterNodesResponse(SV *out, UA_RegisterNodesResponse i
 static void
 XS_pack_UA_RegisterNodesResponse(SV *out, UA_RegisterNodesResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6274,6 +6455,7 @@ static UA_RegisterNodesResponse XS_unpack_UA_RegisterNodesResponse(SV *in)  __at
 static UA_RegisterNodesResponse
 XS_unpack_UA_RegisterNodesResponse(SV *in)
 {
+    dTHX;
 	UA_RegisterNodesResponse out;
 	SV **svp;
 	AV *av;
@@ -6319,6 +6501,7 @@ static void XS_pack_UA_UnregisterNodesRequest(SV *out, UA_UnregisterNodesRequest
 static void
 XS_pack_UA_UnregisterNodesRequest(SV *out, UA_UnregisterNodesRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6344,6 +6527,7 @@ static UA_UnregisterNodesRequest XS_unpack_UA_UnregisterNodesRequest(SV *in)  __
 static UA_UnregisterNodesRequest
 XS_unpack_UA_UnregisterNodesRequest(SV *in)
 {
+    dTHX;
 	UA_UnregisterNodesRequest out;
 	SV **svp;
 	AV *av;
@@ -6389,6 +6573,7 @@ static void XS_pack_UA_UnregisterNodesResponse(SV *out, UA_UnregisterNodesRespon
 static void
 XS_pack_UA_UnregisterNodesResponse(SV *out, UA_UnregisterNodesResponse in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -6403,6 +6588,7 @@ static UA_UnregisterNodesResponse XS_unpack_UA_UnregisterNodesResponse(SV *in)  
 static UA_UnregisterNodesResponse
 XS_unpack_UA_UnregisterNodesResponse(SV *in)
 {
+    dTHX;
 	UA_UnregisterNodesResponse out;
 	SV **svp;
 	HV *hv;
@@ -6426,6 +6612,7 @@ static void XS_pack_UA_FilterOperator(SV *out, UA_FilterOperator in)  __attribut
 static void
 XS_pack_UA_FilterOperator(SV *out, UA_FilterOperator in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -6433,6 +6620,7 @@ static UA_FilterOperator XS_unpack_UA_FilterOperator(SV *in)  __attribute__((unu
 static UA_FilterOperator
 XS_unpack_UA_FilterOperator(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -6441,6 +6629,7 @@ static void XS_pack_UA_ContentFilterElement(SV *out, UA_ContentFilterElement in)
 static void
 XS_pack_UA_ContentFilterElement(SV *out, UA_ContentFilterElement in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6466,6 +6655,7 @@ static UA_ContentFilterElement XS_unpack_UA_ContentFilterElement(SV *in)  __attr
 static UA_ContentFilterElement
 XS_unpack_UA_ContentFilterElement(SV *in)
 {
+    dTHX;
 	UA_ContentFilterElement out;
 	SV **svp;
 	AV *av;
@@ -6511,6 +6701,7 @@ static void XS_pack_UA_ContentFilter(SV *out, UA_ContentFilter in)  __attribute_
 static void
 XS_pack_UA_ContentFilter(SV *out, UA_ContentFilter in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6532,6 +6723,7 @@ static UA_ContentFilter XS_unpack_UA_ContentFilter(SV *in)  __attribute__((unuse
 static UA_ContentFilter
 XS_unpack_UA_ContentFilter(SV *in)
 {
+    dTHX;
 	UA_ContentFilter out;
 	SV **svp;
 	AV *av;
@@ -6573,6 +6765,7 @@ static void XS_pack_UA_FilterOperand(SV *out, UA_FilterOperand in)  __attribute_
 static void
 XS_pack_UA_FilterOperand(SV *out, UA_FilterOperand in)
 {
+    dTHX;
 	croak("%s: conversion for type not implemented", __func__);
 }
 
@@ -6580,6 +6773,7 @@ static UA_FilterOperand XS_unpack_UA_FilterOperand(SV *in)  __attribute__((unuse
 static UA_FilterOperand
 XS_unpack_UA_FilterOperand(SV *in)
 {
+    dTHX;
 	croak("%s: conversion for type not implemented", __func__);
 }
 
@@ -6588,6 +6782,7 @@ static void XS_pack_UA_ElementOperand(SV *out, UA_ElementOperand in)  __attribut
 static void
 XS_pack_UA_ElementOperand(SV *out, UA_ElementOperand in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -6602,6 +6797,7 @@ static UA_ElementOperand XS_unpack_UA_ElementOperand(SV *in)  __attribute__((unu
 static UA_ElementOperand
 XS_unpack_UA_ElementOperand(SV *in)
 {
+    dTHX;
 	UA_ElementOperand out;
 	SV **svp;
 	HV *hv;
@@ -6625,6 +6821,7 @@ static void XS_pack_UA_LiteralOperand(SV *out, UA_LiteralOperand in)  __attribut
 static void
 XS_pack_UA_LiteralOperand(SV *out, UA_LiteralOperand in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -6639,6 +6836,7 @@ static UA_LiteralOperand XS_unpack_UA_LiteralOperand(SV *in)  __attribute__((unu
 static UA_LiteralOperand
 XS_unpack_UA_LiteralOperand(SV *in)
 {
+    dTHX;
 	UA_LiteralOperand out;
 	SV **svp;
 	HV *hv;
@@ -6662,6 +6860,7 @@ static void XS_pack_UA_AttributeOperand(SV *out, UA_AttributeOperand in)  __attr
 static void
 XS_pack_UA_AttributeOperand(SV *out, UA_AttributeOperand in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -6692,6 +6891,7 @@ static UA_AttributeOperand XS_unpack_UA_AttributeOperand(SV *in)  __attribute__(
 static UA_AttributeOperand
 XS_unpack_UA_AttributeOperand(SV *in)
 {
+    dTHX;
 	UA_AttributeOperand out;
 	SV **svp;
 	HV *hv;
@@ -6731,6 +6931,7 @@ static void XS_pack_UA_SimpleAttributeOperand(SV *out, UA_SimpleAttributeOperand
 static void
 XS_pack_UA_SimpleAttributeOperand(SV *out, UA_SimpleAttributeOperand in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6764,6 +6965,7 @@ static UA_SimpleAttributeOperand XS_unpack_UA_SimpleAttributeOperand(SV *in)  __
 static UA_SimpleAttributeOperand
 XS_unpack_UA_SimpleAttributeOperand(SV *in)
 {
+    dTHX;
 	UA_SimpleAttributeOperand out;
 	SV **svp;
 	AV *av;
@@ -6817,6 +7019,7 @@ static void XS_pack_UA_ContentFilterElementResult(SV *out, UA_ContentFilterEleme
 static void
 XS_pack_UA_ContentFilterElementResult(SV *out, UA_ContentFilterElementResult in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6851,6 +7054,7 @@ static UA_ContentFilterElementResult XS_unpack_UA_ContentFilterElementResult(SV 
 static UA_ContentFilterElementResult
 XS_unpack_UA_ContentFilterElementResult(SV *in)
 {
+    dTHX;
 	UA_ContentFilterElementResult out;
 	SV **svp;
 	AV *av;
@@ -6916,6 +7120,7 @@ static void XS_pack_UA_ContentFilterResult(SV *out, UA_ContentFilterResult in)  
 static void
 XS_pack_UA_ContentFilterResult(SV *out, UA_ContentFilterResult in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -6946,6 +7151,7 @@ static UA_ContentFilterResult XS_unpack_UA_ContentFilterResult(SV *in)  __attrib
 static UA_ContentFilterResult
 XS_unpack_UA_ContentFilterResult(SV *in)
 {
+    dTHX;
 	UA_ContentFilterResult out;
 	SV **svp;
 	AV *av;
@@ -7007,6 +7213,7 @@ static void XS_pack_UA_TimestampsToReturn(SV *out, UA_TimestampsToReturn in)  __
 static void
 XS_pack_UA_TimestampsToReturn(SV *out, UA_TimestampsToReturn in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -7014,6 +7221,7 @@ static UA_TimestampsToReturn XS_unpack_UA_TimestampsToReturn(SV *in)  __attribut
 static UA_TimestampsToReturn
 XS_unpack_UA_TimestampsToReturn(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -7022,6 +7230,7 @@ static void XS_pack_UA_ReadValueId(SV *out, UA_ReadValueId in)  __attribute__((u
 static void
 XS_pack_UA_ReadValueId(SV *out, UA_ReadValueId in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -7048,6 +7257,7 @@ static UA_ReadValueId XS_unpack_UA_ReadValueId(SV *in)  __attribute__((unused));
 static UA_ReadValueId
 XS_unpack_UA_ReadValueId(SV *in)
 {
+    dTHX;
 	UA_ReadValueId out;
 	SV **svp;
 	HV *hv;
@@ -7083,6 +7293,7 @@ static void XS_pack_UA_ReadRequest(SV *out, UA_ReadRequest in)  __attribute__((u
 static void
 XS_pack_UA_ReadRequest(SV *out, UA_ReadRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -7116,6 +7327,7 @@ static UA_ReadRequest XS_unpack_UA_ReadRequest(SV *in)  __attribute__((unused));
 static UA_ReadRequest
 XS_unpack_UA_ReadRequest(SV *in)
 {
+    dTHX;
 	UA_ReadRequest out;
 	SV **svp;
 	AV *av;
@@ -7169,6 +7381,7 @@ static void XS_pack_UA_ReadResponse(SV *out, UA_ReadResponse in)  __attribute__(
 static void
 XS_pack_UA_ReadResponse(SV *out, UA_ReadResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -7203,6 +7416,7 @@ static UA_ReadResponse XS_unpack_UA_ReadResponse(SV *in)  __attribute__((unused)
 static UA_ReadResponse
 XS_unpack_UA_ReadResponse(SV *in)
 {
+    dTHX;
 	UA_ReadResponse out;
 	SV **svp;
 	AV *av;
@@ -7268,6 +7482,7 @@ static void XS_pack_UA_WriteValue(SV *out, UA_WriteValue in)  __attribute__((unu
 static void
 XS_pack_UA_WriteValue(SV *out, UA_WriteValue in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -7294,6 +7509,7 @@ static UA_WriteValue XS_unpack_UA_WriteValue(SV *in)  __attribute__((unused));
 static UA_WriteValue
 XS_unpack_UA_WriteValue(SV *in)
 {
+    dTHX;
 	UA_WriteValue out;
 	SV **svp;
 	HV *hv;
@@ -7329,6 +7545,7 @@ static void XS_pack_UA_WriteRequest(SV *out, UA_WriteRequest in)  __attribute__(
 static void
 XS_pack_UA_WriteRequest(SV *out, UA_WriteRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -7354,6 +7571,7 @@ static UA_WriteRequest XS_unpack_UA_WriteRequest(SV *in)  __attribute__((unused)
 static UA_WriteRequest
 XS_unpack_UA_WriteRequest(SV *in)
 {
+    dTHX;
 	UA_WriteRequest out;
 	SV **svp;
 	AV *av;
@@ -7399,6 +7617,7 @@ static void XS_pack_UA_WriteResponse(SV *out, UA_WriteResponse in)  __attribute_
 static void
 XS_pack_UA_WriteResponse(SV *out, UA_WriteResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -7433,6 +7652,7 @@ static UA_WriteResponse XS_unpack_UA_WriteResponse(SV *in)  __attribute__((unuse
 static UA_WriteResponse
 XS_unpack_UA_WriteResponse(SV *in)
 {
+    dTHX;
 	UA_WriteResponse out;
 	SV **svp;
 	AV *av;
@@ -7498,6 +7718,7 @@ static void XS_pack_UA_CallMethodRequest(SV *out, UA_CallMethodRequest in)  __at
 static void
 XS_pack_UA_CallMethodRequest(SV *out, UA_CallMethodRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -7527,6 +7748,7 @@ static UA_CallMethodRequest XS_unpack_UA_CallMethodRequest(SV *in)  __attribute_
 static UA_CallMethodRequest
 XS_unpack_UA_CallMethodRequest(SV *in)
 {
+    dTHX;
 	UA_CallMethodRequest out;
 	SV **svp;
 	AV *av;
@@ -7576,6 +7798,7 @@ static void XS_pack_UA_CallMethodResult(SV *out, UA_CallMethodResult in)  __attr
 static void
 XS_pack_UA_CallMethodResult(SV *out, UA_CallMethodResult in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -7619,6 +7842,7 @@ static UA_CallMethodResult XS_unpack_UA_CallMethodResult(SV *in)  __attribute__(
 static UA_CallMethodResult
 XS_unpack_UA_CallMethodResult(SV *in)
 {
+    dTHX;
 	UA_CallMethodResult out;
 	SV **svp;
 	AV *av;
@@ -7704,6 +7928,7 @@ static void XS_pack_UA_CallRequest(SV *out, UA_CallRequest in)  __attribute__((u
 static void
 XS_pack_UA_CallRequest(SV *out, UA_CallRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -7729,6 +7954,7 @@ static UA_CallRequest XS_unpack_UA_CallRequest(SV *in)  __attribute__((unused));
 static UA_CallRequest
 XS_unpack_UA_CallRequest(SV *in)
 {
+    dTHX;
 	UA_CallRequest out;
 	SV **svp;
 	AV *av;
@@ -7774,6 +8000,7 @@ static void XS_pack_UA_CallResponse(SV *out, UA_CallResponse in)  __attribute__(
 static void
 XS_pack_UA_CallResponse(SV *out, UA_CallResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -7808,6 +8035,7 @@ static UA_CallResponse XS_unpack_UA_CallResponse(SV *in)  __attribute__((unused)
 static UA_CallResponse
 XS_unpack_UA_CallResponse(SV *in)
 {
+    dTHX;
 	UA_CallResponse out;
 	SV **svp;
 	AV *av;
@@ -7873,6 +8101,7 @@ static void XS_pack_UA_MonitoringMode(SV *out, UA_MonitoringMode in)  __attribut
 static void
 XS_pack_UA_MonitoringMode(SV *out, UA_MonitoringMode in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -7880,6 +8109,7 @@ static UA_MonitoringMode XS_unpack_UA_MonitoringMode(SV *in)  __attribute__((unu
 static UA_MonitoringMode
 XS_unpack_UA_MonitoringMode(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -7888,6 +8118,7 @@ static void XS_pack_UA_DataChangeTrigger(SV *out, UA_DataChangeTrigger in)  __at
 static void
 XS_pack_UA_DataChangeTrigger(SV *out, UA_DataChangeTrigger in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -7895,6 +8126,7 @@ static UA_DataChangeTrigger XS_unpack_UA_DataChangeTrigger(SV *in)  __attribute_
 static UA_DataChangeTrigger
 XS_unpack_UA_DataChangeTrigger(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -7903,6 +8135,7 @@ static void XS_pack_UA_DeadbandType(SV *out, UA_DeadbandType in)  __attribute__(
 static void
 XS_pack_UA_DeadbandType(SV *out, UA_DeadbandType in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -7910,6 +8143,7 @@ static UA_DeadbandType XS_unpack_UA_DeadbandType(SV *in)  __attribute__((unused)
 static UA_DeadbandType
 XS_unpack_UA_DeadbandType(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -7918,6 +8152,7 @@ static void XS_pack_UA_DataChangeFilter(SV *out, UA_DataChangeFilter in)  __attr
 static void
 XS_pack_UA_DataChangeFilter(SV *out, UA_DataChangeFilter in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -7940,6 +8175,7 @@ static UA_DataChangeFilter XS_unpack_UA_DataChangeFilter(SV *in)  __attribute__(
 static UA_DataChangeFilter
 XS_unpack_UA_DataChangeFilter(SV *in)
 {
+    dTHX;
 	UA_DataChangeFilter out;
 	SV **svp;
 	HV *hv;
@@ -7971,6 +8207,7 @@ static void XS_pack_UA_EventFilter(SV *out, UA_EventFilter in)  __attribute__((u
 static void
 XS_pack_UA_EventFilter(SV *out, UA_EventFilter in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -7996,6 +8233,7 @@ static UA_EventFilter XS_unpack_UA_EventFilter(SV *in)  __attribute__((unused));
 static UA_EventFilter
 XS_unpack_UA_EventFilter(SV *in)
 {
+    dTHX;
 	UA_EventFilter out;
 	SV **svp;
 	AV *av;
@@ -8041,6 +8279,7 @@ static void XS_pack_UA_AggregateConfiguration(SV *out, UA_AggregateConfiguration
 static void
 XS_pack_UA_AggregateConfiguration(SV *out, UA_AggregateConfiguration in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -8071,6 +8310,7 @@ static UA_AggregateConfiguration XS_unpack_UA_AggregateConfiguration(SV *in)  __
 static UA_AggregateConfiguration
 XS_unpack_UA_AggregateConfiguration(SV *in)
 {
+    dTHX;
 	UA_AggregateConfiguration out;
 	SV **svp;
 	HV *hv;
@@ -8110,6 +8350,7 @@ static void XS_pack_UA_AggregateFilter(SV *out, UA_AggregateFilter in)  __attrib
 static void
 XS_pack_UA_AggregateFilter(SV *out, UA_AggregateFilter in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -8136,6 +8377,7 @@ static UA_AggregateFilter XS_unpack_UA_AggregateFilter(SV *in)  __attribute__((u
 static UA_AggregateFilter
 XS_unpack_UA_AggregateFilter(SV *in)
 {
+    dTHX;
 	UA_AggregateFilter out;
 	SV **svp;
 	HV *hv;
@@ -8171,6 +8413,7 @@ static void XS_pack_UA_EventFilterResult(SV *out, UA_EventFilterResult in)  __at
 static void
 XS_pack_UA_EventFilterResult(SV *out, UA_EventFilterResult in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -8205,6 +8448,7 @@ static UA_EventFilterResult XS_unpack_UA_EventFilterResult(SV *in)  __attribute_
 static UA_EventFilterResult
 XS_unpack_UA_EventFilterResult(SV *in)
 {
+    dTHX;
 	UA_EventFilterResult out;
 	SV **svp;
 	AV *av;
@@ -8270,6 +8514,7 @@ static void XS_pack_UA_MonitoringParameters(SV *out, UA_MonitoringParameters in)
 static void
 XS_pack_UA_MonitoringParameters(SV *out, UA_MonitoringParameters in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -8300,6 +8545,7 @@ static UA_MonitoringParameters XS_unpack_UA_MonitoringParameters(SV *in)  __attr
 static UA_MonitoringParameters
 XS_unpack_UA_MonitoringParameters(SV *in)
 {
+    dTHX;
 	UA_MonitoringParameters out;
 	SV **svp;
 	HV *hv;
@@ -8339,6 +8585,7 @@ static void XS_pack_UA_MonitoredItemCreateRequest(SV *out, UA_MonitoredItemCreat
 static void
 XS_pack_UA_MonitoredItemCreateRequest(SV *out, UA_MonitoredItemCreateRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -8361,6 +8608,7 @@ static UA_MonitoredItemCreateRequest XS_unpack_UA_MonitoredItemCreateRequest(SV 
 static UA_MonitoredItemCreateRequest
 XS_unpack_UA_MonitoredItemCreateRequest(SV *in)
 {
+    dTHX;
 	UA_MonitoredItemCreateRequest out;
 	SV **svp;
 	HV *hv;
@@ -8392,6 +8640,7 @@ static void XS_pack_UA_MonitoredItemCreateResult(SV *out, UA_MonitoredItemCreate
 static void
 XS_pack_UA_MonitoredItemCreateResult(SV *out, UA_MonitoredItemCreateResult in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -8422,6 +8671,7 @@ static UA_MonitoredItemCreateResult XS_unpack_UA_MonitoredItemCreateResult(SV *i
 static UA_MonitoredItemCreateResult
 XS_unpack_UA_MonitoredItemCreateResult(SV *in)
 {
+    dTHX;
 	UA_MonitoredItemCreateResult out;
 	SV **svp;
 	HV *hv;
@@ -8461,6 +8711,7 @@ static void XS_pack_UA_CreateMonitoredItemsRequest(SV *out, UA_CreateMonitoredIt
 static void
 XS_pack_UA_CreateMonitoredItemsRequest(SV *out, UA_CreateMonitoredItemsRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -8494,6 +8745,7 @@ static UA_CreateMonitoredItemsRequest XS_unpack_UA_CreateMonitoredItemsRequest(S
 static UA_CreateMonitoredItemsRequest
 XS_unpack_UA_CreateMonitoredItemsRequest(SV *in)
 {
+    dTHX;
 	UA_CreateMonitoredItemsRequest out;
 	SV **svp;
 	AV *av;
@@ -8547,6 +8799,7 @@ static void XS_pack_UA_CreateMonitoredItemsResponse(SV *out, UA_CreateMonitoredI
 static void
 XS_pack_UA_CreateMonitoredItemsResponse(SV *out, UA_CreateMonitoredItemsResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -8581,6 +8834,7 @@ static UA_CreateMonitoredItemsResponse XS_unpack_UA_CreateMonitoredItemsResponse
 static UA_CreateMonitoredItemsResponse
 XS_unpack_UA_CreateMonitoredItemsResponse(SV *in)
 {
+    dTHX;
 	UA_CreateMonitoredItemsResponse out;
 	SV **svp;
 	AV *av;
@@ -8646,6 +8900,7 @@ static void XS_pack_UA_MonitoredItemModifyRequest(SV *out, UA_MonitoredItemModif
 static void
 XS_pack_UA_MonitoredItemModifyRequest(SV *out, UA_MonitoredItemModifyRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -8664,6 +8919,7 @@ static UA_MonitoredItemModifyRequest XS_unpack_UA_MonitoredItemModifyRequest(SV 
 static UA_MonitoredItemModifyRequest
 XS_unpack_UA_MonitoredItemModifyRequest(SV *in)
 {
+    dTHX;
 	UA_MonitoredItemModifyRequest out;
 	SV **svp;
 	HV *hv;
@@ -8691,6 +8947,7 @@ static void XS_pack_UA_MonitoredItemModifyResult(SV *out, UA_MonitoredItemModify
 static void
 XS_pack_UA_MonitoredItemModifyResult(SV *out, UA_MonitoredItemModifyResult in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -8717,6 +8974,7 @@ static UA_MonitoredItemModifyResult XS_unpack_UA_MonitoredItemModifyResult(SV *i
 static UA_MonitoredItemModifyResult
 XS_unpack_UA_MonitoredItemModifyResult(SV *in)
 {
+    dTHX;
 	UA_MonitoredItemModifyResult out;
 	SV **svp;
 	HV *hv;
@@ -8752,6 +9010,7 @@ static void XS_pack_UA_ModifyMonitoredItemsRequest(SV *out, UA_ModifyMonitoredIt
 static void
 XS_pack_UA_ModifyMonitoredItemsRequest(SV *out, UA_ModifyMonitoredItemsRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -8785,6 +9044,7 @@ static UA_ModifyMonitoredItemsRequest XS_unpack_UA_ModifyMonitoredItemsRequest(S
 static UA_ModifyMonitoredItemsRequest
 XS_unpack_UA_ModifyMonitoredItemsRequest(SV *in)
 {
+    dTHX;
 	UA_ModifyMonitoredItemsRequest out;
 	SV **svp;
 	AV *av;
@@ -8838,6 +9098,7 @@ static void XS_pack_UA_ModifyMonitoredItemsResponse(SV *out, UA_ModifyMonitoredI
 static void
 XS_pack_UA_ModifyMonitoredItemsResponse(SV *out, UA_ModifyMonitoredItemsResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -8872,6 +9133,7 @@ static UA_ModifyMonitoredItemsResponse XS_unpack_UA_ModifyMonitoredItemsResponse
 static UA_ModifyMonitoredItemsResponse
 XS_unpack_UA_ModifyMonitoredItemsResponse(SV *in)
 {
+    dTHX;
 	UA_ModifyMonitoredItemsResponse out;
 	SV **svp;
 	AV *av;
@@ -8937,6 +9199,7 @@ static void XS_pack_UA_SetMonitoringModeRequest(SV *out, UA_SetMonitoringModeReq
 static void
 XS_pack_UA_SetMonitoringModeRequest(SV *out, UA_SetMonitoringModeRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -8970,6 +9233,7 @@ static UA_SetMonitoringModeRequest XS_unpack_UA_SetMonitoringModeRequest(SV *in)
 static UA_SetMonitoringModeRequest
 XS_unpack_UA_SetMonitoringModeRequest(SV *in)
 {
+    dTHX;
 	UA_SetMonitoringModeRequest out;
 	SV **svp;
 	AV *av;
@@ -9023,6 +9287,7 @@ static void XS_pack_UA_SetMonitoringModeResponse(SV *out, UA_SetMonitoringModeRe
 static void
 XS_pack_UA_SetMonitoringModeResponse(SV *out, UA_SetMonitoringModeResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -9057,6 +9322,7 @@ static UA_SetMonitoringModeResponse XS_unpack_UA_SetMonitoringModeResponse(SV *i
 static UA_SetMonitoringModeResponse
 XS_unpack_UA_SetMonitoringModeResponse(SV *in)
 {
+    dTHX;
 	UA_SetMonitoringModeResponse out;
 	SV **svp;
 	AV *av;
@@ -9122,6 +9388,7 @@ static void XS_pack_UA_SetTriggeringRequest(SV *out, UA_SetTriggeringRequest in)
 static void
 XS_pack_UA_SetTriggeringRequest(SV *out, UA_SetTriggeringRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -9164,6 +9431,7 @@ static UA_SetTriggeringRequest XS_unpack_UA_SetTriggeringRequest(SV *in)  __attr
 static UA_SetTriggeringRequest
 XS_unpack_UA_SetTriggeringRequest(SV *in)
 {
+    dTHX;
 	UA_SetTriggeringRequest out;
 	SV **svp;
 	AV *av;
@@ -9237,6 +9505,7 @@ static void XS_pack_UA_SetTriggeringResponse(SV *out, UA_SetTriggeringResponse i
 static void
 XS_pack_UA_SetTriggeringResponse(SV *out, UA_SetTriggeringResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -9289,6 +9558,7 @@ static UA_SetTriggeringResponse XS_unpack_UA_SetTriggeringResponse(SV *in)  __at
 static UA_SetTriggeringResponse
 XS_unpack_UA_SetTriggeringResponse(SV *in)
 {
+    dTHX;
 	UA_SetTriggeringResponse out;
 	SV **svp;
 	AV *av;
@@ -9394,6 +9664,7 @@ static void XS_pack_UA_DeleteMonitoredItemsRequest(SV *out, UA_DeleteMonitoredIt
 static void
 XS_pack_UA_DeleteMonitoredItemsRequest(SV *out, UA_DeleteMonitoredItemsRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -9423,6 +9694,7 @@ static UA_DeleteMonitoredItemsRequest XS_unpack_UA_DeleteMonitoredItemsRequest(S
 static UA_DeleteMonitoredItemsRequest
 XS_unpack_UA_DeleteMonitoredItemsRequest(SV *in)
 {
+    dTHX;
 	UA_DeleteMonitoredItemsRequest out;
 	SV **svp;
 	AV *av;
@@ -9472,6 +9744,7 @@ static void XS_pack_UA_DeleteMonitoredItemsResponse(SV *out, UA_DeleteMonitoredI
 static void
 XS_pack_UA_DeleteMonitoredItemsResponse(SV *out, UA_DeleteMonitoredItemsResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -9506,6 +9779,7 @@ static UA_DeleteMonitoredItemsResponse XS_unpack_UA_DeleteMonitoredItemsResponse
 static UA_DeleteMonitoredItemsResponse
 XS_unpack_UA_DeleteMonitoredItemsResponse(SV *in)
 {
+    dTHX;
 	UA_DeleteMonitoredItemsResponse out;
 	SV **svp;
 	AV *av;
@@ -9571,6 +9845,7 @@ static void XS_pack_UA_CreateSubscriptionRequest(SV *out, UA_CreateSubscriptionR
 static void
 XS_pack_UA_CreateSubscriptionRequest(SV *out, UA_CreateSubscriptionRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -9609,6 +9884,7 @@ static UA_CreateSubscriptionRequest XS_unpack_UA_CreateSubscriptionRequest(SV *i
 static UA_CreateSubscriptionRequest
 XS_unpack_UA_CreateSubscriptionRequest(SV *in)
 {
+    dTHX;
 	UA_CreateSubscriptionRequest out;
 	SV **svp;
 	HV *hv;
@@ -9656,6 +9932,7 @@ static void XS_pack_UA_CreateSubscriptionResponse(SV *out, UA_CreateSubscription
 static void
 XS_pack_UA_CreateSubscriptionResponse(SV *out, UA_CreateSubscriptionResponse in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -9686,6 +9963,7 @@ static UA_CreateSubscriptionResponse XS_unpack_UA_CreateSubscriptionResponse(SV 
 static UA_CreateSubscriptionResponse
 XS_unpack_UA_CreateSubscriptionResponse(SV *in)
 {
+    dTHX;
 	UA_CreateSubscriptionResponse out;
 	SV **svp;
 	HV *hv;
@@ -9725,6 +10003,7 @@ static void XS_pack_UA_ModifySubscriptionRequest(SV *out, UA_ModifySubscriptionR
 static void
 XS_pack_UA_ModifySubscriptionRequest(SV *out, UA_ModifySubscriptionRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -9763,6 +10042,7 @@ static UA_ModifySubscriptionRequest XS_unpack_UA_ModifySubscriptionRequest(SV *i
 static UA_ModifySubscriptionRequest
 XS_unpack_UA_ModifySubscriptionRequest(SV *in)
 {
+    dTHX;
 	UA_ModifySubscriptionRequest out;
 	SV **svp;
 	HV *hv;
@@ -9810,6 +10090,7 @@ static void XS_pack_UA_ModifySubscriptionResponse(SV *out, UA_ModifySubscription
 static void
 XS_pack_UA_ModifySubscriptionResponse(SV *out, UA_ModifySubscriptionResponse in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -9836,6 +10117,7 @@ static UA_ModifySubscriptionResponse XS_unpack_UA_ModifySubscriptionResponse(SV 
 static UA_ModifySubscriptionResponse
 XS_unpack_UA_ModifySubscriptionResponse(SV *in)
 {
+    dTHX;
 	UA_ModifySubscriptionResponse out;
 	SV **svp;
 	HV *hv;
@@ -9871,6 +10153,7 @@ static void XS_pack_UA_SetPublishingModeRequest(SV *out, UA_SetPublishingModeReq
 static void
 XS_pack_UA_SetPublishingModeRequest(SV *out, UA_SetPublishingModeRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -9900,6 +10183,7 @@ static UA_SetPublishingModeRequest XS_unpack_UA_SetPublishingModeRequest(SV *in)
 static UA_SetPublishingModeRequest
 XS_unpack_UA_SetPublishingModeRequest(SV *in)
 {
+    dTHX;
 	UA_SetPublishingModeRequest out;
 	SV **svp;
 	AV *av;
@@ -9949,6 +10233,7 @@ static void XS_pack_UA_SetPublishingModeResponse(SV *out, UA_SetPublishingModeRe
 static void
 XS_pack_UA_SetPublishingModeResponse(SV *out, UA_SetPublishingModeResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -9983,6 +10268,7 @@ static UA_SetPublishingModeResponse XS_unpack_UA_SetPublishingModeResponse(SV *i
 static UA_SetPublishingModeResponse
 XS_unpack_UA_SetPublishingModeResponse(SV *in)
 {
+    dTHX;
 	UA_SetPublishingModeResponse out;
 	SV **svp;
 	AV *av;
@@ -10048,6 +10334,7 @@ static void XS_pack_UA_NotificationMessage(SV *out, UA_NotificationMessage in)  
 static void
 XS_pack_UA_NotificationMessage(SV *out, UA_NotificationMessage in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -10077,6 +10364,7 @@ static UA_NotificationMessage XS_unpack_UA_NotificationMessage(SV *in)  __attrib
 static UA_NotificationMessage
 XS_unpack_UA_NotificationMessage(SV *in)
 {
+    dTHX;
 	UA_NotificationMessage out;
 	SV **svp;
 	AV *av;
@@ -10126,6 +10414,7 @@ static void XS_pack_UA_MonitoredItemNotification(SV *out, UA_MonitoredItemNotifi
 static void
 XS_pack_UA_MonitoredItemNotification(SV *out, UA_MonitoredItemNotification in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -10144,6 +10433,7 @@ static UA_MonitoredItemNotification XS_unpack_UA_MonitoredItemNotification(SV *i
 static UA_MonitoredItemNotification
 XS_unpack_UA_MonitoredItemNotification(SV *in)
 {
+    dTHX;
 	UA_MonitoredItemNotification out;
 	SV **svp;
 	HV *hv;
@@ -10171,6 +10461,7 @@ static void XS_pack_UA_EventFieldList(SV *out, UA_EventFieldList in)  __attribut
 static void
 XS_pack_UA_EventFieldList(SV *out, UA_EventFieldList in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -10196,6 +10487,7 @@ static UA_EventFieldList XS_unpack_UA_EventFieldList(SV *in)  __attribute__((unu
 static UA_EventFieldList
 XS_unpack_UA_EventFieldList(SV *in)
 {
+    dTHX;
 	UA_EventFieldList out;
 	SV **svp;
 	AV *av;
@@ -10241,6 +10533,7 @@ static void XS_pack_UA_StatusChangeNotification(SV *out, UA_StatusChangeNotifica
 static void
 XS_pack_UA_StatusChangeNotification(SV *out, UA_StatusChangeNotification in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -10259,6 +10552,7 @@ static UA_StatusChangeNotification XS_unpack_UA_StatusChangeNotification(SV *in)
 static UA_StatusChangeNotification
 XS_unpack_UA_StatusChangeNotification(SV *in)
 {
+    dTHX;
 	UA_StatusChangeNotification out;
 	SV **svp;
 	HV *hv;
@@ -10286,6 +10580,7 @@ static void XS_pack_UA_SubscriptionAcknowledgement(SV *out, UA_SubscriptionAckno
 static void
 XS_pack_UA_SubscriptionAcknowledgement(SV *out, UA_SubscriptionAcknowledgement in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -10304,6 +10599,7 @@ static UA_SubscriptionAcknowledgement XS_unpack_UA_SubscriptionAcknowledgement(S
 static UA_SubscriptionAcknowledgement
 XS_unpack_UA_SubscriptionAcknowledgement(SV *in)
 {
+    dTHX;
 	UA_SubscriptionAcknowledgement out;
 	SV **svp;
 	HV *hv;
@@ -10331,6 +10627,7 @@ static void XS_pack_UA_PublishRequest(SV *out, UA_PublishRequest in)  __attribut
 static void
 XS_pack_UA_PublishRequest(SV *out, UA_PublishRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -10356,6 +10653,7 @@ static UA_PublishRequest XS_unpack_UA_PublishRequest(SV *in)  __attribute__((unu
 static UA_PublishRequest
 XS_unpack_UA_PublishRequest(SV *in)
 {
+    dTHX;
 	UA_PublishRequest out;
 	SV **svp;
 	AV *av;
@@ -10401,6 +10699,7 @@ static void XS_pack_UA_PublishResponse(SV *out, UA_PublishResponse in)  __attrib
 static void
 XS_pack_UA_PublishResponse(SV *out, UA_PublishResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -10456,6 +10755,7 @@ static UA_PublishResponse XS_unpack_UA_PublishResponse(SV *in)  __attribute__((u
 static UA_PublishResponse
 XS_unpack_UA_PublishResponse(SV *in)
 {
+    dTHX;
 	UA_PublishResponse out;
 	SV **svp;
 	AV *av;
@@ -10553,6 +10853,7 @@ static void XS_pack_UA_RepublishRequest(SV *out, UA_RepublishRequest in)  __attr
 static void
 XS_pack_UA_RepublishRequest(SV *out, UA_RepublishRequest in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -10575,6 +10876,7 @@ static UA_RepublishRequest XS_unpack_UA_RepublishRequest(SV *in)  __attribute__(
 static UA_RepublishRequest
 XS_unpack_UA_RepublishRequest(SV *in)
 {
+    dTHX;
 	UA_RepublishRequest out;
 	SV **svp;
 	HV *hv;
@@ -10606,6 +10908,7 @@ static void XS_pack_UA_RepublishResponse(SV *out, UA_RepublishResponse in)  __at
 static void
 XS_pack_UA_RepublishResponse(SV *out, UA_RepublishResponse in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -10624,6 +10927,7 @@ static UA_RepublishResponse XS_unpack_UA_RepublishResponse(SV *in)  __attribute_
 static UA_RepublishResponse
 XS_unpack_UA_RepublishResponse(SV *in)
 {
+    dTHX;
 	UA_RepublishResponse out;
 	SV **svp;
 	HV *hv;
@@ -10651,6 +10955,7 @@ static void XS_pack_UA_DeleteSubscriptionsRequest(SV *out, UA_DeleteSubscription
 static void
 XS_pack_UA_DeleteSubscriptionsRequest(SV *out, UA_DeleteSubscriptionsRequest in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -10676,6 +10981,7 @@ static UA_DeleteSubscriptionsRequest XS_unpack_UA_DeleteSubscriptionsRequest(SV 
 static UA_DeleteSubscriptionsRequest
 XS_unpack_UA_DeleteSubscriptionsRequest(SV *in)
 {
+    dTHX;
 	UA_DeleteSubscriptionsRequest out;
 	SV **svp;
 	AV *av;
@@ -10721,6 +11027,7 @@ static void XS_pack_UA_DeleteSubscriptionsResponse(SV *out, UA_DeleteSubscriptio
 static void
 XS_pack_UA_DeleteSubscriptionsResponse(SV *out, UA_DeleteSubscriptionsResponse in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -10755,6 +11062,7 @@ static UA_DeleteSubscriptionsResponse XS_unpack_UA_DeleteSubscriptionsResponse(S
 static UA_DeleteSubscriptionsResponse
 XS_unpack_UA_DeleteSubscriptionsResponse(SV *in)
 {
+    dTHX;
 	UA_DeleteSubscriptionsResponse out;
 	SV **svp;
 	AV *av;
@@ -10820,6 +11128,7 @@ static void XS_pack_UA_BuildInfo(SV *out, UA_BuildInfo in)  __attribute__((unuse
 static void
 XS_pack_UA_BuildInfo(SV *out, UA_BuildInfo in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -10854,6 +11163,7 @@ static UA_BuildInfo XS_unpack_UA_BuildInfo(SV *in)  __attribute__((unused));
 static UA_BuildInfo
 XS_unpack_UA_BuildInfo(SV *in)
 {
+    dTHX;
 	UA_BuildInfo out;
 	SV **svp;
 	HV *hv;
@@ -10897,6 +11207,7 @@ static void XS_pack_UA_RedundancySupport(SV *out, UA_RedundancySupport in)  __at
 static void
 XS_pack_UA_RedundancySupport(SV *out, UA_RedundancySupport in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -10904,6 +11215,7 @@ static UA_RedundancySupport XS_unpack_UA_RedundancySupport(SV *in)  __attribute_
 static UA_RedundancySupport
 XS_unpack_UA_RedundancySupport(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -10912,6 +11224,7 @@ static void XS_pack_UA_ServerState(SV *out, UA_ServerState in)  __attribute__((u
 static void
 XS_pack_UA_ServerState(SV *out, UA_ServerState in)
 {
+    dTHX;
 	sv_setiv(out, in);
 }
 
@@ -10919,6 +11232,7 @@ static UA_ServerState XS_unpack_UA_ServerState(SV *in)  __attribute__((unused));
 static UA_ServerState
 XS_unpack_UA_ServerState(SV *in)
 {
+    dTHX;
 	return SvIV(in);
 }
 
@@ -10927,6 +11241,7 @@ static void XS_pack_UA_ServerDiagnosticsSummaryDataType(SV *out, UA_ServerDiagno
 static void
 XS_pack_UA_ServerDiagnosticsSummaryDataType(SV *out, UA_ServerDiagnosticsSummaryDataType in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -10985,6 +11300,7 @@ static UA_ServerDiagnosticsSummaryDataType XS_unpack_UA_ServerDiagnosticsSummary
 static UA_ServerDiagnosticsSummaryDataType
 XS_unpack_UA_ServerDiagnosticsSummaryDataType(SV *in)
 {
+    dTHX;
 	UA_ServerDiagnosticsSummaryDataType out;
 	SV **svp;
 	HV *hv;
@@ -11052,6 +11368,7 @@ static void XS_pack_UA_ServerStatusDataType(SV *out, UA_ServerStatusDataType in)
 static void
 XS_pack_UA_ServerStatusDataType(SV *out, UA_ServerStatusDataType in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -11086,6 +11403,7 @@ static UA_ServerStatusDataType XS_unpack_UA_ServerStatusDataType(SV *in)  __attr
 static UA_ServerStatusDataType
 XS_unpack_UA_ServerStatusDataType(SV *in)
 {
+    dTHX;
 	UA_ServerStatusDataType out;
 	SV **svp;
 	HV *hv;
@@ -11129,6 +11447,7 @@ static void XS_pack_UA_Range(SV *out, UA_Range in)  __attribute__((unused));
 static void
 XS_pack_UA_Range(SV *out, UA_Range in)
 {
+    dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -11147,6 +11466,7 @@ static UA_Range XS_unpack_UA_Range(SV *in)  __attribute__((unused));
 static UA_Range
 XS_unpack_UA_Range(SV *in)
 {
+    dTHX;
 	UA_Range out;
 	SV **svp;
 	HV *hv;
@@ -11174,6 +11494,7 @@ static void XS_pack_UA_DataChangeNotification(SV *out, UA_DataChangeNotification
 static void
 XS_pack_UA_DataChangeNotification(SV *out, UA_DataChangeNotification in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -11204,6 +11525,7 @@ static UA_DataChangeNotification XS_unpack_UA_DataChangeNotification(SV *in)  __
 static UA_DataChangeNotification
 XS_unpack_UA_DataChangeNotification(SV *in)
 {
+    dTHX;
 	UA_DataChangeNotification out;
 	SV **svp;
 	AV *av;
@@ -11265,6 +11587,7 @@ static void XS_pack_UA_EventNotificationList(SV *out, UA_EventNotificationList i
 static void
 XS_pack_UA_EventNotificationList(SV *out, UA_EventNotificationList in)
 {
+    dTHX;
 	SV *sv;
 	AV *av;
 	size_t i;
@@ -11286,6 +11609,7 @@ static UA_EventNotificationList XS_unpack_UA_EventNotificationList(SV *in)  __at
 static UA_EventNotificationList
 XS_unpack_UA_EventNotificationList(SV *in)
 {
+    dTHX;
 	UA_EventNotificationList out;
 	SV **svp;
 	AV *av;

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -269,12 +269,14 @@ static OPCUA_Open62541_DataType XS_unpack_OPCUA_Open62541_DataType(SV *)
 static UA_Boolean
 XS_unpack_UA_Boolean(SV *in)
 {
+	dTHX;
 	return SvTRUE(in);
 }
 
 static void
 XS_pack_UA_Boolean(SV *out, UA_Boolean in)
 {
+	dTHX;
 	sv_setsv(out, boolSV(in));
 }
 
@@ -285,6 +287,7 @@ XS_pack_UA_Boolean(SV *out, UA_Boolean in)
 static UA_##type							\
 XS_unpack_UA_##type(SV *in)						\
 {									\
+	dTHX;								\
 	IV out = SvIV(in);						\
 									\
 	if (out < UA_##limit##_MIN)					\
@@ -299,6 +302,7 @@ XS_unpack_UA_##type(SV *in)						\
 static void								\
 XS_pack_UA_##type(SV *out, UA_##type in)				\
 {									\
+	dTHX;								\
 	sv_setiv(out, in);						\
 }
 
@@ -307,6 +311,7 @@ XS_pack_UA_##type(SV *out, UA_##type in)				\
 static UA_##type							\
 XS_unpack_UA_##type(SV *in)						\
 {									\
+	dTHX;								\
 	UV out = SvUV(in);						\
 									\
 	if (out > UA_##limit##_MAX)					\
@@ -318,6 +323,7 @@ XS_unpack_UA_##type(SV *in)						\
 static void								\
 XS_pack_UA_##type(SV *out, UA_##type in)				\
 {									\
+	dTHX;								\
 	sv_setuv(out, in);						\
 }
 
@@ -339,6 +345,7 @@ XS_PACKED_CHECK_UV(UInt64, UINT64)	/* 6.1.9 UInt64, types.h */
 static UA_Float
 XS_unpack_UA_Float(SV *in)
 {
+	dTHX;
 	NV out = SvNV(in);
 
 	if (out < -FLT_MAX)
@@ -351,6 +358,7 @@ XS_unpack_UA_Float(SV *in)
 static void
 XS_pack_UA_Float(SV *out, UA_Float in)
 {
+	dTHX;
 	sv_setnv(out, in);
 }
 
@@ -359,12 +367,14 @@ XS_pack_UA_Float(SV *out, UA_Float in)
 static UA_Double
 XS_unpack_UA_Double(SV *in)
 {
+	dTHX;
 	return SvNV(in);
 }
 
 static void
 XS_pack_UA_Double(SV *out, UA_Double in)
 {
+	dTHX;
 	sv_setnv(out, in);
 }
 
@@ -373,12 +383,14 @@ XS_pack_UA_Double(SV *out, UA_Double in)
 static UA_StatusCode
 XS_unpack_UA_StatusCode(SV *in)
 {
+	dTHX;
 	return SvUV(in);
 }
 
 static void
 XS_pack_UA_StatusCode(SV *out, UA_StatusCode in)
 {
+	dTHX;
 	const char *name;
 
 	/* SV out contains number and string, like $! does. */
@@ -396,6 +408,7 @@ XS_pack_UA_StatusCode(SV *out, UA_StatusCode in)
 static UA_String
 XS_unpack_UA_String(SV *in)
 {
+	dTHX;
 	UA_String out;
 
 	/* XXX
@@ -411,6 +424,7 @@ XS_unpack_UA_String(SV *in)
 static void
 XS_pack_UA_String(SV *out, UA_String in)
 {
+	dTHX;
 	if (in.length == 0 && in.data == NULL) {
 		/* Convert NULL string to undef. */
 		sv_setsv(out, &PL_sv_undef);
@@ -425,12 +439,14 @@ XS_pack_UA_String(SV *out, UA_String in)
 static UA_DateTime
 XS_unpack_UA_DateTime(SV *in)
 {
+	dTHX;
 	return SvIV(in);
 }
 
 static void
 XS_pack_UA_DateTime(SV *out, UA_DateTime in)
 {
+	dTHX;
 	sv_setiv(out, in);
 }
 
@@ -439,6 +455,7 @@ XS_pack_UA_DateTime(SV *out, UA_DateTime in)
 static UA_Guid
 XS_unpack_UA_Guid(SV *in)
 {
+	dTHX;
 	UA_Guid out;
 	char *data;
 	size_t len;
@@ -454,6 +471,7 @@ XS_unpack_UA_Guid(SV *in)
 static void
 XS_pack_UA_Guid(SV *out, UA_Guid in)
 {
+	dTHX;
 	sv_setpvn(out, (char *)&in, sizeof(in));
 }
 
@@ -462,6 +480,7 @@ XS_pack_UA_Guid(SV *out, UA_Guid in)
 static UA_ByteString
 XS_unpack_UA_ByteString(SV *in)
 {
+	dTHX;
 	UA_ByteString out;
 
 	/* XXX
@@ -477,6 +496,7 @@ XS_unpack_UA_ByteString(SV *in)
 static void
 XS_pack_UA_ByteString(SV *out, UA_ByteString in)
 {
+	dTHX;
 	if (in.length == 0 && in.data == NULL) {
 		/* Convert NULL string to undef. */
 		sv_setsv(out, &PL_sv_undef);
@@ -504,6 +524,7 @@ XS_unpack_UA_XmlElement(SV *in)
 static UA_NodeId
 XS_unpack_UA_NodeId(SV *in)
 {
+	dTHX;
 	UA_NodeId out;
 	SV **svp;
 	HV *hv;
@@ -560,6 +581,7 @@ XS_unpack_UA_NodeId(SV *in)
 static void
 XS_pack_UA_NodeId(SV *out, UA_NodeId in)
 {
+	dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -599,6 +621,7 @@ XS_pack_UA_NodeId(SV *out, UA_NodeId in)
 static UA_ExpandedNodeId
 XS_unpack_UA_ExpandedNodeId(SV *in)
 {
+	dTHX;
 	UA_ExpandedNodeId out;
 	SV **svp;
 	HV *hv;
@@ -628,6 +651,7 @@ XS_unpack_UA_ExpandedNodeId(SV *in)
 static void
 XS_pack_UA_ExpandedNodeId(SV *out, UA_ExpandedNodeId in)
 {
+	dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -651,6 +675,7 @@ XS_pack_UA_ExpandedNodeId(SV *out, UA_ExpandedNodeId in)
 static UA_QualifiedName
 XS_unpack_UA_QualifiedName(SV *in)
 {
+	dTHX;
 	UA_QualifiedName out;
 	SV **svp;
 	HV *hv;
@@ -676,6 +701,7 @@ XS_unpack_UA_QualifiedName(SV *in)
 static void
 XS_pack_UA_QualifiedName(SV *out, UA_QualifiedName in)
 {
+	dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -695,6 +721,7 @@ XS_pack_UA_QualifiedName(SV *out, UA_QualifiedName in)
 static UA_LocalizedText
 XS_unpack_UA_LocalizedText(SV *in)
 {
+	dTHX;
 	UA_LocalizedText out;
 	SV **svp;
 	HV *hv;
@@ -720,6 +747,7 @@ XS_unpack_UA_LocalizedText(SV *in)
 static void
 XS_pack_UA_LocalizedText(SV *out, UA_LocalizedText in)
 {
+	dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -797,6 +825,7 @@ OPCUA_Open62541_Variant_setScalar(OPCUA_Open62541_Variant variant, SV *sv,
 static UA_Variant
 XS_unpack_UA_Variant(SV *in)
 {
+	dTHX;
 	UA_Variant out;
 	OPCUA_Open62541_DataType type;
 	SV **svp, **scalar, **array;
@@ -888,6 +917,7 @@ OPCUA_Open62541_Variant_getScalar(OPCUA_Open62541_Variant variant, SV *sv)
 static void
 XS_pack_UA_Variant(SV *out, UA_Variant in)
 {
+	dTHX;
 	SV *sv;
 	HV *hv;
 
@@ -917,6 +947,7 @@ XS_pack_UA_Variant(SV *out, UA_Variant in)
 static OPCUA_Open62541_DataType
 XS_unpack_OPCUA_Open62541_DataType(SV *in)
 {
+	dTHX;
 	UV index = SvUV(in);
 
 	if (index >= UA_TYPES_COUNT) {
@@ -929,6 +960,7 @@ XS_unpack_OPCUA_Open62541_DataType(SV *in)
 static void
 XS_pack_OPCUA_Open62541_DataType(SV *out, OPCUA_Open62541_DataType in)
 {
+	dTHX;
 	sv_setuv(out, in->typeIndex);
 }
 
@@ -937,6 +969,7 @@ XS_pack_OPCUA_Open62541_DataType(SV *out, OPCUA_Open62541_DataType in)
 static UA_DataValue
 XS_unpack_UA_DataValue(SV *in)
 {
+	dTHX;
 	UA_DataValue out;
 	SV **svp;
 	HV *hv;
@@ -1002,6 +1035,7 @@ XS_unpack_UA_DataValue(SV *in)
 static void
 XS_pack_UA_DataValue(SV *out, UA_DataValue in)
 {
+	dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -1061,6 +1095,7 @@ XS_pack_UA_DataValue(SV *out, UA_DataValue in)
 static UA_DiagnosticInfo
 XS_unpack_UA_DiagnosticInfo(SV *in)
 {
+	dTHX;
 	UA_DiagnosticInfo out;
 	SV **svp;
 	HV *hv;
@@ -1136,6 +1171,7 @@ XS_unpack_UA_DiagnosticInfo(SV *in)
 static void
 XS_pack_UA_DiagnosticInfo(SV *out, UA_DiagnosticInfo in)
 {
+	dTHX;
 	SV *sv;
 	HV *hv = newHV();
 
@@ -1202,7 +1238,7 @@ XS_pack_UA_DiagnosticInfo(SV *out, UA_DiagnosticInfo in)
 
 /* Magic callback for UA_Server_run() will change the C variable. */
 static int
-server_run_mgset(SV* sv, MAGIC* mg)
+server_run_mgset(pTHX_ SV* sv, MAGIC* mg)
 {
 	volatile UA_Boolean		*running;
 
@@ -1248,6 +1284,7 @@ prepareClientCallback(SV *callback, SV *client, SV *data)
 static void
 clientCallbackPerl(UA_Client *client, void *userdata, UA_UInt32 requestId,
     SV *response) {
+	dTHX;
 	PerlClientCallback *pcc = (PerlClientCallback*) userdata;
 	SV * callback = pcc->pcc_callback;
 	SV * cl = pcc->pcc_client;
@@ -1282,6 +1319,7 @@ static void
 clientAsyncServiceCallbackPerl(UA_Client *client, void *userdata,
     UA_UInt32 requestId, void *response)
 {
+	dTHX;
 	SV *sv;
 
 	sv = newSV(0);
@@ -1295,6 +1333,7 @@ static void
 clientAsyncBrowseCallbackPerl(UA_Client *client, void *userdata,
     UA_UInt32 requestId, UA_BrowseResponse *response)
 {
+	dTHX;
 	SV *sv;
 
 	sv = newSV(0);


### PR DESCRIPTION
…CONTEXT

As 9eacf2988d3b856f35f4e91ebf1bf1d237a2ed88 did not work (see
0f24ab8d6265a379f52e28b7eaac1826c0ccd5b1), use the second way mentioned
in perlguts(1) to fetch the context in the functions. This is not as
fast as the third way but should be good enough for now.

This changes makes the XS module on Debian compilable again.