### PR TITLE
Delete Logger->new() from API.

### DIFF
--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -184,8 +184,6 @@ and clear functions.  The log functions are exported to Perl.
 
 =over 4
 
-=item $logger = OPCUA::Open62541::Logger->new()
-
 =item $logger->setCallback($log, $context, $clear);
 
 =over 8

--- a/lib/OPCUA/Open62541/Test/Logger.pm
+++ b/lib/OPCUA/Open62541/Test/Logger.pm
@@ -135,7 +135,7 @@ Usually called from test server.
 
 =item $args{logger}
 
-Required logger instance of the server config.
+Required logger instance of the client or server config.
 
 =back
 

--- a/t/logger-leak.t
+++ b/t/logger-leak.t
@@ -29,7 +29,9 @@ no_leaks_ok {
 } "logger storage leak";
 
 no_leaks_ok {
-    my $logger = OPCUA::Open62541::Logger->new();
+    my $server = OPCUA::Open62541::Server->new();
+    my $config = $server->getConfig();
+    my $logger = $config->getLogger();
     $logger->setCallback(\&nolog, "malloc", \&noclear);
     $logger->logFatal(1, "fatal");
 } "logger malloc leak";

--- a/t/logger.t
+++ b/t/logger.t
@@ -8,14 +8,11 @@ use Test::LeakTrace;
 use Test::NoWarnings;
 use Test::Warn;
 
-ok(my $logger = OPCUA::Open62541::Logger->new(), "logger new");
-is(ref($logger), "OPCUA::Open62541::Logger", "logger new class");
-no_leaks_ok { OPCUA::Open62541::Logger->new() } "logger new leak";
-
-throws_ok { OPCUA::Open62541::Logger::new("subclass") }
-    (qr/Class 'subclass' is not OPCUA::Open62541::Logger/, "subclass");
-no_leaks_ok { eval { OPCUA::Open62541::Logger::new("subclass") } }
-    "subclass leak";
+ok(my $server = OPCUA::Open62541::Server->new(), "server new");
+ok(my $config = $server->getConfig(), "config get");
+ok(my $logger = $config->getLogger(), "logger get");
+is(ref($logger), "OPCUA::Open62541::Logger", "logger class");
+no_leaks_ok { $config->getLogger() } "logger get leak";
 
 lives_ok { $logger->setCallback(undef, undef, undef) } "setCallback";
 no_leaks_ok { $logger->setCallback(undef, undef, undef) } "setCallback leak";
@@ -49,7 +46,7 @@ sub log {
 lives_ok { $logger->setCallback(\&log, "context", undef) }
     "setCallback log context";
 no_leaks_ok {
-    OPCUA::Open62541::Logger->new()->setCallback(\&log, "context", undef);
+    $logger->setCallback(\&log, "context", undef);
 } "setCallback log context leak";
 
 lives_ok { $logger->logWarning(1, "message") } "logWarning message";


### PR DESCRIPTION
Creating a stand alone logger is not necessary.  It makes the code
more complicated and it may encourage users to use the wrong API.
Always get a logger from client or server config.