### PR TITLE
Implement client disconnect_async().

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -1981,6 +1981,20 @@ UA_StatusCode
 UA_Client_disconnect(client)
 	OPCUA_Open62541_Client		client
 
+UA_StatusCode
+UA_Client_disconnect_async(client, requestId)
+	OPCUA_Open62541_Client		client
+	OPCUA_Open62541_UInt32		requestId
+    INIT:
+	if (SvOK(ST(1)) && !(SvROK(ST(1)) && SvTYPE(SvRV(ST(1))) < SVt_PVAV))
+		CROAK("requestId is not a scalar reference");
+    CODE:
+	RETVAL = UA_Client_disconnect_async(client, requestId);
+	if (requestId != NULL)
+		XS_pack_UA_UInt32(SvRV(ST(1)), *requestId);
+    OUTPUT:
+	RETVAL
+
 UA_ClientState
 UA_Client_getState(client)
 	OPCUA_Open62541_Client		client

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -132,6 +132,8 @@ magically.
 
 =item $status_code = $client->disconnect()
 
+=item $status_code = $client->disconnect_async(\$requestId)
+
 =item $client_state = $client->getState()
 
 =item $status_code = $client->sendAsyncBrowseRequest(\%request, \&callback, $data, \$reqId)

--- a/lib/OPCUA/Open62541/Test/Client.pm
+++ b/lib/OPCUA/Open62541/Test/Client.pm
@@ -3,7 +3,8 @@ use warnings;
 
 package OPCUA::Open62541::Test::Client;
 use OPCUA::Open62541::Test::Logger;
-use OPCUA::Open62541 qw(STATUSCODE_GOOD :CLIENTSTATE);
+use OPCUA::Open62541 qw(STATUSCODE_GOOD STATUSCODE_BADCONNECTIONCLOSED
+    :CLIENTSTATE);
 use Carp 'croak';
 use Time::HiRes qw(sleep);
 
@@ -73,6 +74,11 @@ sub iterate {
     # loop should not take longer than 5 seconds
     for ($i = 50; $i > 0; $i--) {
 	my $sc = $self->{client}->run_iterate(0);
+	if (!defined($end) && $sc == STATUSCODE_BADCONNECTIONCLOSED) {
+	    # iterate until disconnected
+	    pass "client: $ident iterate" if $ident;
+	    last;
+	}
 	if ($sc != STATUSCODE_GOOD) {
 	    fail "client: $ident iterate" or diag "run_iterate failed: $sc"
 		if $ident;
@@ -80,7 +86,8 @@ sub iterate {
 	}
 	if (ref($end) eq 'ARRAY' && @$end == 0 or
 	    ref($end) eq 'HASH' && keys %$end == 0 or
-	    $$end) {
+	    ref($end) eq 'CODE' && $end->() or
+	    defined($end) && $$end) {
 	    pass "client: $ident iterate" if $ident;
 	    last;
 	}
@@ -182,6 +189,13 @@ Otherwise the loop terminates with failure if the status of client
 run_iterate() is not good or after calling it 50 times.
 If $ident is set, it is used to identify a passed or failed test.
 This one test is not included in planning().
+
+If $end is undef, the iteration will continue until the client has
+disconnected.
+If $end is an array or hash reference, the iteration will continue
+until the array or hash is empty.
+If $end is a code reference, the iteration will continue until the
+function call returns true.
 
 =item $client->stop()
 

--- a/t/client-disconnect-async.t
+++ b/t/client-disconnect-async.t
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+use OPCUA::Open62541 qw(:STATUSCODE :CLIENTSTATE);
+use Scalar::Util qw(looks_like_number);
+
+use OPCUA::Open62541::Test::Server;
+use OPCUA::Open62541::Test::Client;
+use Test::More tests =>
+    OPCUA::Open62541::Test::Server::planning() +
+    OPCUA::Open62541::Test::Client::planning() * 3 + 5;
+use Test::Exception;
+use Test::NoWarnings;
+use Test::LeakTrace;
+
+my $server = OPCUA::Open62541::Test::Server->new();
+$server->start();
+my $client = OPCUA::Open62541::Test::Client->new(port => $server->port());
+$client->start();
+$server->run();
+$client->run();
+
+my $requestId;
+is($client->{client}->disconnect_async(\$requestId),
+    STATUSCODE_GOOD, "disconnect async");
+ok(looks_like_number $requestId, "disconnect request id")
+    or diag "request id not a number: $requestId";
+
+$client->iterate(undef, "disconnect");
+is($client->{client}->getState(), CLIENTSTATE_DISCONNECTED, "state");
+
+$client = OPCUA::Open62541::Test::Client->new(port => $server->port());
+$client->start();
+$client->run();
+
+# Run the test again, check for leaks, no check within leak detection.
+no_leaks_ok {
+    $client->{client}->disconnect_async(\$requestId);
+    $client->iterate(undef);
+} "disconnect async leak";
+
+$client = OPCUA::Open62541::Test::Client->new(port => $server->port());
+$client->start();
+$client->run();
+
+is($client->{client}->disconnect_async(undef), STATUSCODE_GOOD,
+    "disconnect async undef requestid");
+no_leaks_ok {
+    $client->{client}->disconnect_async(undef);
+} "disconnect async undef requestid leak";
+
+$client->iterate(undef, "disconnect undef requestid");
+
+$server->stop();
+
+# The following tests do not need a connection.
+
+throws_ok {
+    $client->{client}->disconnect_async("foo");
+} (qr/requestId is not a scalar reference /, "disconnect noref requestid");
+no_leaks_ok { eval {
+    $client->{client}->disconnect_async("foo");
+} } "disconnect noref requestid leak";


### PR DESCRIPTION
Perl XS function UA_Client_disconnect_async takes optional scalar
reference to requestId.  Document $client->disconnect_async() in
pod.  Extend test client iterate to allow iteration until disconnect.
To be more flexible, a code ref to end iteration can be passed.
Add client-disconnect-async test.