### PR TITLE
Server config clean() is not needed from Perl.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -2026,12 +2026,6 @@ UA_ServerConfig_setMinimal(config, portNumber, certificate)
 	RETVAL
 
 void
-UA_ServerConfig_clean(config)
-	OPCUA_Open62541_ServerConfig	config
-    CODE:
-	UA_ServerConfig_clean(config->svc_serverconfig);
-
-void
 UA_ServerConfig_setCustomHostname(config, customHostname)
 	OPCUA_Open62541_ServerConfig	config
 	UA_String			customHostname

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -674,8 +674,6 @@ magically.
 
 =item $status_code = $server_config->setMinimal($port, $certificate)
 
-=item $server_config->clean()
-
 =item $server_config->setCustomHostname($custom_hostname)
 
 =back

--- a/t/server-config-default.t
+++ b/t/server-config-default.t
@@ -24,11 +24,6 @@ throws_ok { OPCUA::Open62541::ServerConfig::setDefault(1) }
 no_leaks_ok { eval { OPCUA::Open62541::ServerConfig::setDefault(1) } }
     "config type leak";
 
-# FIXME: Leads to double free in v1.0/1.0.1. Fixed in master, see
-# https://github.com/open62541/open62541/commit/f05bafc25d332d4571b2e42fb42221c2ec3cc98c
-# just call it, no way to test easily
-#$config->clean();
-
 lives_ok { $config->setCustomHostname("foo\0bar") }
     "custom hostname";
 no_leaks_ok { $config->setCustomHostname("foo\0bar") }


### PR DESCRIPTION
UA_ServerConfig_clean() is used for cleanup in the C layer.  It is
called automatically from server config delete.  It does not make
sense to expose it to the Perl layer.