### PR TITLE
Remove signal race from test server.

### DIFF
--- a/t/test-server-runtimeaction.t
+++ b/t/test-server-runtimeaction.t
@@ -5,7 +5,7 @@ use OPCUA::Open62541 qw(:all);
 use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
 use Test::Deep;
-use Test::More tests => OPCUA::Open62541::Test::Server::planning() + 18;
+use Test::More tests => OPCUA::Open62541::Test::Server::planning() + 19;
 use Test::NoWarnings;
 
 my %requestedNewNodeId = (

--- a/t/test-server-singlestep.t
+++ b/t/test-server-singlestep.t
@@ -4,7 +4,7 @@ use OPCUA::Open62541 qw(:STATUSCODE :CLIENTSTATE);
 
 use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
-use Test::More tests => OPCUA::Open62541::Test::Server::planning() + 19;
+use Test::More tests => OPCUA::Open62541::Test::Server::planning() + 20;
 use Test::LeakTrace;
 use Test::NoWarnings;
 use Time::HiRes qw(sleep);


### PR DESCRIPTION
Test server uses sigpending() and sigsuspend() to run next action.
The methods step() and next_action() in the test server parent wait
until the server sends an acknowledge signal.