### PR TITLE
Grep for server startup.

### DIFF
--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -721,8 +721,13 @@ and clear functions.  The log funtions are exported to Perl.
 
 =item $logger->setCallback($log, $context, $clear);
 
-    $log = sub { my ($context, $level, $category, $message) = @_ }
-    $clear = sub { my ($context) = @_ }
+=over 8
+
+=item $log = sub { my ($context, $level, $category, $message) = @_ }
+
+=item $clear = sub { my ($context) = @_ }
+
+=back
 
 =item $logger->logTrace($category, $msg, ...);
 

--- a/lib/OPCUA/Open62541/Test/Client.pm
+++ b/lib/OPCUA/Open62541/Test/Client.pm
@@ -1,8 +1,9 @@
-package OPCUA::Open62541::Test::Client;
-
 use strict;
 use warnings;
+
+package OPCUA::Open62541::Test::Client;
 use OPCUA::Open62541 ':statuscode';
+use Carp 'croak';
 
 use Test::More;
 
@@ -13,10 +14,10 @@ sub planning {
 
 sub new {
     my $class = shift;
-    my %args = @_;
-    my $self = {};
-    $self->{port} = $args{port};
-    $self->{timeout} = $args{timeout} || 10;
+    my $self = { @_ };
+    $self->{port}
+	or croak "no port given";
+    $self->{timeout} ||= 10;
 
     ok($self->{client} = OPCUA::Open62541::Client->new(), "client new");
     ok($self->{config} = $self->{client}->getConfig(), "client get config");
@@ -85,7 +86,7 @@ Create a new test client instance.
 
 =item $args{port}
 
-Port number of the server.
+Required port number of the server.
 
 =item $args{timeout}
 

--- a/lib/OPCUA/Open62541/Test/Logger.pm
+++ b/lib/OPCUA/Open62541/Test/Logger.pm
@@ -1,0 +1,160 @@
+use strict;
+use warnings;
+
+package OPCUA::Open62541::Test::Logger;
+use Carp;
+use POSIX;
+use Time::HiRes qw(gettimeofday time sleep);
+
+use Test::More;
+
+sub planning {
+    # number of ok(), pass() and fail() calls in this code
+    return 3;
+}
+
+sub new {
+    my $class = shift;
+    my $self = { @_ };
+    $self->{logger}
+	or croak "$class logger not given";
+
+    return bless($self, $class);
+}
+
+sub writelog {
+    my ($context, $level, $category, $message) = @_;
+    $context->printf("%d.%06d %d %s: %s\n",
+	gettimeofday(), $level, $category, $message);
+    $context->flush();
+}
+
+sub file {
+    my $self = shift;
+    my $file = shift;
+
+    ok(open(my $fh, '>', $file), "open log file")
+	or return fail "open '$file' for writing failed: $!";
+    $self->{logger}->setCallback(\&writelog, $fh, undef);
+    pass "set log callback";
+    $self->{file} = $file;
+}
+
+sub pid {
+    my $self = shift;
+    $self->{pid} = shift if @_;
+    return $self->{pid};
+}
+
+sub loggrep {
+    my $self = shift;
+    my ($regex, $timeout, $count) = @_;
+
+    my $end;
+    $end = time() + $timeout if $timeout;
+
+    do {
+	my $kid = waitpid($self->{pid}, WNOHANG);
+	if ($kid > 0 && $? != 0) {
+	    # child terminated with failure
+	    fail "no log grep match, child '$self->{pid}' failed: $?";
+	    return;
+	}
+	open(my $fh, '<', $self->{file}) or
+	    return fail "open '$self->{file}' for reading failed: $!";
+	my @match = grep { /$regex/ } <$fh>;
+	if (!$count && @match or $count && @match >= $count) {
+	    pass "log grep match";
+	    return wantarray ? @match : $match[0]
+	}
+	close($fh);
+	# pattern not found
+	if ($kid == 0) {
+	    # child still running, wait for log data
+	    sleep .1;
+	} else {
+	    # child terminated, no new log data possible
+	    fail "no log grep match, child '$self->{pid}' terminated";
+	    return;
+	}
+    } while ($timeout and time() < $end);
+
+    fail "no log grep match, timeout '$timeout' reached";
+    return;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+OPCUA::Open62541::Test::Logger - manage open62541 log file for testing
+
+=head1 SYNOPSIS
+
+  use OPCUA::Open62541::Test::Logger;
+
+  my $logger = OPCUA::Open62541::Test::Server->logger();
+
+=head1 DESCRIPTION
+
+Write the output of a server into a log file.
+Wait until a given regular expression matches a line in the file.
+
+=head2 METHODS
+
+=over 4
+
+=item $logger = OPCUA::Open62541::Test::Logger->new(%args);
+
+Create a new test logger instance.
+Usually called from test server.
+
+=over 8
+
+=item $args{logger}
+
+Required logger instance of the server config.
+
+=back
+
+=item $logger->file($file)
+
+Start writing to log file.
+
+=item $logger->loggrep($regex, $timeout, $count)
+
+Check if regex is present in the log file.
+If the process is still alive and a timeout is given, repeat the
+check for the number of seconds.
+If count is given, wait for this number of matches.
+Returns the number of matches.
+
+=item $logger->pid($pid)
+
+Optionally set the id of the process that is writing to log file.
+When grepping it will not wait for more input if the process is dead.
+Returns the pid.
+
+=back
+
+=head1 SEE ALSO
+
+OPCUA::Open62541,
+OPCUA::Open62541::Test::Server
+
+=head1 AUTHORS
+
+Alexander Bluhm E<lt>bluhm@genua.deE<gt>,
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (c) 2020 Alexander Bluhm
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+Thanks to genua GmbH, https://www.genua.de/ for sponsoring this work.
+
+=cut

--- a/t/client-connect-async.t
+++ b/t/client-connect-async.t
@@ -5,7 +5,7 @@ use POSIX qw(sigaction SIGALRM);
 
 use Scalar::Util qw(looks_like_number);
 use OPCUA::Open62541::Test::Server;
-use Test::More tests => 31;
+use Test::More tests => OPCUA::Open62541::Test::Server::planning() + 23;
 use Test::NoWarnings;
 use Test::LeakTrace;
 

--- a/t/client-connect.t
+++ b/t/client-connect.t
@@ -4,7 +4,7 @@ use OPCUA::Open62541 ':all';
 use POSIX qw(sigaction SIGALRM);
 
 use OPCUA::Open62541::Test::Server;
-use Test::More tests => 16;
+use Test::More tests => OPCUA::Open62541::Test::Server::planning() + 8;
 use Test::NoWarnings;
 use Test::Warn;
 

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -25,6 +25,9 @@ severity = 2
 [InputOutput::ProhibitBacktickOperators]
 [InputOutput::ProhibitBarewordFileHandles]
 [InputOutput::ProhibitTwoArgOpen]
+severity = 3
+[InputOutput::RequireBriefOpen]
+severity = 2
 [InputOutput::RequireCheckedClose]
 [InputOutput::RequireCheckedOpen]
 [InputOutput::RequireCheckedSyscalls]
@@ -35,8 +38,10 @@ severity = 2
 [Modules::RequireNoMatchVarsWithUseEnglish]
 [NamingConventions::ProhibitAmbiguousNames]
 [RegularExpressions::ProhibitCaptureWithoutTest]
-[Subroutines::ProhibitExplicitReturnUndef]
+severity = 3
+[RegularExpressions::RequireExtendedFormatting]
 severity = 2
+[Subroutines::ProhibitExplicitReturnUndef]
 [Subroutines::ProhibitNestedSubs]
 [Subroutines::RequireArgUnpacking]
 severity = 2
@@ -44,6 +49,7 @@ severity = 2
 [Subroutines::RequireFinalReturn]
 severity = 2
 [TestingAndDebugging::RequireUseStrict]
+[TestingAndDebugging::RequireUseWarnings]
 [ValuesAndExpressions::ProhibitMixedBooleanOperators]
 severity = 2
 [ValuesAndExpressions::RequireQuotedHeredocTerminator]
@@ -53,4 +59,3 @@ severity = 2
 
 #[Modules::ProhibitExcessMainComplexity]
 #[Subroutines::ProhibitExcessComplexity]
-#[TestingAndDebugging::RequireUseWarnings]

--- a/t/test-client.t
+++ b/t/test-client.t
@@ -1,3 +1,7 @@
+# test server listens
+# test client connects
+# check that both test modules work
+
 use strict;
 use warnings;
 use OPCUA::Open62541 ':all';

--- a/t/test-server.t
+++ b/t/test-server.t
@@ -1,3 +1,6 @@
+# test server listens
+# check that test module works
+
 use strict;
 use warnings;
 
@@ -10,5 +13,4 @@ use Test::NoWarnings;
 
 my $server = OPCUA::Open62541::Test::Server->new();
 $server->start();
-sleep(1);
 $server->stop();


### PR DESCRIPTION
To avoid a race, the client must be started after the server has
bound the socket.  Redirect the server output to a log file and
grep for TCP listening.  Wait until the server is up or abort after
a timeout.