### PR TITLE
Test multiple browse request id.

### DIFF
--- a/lib/OPCUA/Open62541/Test/Client.pm
+++ b/lib/OPCUA/Open62541/Test/Client.pm
@@ -78,7 +78,9 @@ sub iterate {
 		if $ident;
 	    last;
 	}
-	if ($$end) {
+	if (ref($end) eq 'ARRAY' && @$end == 0 or
+	    ref($end) eq 'HASH' && keys %$end == 0 or
+	    $$end) {
 	    pass "client: $ident iterate" if $ident;
 	    last;
 	}

--- a/t/client-browse-async.t
+++ b/t/client-browse-async.t
@@ -6,7 +6,7 @@ use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
 use Test::More tests =>
     OPCUA::Open62541::Test::Server::planning() +
-    OPCUA::Open62541::Test::Client::planning() + 28;
+    OPCUA::Open62541::Test::Client::planning() + 45;
 use Test::Deep;
 use Test::Exception;
 use Test::NoWarnings;
@@ -384,6 +384,50 @@ no_leaks_ok { eval {
 	undef,
     );
 } } "sendAsyncBrowseRequest bad callback leak";
+
+### multiple requests
+# Call sendAsyncBrowseRequest() multiple times.  Check that request
+# id is unique.  Check that all request id are uses in callback.
+
+my %reqid2seq;
+foreach my $seq (1..5) {
+    my $reqid;
+    is($client->{client}->sendAsyncBrowseRequest(
+	$request,
+	sub {
+	    my ($c, $d, $i, $r) = @_;
+
+	    note "multiple reqid $i, seq $d->{$i}";
+	    ok(delete $d->{$i}, "multiple reqid exists");
+	},
+	\%reqid2seq,
+	\$reqid,
+    ), STATUSCODE_GOOD, "sendAsyncBrowseRequest multiple reqid");
+    is($reqid2seq{$reqid}, undef, "multiple reqid unique");
+    $reqid2seq{$reqid} = $seq;
+}
+$client->iterate(\%reqid2seq, "multiple reqid");
+
+no_leaks_ok { eval {
+    foreach my $seq (1..5) {
+	my $reqid;
+	$client->{client}->sendAsyncBrowseRequest(
+	    $request,
+	    sub {
+		my ($c, $d, $i, $r) = @_;
+		delete $d->{$i};
+	    },
+	    \%reqid2seq,
+	    \$reqid,
+	);
+	$reqid2seq{$reqid} = $seq;
+    }
+    # For unknown reasons this note command makes a potential leak
+    # go away.  no_leaks_ok() does not work well with hashes.
+    note "keys before iterate: ", scalar keys %reqid2seq;
+    $client->iterate(\%reqid2seq);
+    note "keys after iterate: ", scalar keys %reqid2seq;
+} } "sendAsyncBrowseRequest multiple reqid leak";
 
 $client->stop();
 

--- a/t/client-browse-async.t
+++ b/t/client-browse-async.t
@@ -6,7 +6,7 @@ use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
 use Test::More tests =>
     OPCUA::Open62541::Test::Server::planning() +
-    OPCUA::Open62541::Test::Client::planning() + 45;
+    OPCUA::Open62541::Test::Client::planning() + 50;
 use Test::Deep;
 use Test::Exception;
 use Test::NoWarnings;
@@ -397,10 +397,11 @@ foreach my $seq (1..5) {
 	sub {
 	    my ($c, $d, $i, $r) = @_;
 
-	    note "multiple reqid $i, seq $d->{$i}";
-	    ok(delete $d->{$i}, "multiple reqid exists");
+	    note "multiple reqid $i";
+	    is($d->[0]{$i}, $d->[1], "multiple reqid seqence");
+	    ok(delete $d->[0]{$i}, "multiple reqid exists");
 	},
-	\%reqid2seq,
+	[ \%reqid2seq, $seq ],
 	\$reqid,
     ), STATUSCODE_GOOD, "sendAsyncBrowseRequest multiple reqid");
     is($reqid2seq{$reqid}, undef, "multiple reqid unique");


### PR DESCRIPTION
Call sendAsyncBrowseRequest() multiple times.  Check that request
id is unique.  Check that all request id are uses in callback.