### PR TITLE
Free logger context from client and server destroy.

### DIFF
--- a/t/logger-client.t
+++ b/t/logger-client.t
@@ -2,28 +2,43 @@ use strict;
 use warnings;
 use OPCUA::Open62541;
 
-use Test::More tests => 10;
+use Test::More tests => 14;
 use Test::Exception;
 use Test::NoWarnings;
 
-my $once = 0;
+my $log_calls = 0;
 sub log {
     my ($context, $level, $category, $message) = @_;
-    return if $once++;
+    return if $log_calls++;
+    is($log_calls, 1, "log once");
     is($context, "client", "log context");
     is($level, "info", "log level");
     is($category, "client", "log category");
     is($message, "Connecting to endpoint opc.tcp://localhost:", "log message");
 }
 
+my $clear_calls = 0;
 sub clear {
     my ($context) = @_;
+    $clear_calls++;
+    is($clear_calls, 1, "clear once");
     is($context, "client", "clear context");
+
+    fail "clear function is not called for client in open62541 1.0.1";
+    # https://github.com/open62541/open62541/commit/280012ee016e2f42ab9b1386174a8c12e6b29821
 }
 
-ok(my $client = OPCUA::Open62541::Client->new(), "client");
-ok(my $config = $client->getConfig(), "config");
-ok(my $logger = $config->getLogger(), "logger");
-lives_ok { $logger->setCallback(\&log, "client", \&clear) } "set log";
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client");
+    {
+	ok(my $config = $client->getConfig(), "config");
+	ok(my $logger = $config->getLogger(), "logger");
+	lives_ok { $logger->setCallback(\&log, "client", \&clear) } "set log";
+    }
+    is($clear_calls, 0, "logger scope");
 
-$client->connect("opc.tcp://localhost:");
+    is($log_calls, 0, "logger begin");
+    $client->connect("opc.tcp://localhost:");
+    isnt($log_calls, 0, "logger begin");
+}
+is($clear_calls, 0, "client scope");  # XXX should be 1, bug in open62541 1.0.1

--- a/t/logger-server.t
+++ b/t/logger-server.t
@@ -2,30 +2,42 @@ use strict;
 use warnings;
 use OPCUA::Open62541;
 
-use Test::More tests => 10;
+use Test::More tests => 16;
 use Test::Exception;
 use Test::NoWarnings;
 
-my $once = 0;
+my $log_calls = 0;
 sub log {
     my ($context, $level, $category, $message) = @_;
-    return if $once++;
+    return if $log_calls++;
+    is($log_calls, 1, "log once");
     is($context, "server", "log context");
     is($level, "warn", "log level");
     is($category, "server", "log category");
     is($message, "There has to be at least one endpoint.", "log message");
 }
 
+my $clear_calls = 0;
 sub clear {
     my ($context) = @_;
+    $clear_calls++;
+    is($clear_calls, 1, "clear once");
     is($context, "server", "clear context");
 }
 
-ok(my $server = OPCUA::Open62541::Server->new(), "server");
-ok(my $config = $server->getConfig(), "config");
-ok(my $logger = $config->getLogger(), "logger");
-lives_ok { $logger->setCallback(\&log, "server", \&clear) } "set log";
+{
+    ok(my $server = OPCUA::Open62541::Server->new(), "server");
+    {
+	ok(my $config = $server->getConfig(), "config");
+	ok(my $logger = $config->getLogger(), "logger");
+	lives_ok { $logger->setCallback(\&log, "server", \&clear) } "set log";
+    }
+    is($clear_calls, 0, "logger scope");
 
-$server->run_startup();
-$server->run_iterate(0);
-$server->run_shutdown();
+    is($log_calls, 0, "logger begin");
+    $server->run_startup();
+    $server->run_iterate(0);
+    $server->run_shutdown();
+    isnt($log_calls, 0, "logger begin");
+}
+is($clear_calls, 1, "server scope");

--- a/t/logger.t
+++ b/t/logger.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use OPCUA::Open62541;
 
-use Test::More tests => 44;
+use Test::More tests => 46;
 use Test::Exception;
 use Test::LeakTrace;
 use Test::NoWarnings;
@@ -30,12 +30,12 @@ throws_ok { $logger->setCallback(undef, undef, "bar") }
 no_leaks_ok { eval { $logger->setCallback(undef, undef, "bar") } }
     "setCallback noref clear leak";
 
-my $calls = 0;
+my $log_calls = 0;
 sub log {
     my ($context, $level, $category, $message) = @_;
-    if ($calls++ == 0) {
-	pass("called once");
-	is($context, "context", "context string");
+    if ($log_calls++ == 0) {
+	is($log_calls, 1, "log once");
+	is($context, "context", "log context string");
     }
     cmp_ok($category, '==', 1, "category warning") if $level == 3;
     cmp_ok($category, '==', 2, "category error") if $level == 4;
@@ -118,3 +118,13 @@ $logger->setCallback(\&log_category_name, undef, undef);
 foreach my $category (0..7) {
     $logger->logInfo($category, "category name");
 }
+
+my $clear_calls = 0;
+sub clear {
+    my ($context) = @_;
+    $clear_calls++;
+    is($clear_calls, 1, "clear once");
+    is($context, undef, "clear context string");
+}
+
+$logger->setCallback(undef, undef, \&clear);


### PR DESCRIPTION
Extend the lifetime of the logger, it should log until the client
or server is destroyed.  For that the OPCUA_Open62541_Logger with
the Perl SVs is pointed to by the client or server config's logger
context.  The OPCUA_Open62541_Logger reference counts the client
or server config storage.  So the Perl logger keeps the Perl client
or server alive, the client or server destroy function is the last
one to be called.  If the Perl reference of the OPCUA_Open62541_Logger
is destroyed, the object is not freed.  This is is done later from
the client or server destroy function.