### PR TITLE
Print log level and category as string.

### DIFF
--- a/lib/OPCUA/Open62541/Test/Logger.pm
+++ b/lib/OPCUA/Open62541/Test/Logger.pm
@@ -18,15 +18,19 @@ sub new {
     my $self = { @_ };
     $self->{logger}
 	or croak "$class logger not given";
+    $self->{ident} ||= "OPC UA";
 
     return bless($self, $class);
 }
 
 sub writelog {
     my ($context, $level, $category, $message) = @_;
-    $context->printf("%d.%06d %d %s: %s\n",
+    my OPCUA::Open62541::Test::Logger $self = $context;
+
+    note("$self->{ident} $level/$category: $message");
+    $self->{fh}->printf("%d.%06d %s/%s: %s\n",
 	gettimeofday(), $level, $category, $message);
-    $context->flush();
+    $self->{fh}->flush();
 }
 
 sub file {
@@ -35,9 +39,10 @@ sub file {
 
     ok(open(my $fh, '>', $file), "logger: open log file")
 	or return fail "logger: open '$file' for writing failed: $!";
-    $self->{logger}->setCallback(\&writelog, $fh, undef);
+    $self->{logger}->setCallback(\&writelog, $self, undef);
     pass "logger: set log callback";
     $self->{file} = $file;
+    $self->{fh} = $fh;
 }
 
 sub pid {

--- a/lib/OPCUA/Open62541/Test/Server.pm
+++ b/lib/OPCUA/Open62541/Test/Server.pm
@@ -53,6 +53,7 @@ sub start {
     ok($self->{logger} = $self->{config}->getLogger(), "server: get logger");
     ok($self->{log} = OPCUA::Open62541::Test::Logger->new(
 	logger => $self->{logger},
+	ident => "OPC UA server",
     ), "server: test logger");
     ok($self->{log}->file("server.log"), "server: log file");
 

--- a/t/logger-server.t
+++ b/t/logger-server.t
@@ -9,8 +9,8 @@ use Test::NoWarnings;
 sub log {
     my ($context, $level, $category, $message) = @_;
     is($context, "server", "log context");
-    is($level, 3, "log level");
-    is($category, 3, "log category");
+    is($level, "warn", "log level");
+    is($category, "server", "log category");
     is($message, "There has to be at least one endpoint.", "log message");
 }
 

--- a/typemap
+++ b/typemap
@@ -33,8 +33,8 @@ OPCUA_Open62541_ClientConfig		T_PTROBJ_SPECIAL
 OPCUA_Open62541_ClientState		T_ENUM
 OPCUA_Open62541_BrowseResultMask	T_ENUM
 OPCUA_Open62541_Logger			T_PTROBJ_SPECIAL
-UA_LogLevel				T_ENUM
-UA_LogCategory				T_ENUM
+UA_LogLevel				T_PACKED
+UA_LogCategory				T_PACKED
 
 #############################################################################
 INPUT


### PR DESCRIPTION
Implement pack functions for UA_LogLevel and UA_LogCategory which
convert the values to number and string simultanously.  Test
the converted names.  Test logger writes names into log file
and all log messages to test output.