### PR TITLE
Enable github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-18.04
+    container:
+      image: ubuntu:18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: apt update
+      run: apt-get update
+    - name: Install base packages
+      run: |
+        apt-get install --yes \
+        gpg \
+        make \
+        software-properties-common
+    - name: Add OPC UA ppa
+      run: add-apt-repository ppa:open62541-team/ppa && apt-get update
+    - name: Install Perl Modules for Testng and libopen62541
+      run: |
+        apt-get install --yes \
+        libdevel-checklib-perl \
+        libopen62541-1 \
+        libopen62541-1-dev \
+        libopen62541-1-tools \
+        libtest-deep-perl \
+        libtest-eol-perl \
+        libtest-exception-perl \
+        libtest-leaktrace-perl \
+        libtest-nowarnings-perl \
+        libtest-perl-critic-perl \
+        libtest-pod-perl \
+        libtest-requires-perl \
+        libtest-tcp-perl \
+        libtest-warn-perl
+    - name: perl Makefile
+      run: perl Makefile.PL
+    - name: Make
+      run: make
+    - name: Test
+      run: make test


### PR DESCRIPTION
Use the github continuous integration framework to build the module and
run tests on push and pull requests. This first version uses one task to
install the requirements, build the software and test it. This could be
split up into different stages which pass the artifacts in the future,
if necessary.