### PR TITLE
Allow to replace the client logger.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -2147,6 +2147,21 @@ UA_ClientConfig_setDefault(config)
     OUTPUT:
 	RETVAL
 
+OPCUA_Open62541_Logger
+UA_ClientConfig_getLogger(config)
+	OPCUA_Open62541_ClientConfig	config
+    CODE:
+	RETVAL = calloc(1, sizeof(*RETVAL));
+	if (RETVAL == NULL)
+		CROAKE("calloc");
+	RETVAL->lg_logger = &config->clc_clientconfig->logger;
+	DPRINTF("config %p, logger %p, lg_logger %p",
+	    config, RETVAL, RETVAL->lg_logger);
+	/* When config gets out of scope, logger still uses its memory. */
+	RETVAL->lg_storage = SvREFCNT_inc(SvRV(ST(0)));
+    OUTPUT:
+	RETVAL
+
 #############################################################################
 MODULE = OPCUA::Open62541	PACKAGE = OPCUA::Open62541::Logger	PREFIX = UA_Logger_
 

--- a/lib/OPCUA/Open62541/Test/Client.pm
+++ b/lib/OPCUA/Open62541/Test/Client.pm
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 package OPCUA::Open62541::Test::Client;
+use OPCUA::Open62541::Test::Logger;
 use OPCUA::Open62541 qw(:statuscode :clientstate);
 use Carp 'croak';
 
@@ -9,7 +10,7 @@ use Test::More;
 
 sub planning {
     # number of ok() and is() calls in this code
-    return 7;
+    return OPCUA::Open62541::Test::Logger::planning() + 11;
 }
 
 sub new {
@@ -37,6 +38,14 @@ sub start {
     is($self->{config}->setDefault(), "Good", "client: set default config");
     $self->{url} = "opc.tcp://localhost";
     $self->{url} .= ":$self->{port}" if $self->{port};
+
+    ok($self->{logger} = $self->{config}->getLogger(), "client: get logger");
+    ok($self->{log} = OPCUA::Open62541::Test::Logger->new(
+	logger => $self->{logger},
+	ident => "OPC UA client",
+    ), "client: test logger");
+    ok($self->{log}->file("client.log"), "client: log file");
+
     return $self;
 }
 
@@ -48,6 +57,9 @@ sub run {
 	"client: connect");
     is($self->{client}->getState(), CLIENTSTATE_SESSION,
 	"client: state session");
+    # check client did connect(2)
+    ok($self->{log}->loggrep(qr/TCP connection established/, 5),
+	"client: log grep connected");
 
     return $self;
 }
@@ -139,7 +151,8 @@ Disconnect the client from the open62541 server.
 =head1 SEE ALSO
 
 OPCUA::Open62541,
-OPCUA::Open62541::Test::Server
+OPCUA::Open62541::Test::Server,
+OPCUA::Open62541::Test::Logger
 
 =head1 AUTHORS
 

--- a/lib/OPCUA/Open62541/Test/Server.pm
+++ b/lib/OPCUA/Open62541/Test/Server.pm
@@ -53,6 +53,7 @@ sub start {
     ok($self->{logger} = $self->{config}->getLogger(), "server: get logger");
     ok($self->{log} = OPCUA::Open62541::Test::Logger->new(
 	logger => $self->{logger},
+	ident => "OPC UA server",
     ), "server: test logger");
     ok($self->{log}->file("server.log"), "server: log file");
 

--- a/t/client-connect-async.t
+++ b/t/client-connect-async.t
@@ -8,7 +8,7 @@ use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
 use Test::More tests =>
     OPCUA::Open62541::Test::Server::planning() +
-    OPCUA::Open62541::Test::Client::planning() + 19;
+    OPCUA::Open62541::Test::Client::planning() + 22;
 use Test::Exception;
 use Test::NoWarnings;
 use Test::LeakTrace;

--- a/t/client-connect.t
+++ b/t/client-connect.t
@@ -20,6 +20,9 @@ is($client->{client}->connect($client->url()), STATUSCODE_GOOD,
     "client connect");
 is($client->{client}->getState, CLIENTSTATE_SESSION,
     "client state connected");
+# check client did connect(2)
+ok($client->{log}->loggrep(qr/TCP connection established/, 5),
+    "client log grep connected");
 
 is($client->{client}->disconnect(), STATUSCODE_GOOD, "client disconnect");
 is($client->{client}->getState, CLIENTSTATE_DISCONNECTED,

--- a/t/logger-client.t
+++ b/t/logger-client.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use OPCUA::Open62541;
+
+use Test::More tests => 10;
+use Test::Exception;
+use Test::NoWarnings;
+
+my $once = 0;
+sub log {
+    my ($context, $level, $category, $message) = @_;
+    return if $once++;
+    is($context, "client", "log context");
+    is($level, 2, "log level");
+    is($category, 4, "log category");
+    is($message, "Connecting to endpoint opc.tcp://localhost:", "log message");
+}
+
+sub clear {
+    my ($context) = @_;
+    is($context, "client", "clear context");
+}
+
+ok(my $client = OPCUA::Open62541::Client->new(), "client");
+ok(my $config = $client->getConfig(), "config");
+ok(my $logger = $config->getLogger(), "logger");
+lives_ok { $logger->setCallback(\&log, "client", \&clear) } "set log";
+
+$client->connect("opc.tcp://localhost:");

--- a/t/logger-server.t
+++ b/t/logger-server.t
@@ -6,8 +6,10 @@ use Test::More tests => 10;
 use Test::Exception;
 use Test::NoWarnings;
 
+my $once = 0;
 sub log {
     my ($context, $level, $category, $message) = @_;
+    return if $once++;
     is($context, "server", "log context");
     is($level, 3, "log level");
     is($category, 3, "log category");
@@ -25,5 +27,5 @@ ok(my $logger = $config->getLogger(), "logger");
 lives_ok { $logger->setCallback(\&log, "server", \&clear) } "set log";
 
 $server->run_startup();
-$server->run_iterate(100);
+$server->run_iterate(0);
 $server->run_shutdown();


### PR DESCRIPTION
New function getLogger() returns logger from client config.  The
test client creates a client.log file.  Test the client logger.