### PR TITLE
Fix several memory leaks.

### DIFF
--- a/Open62541-packed.xsh
+++ b/Open62541-packed.xsh
@@ -216,9 +216,9 @@ XS_unpack_UA_Argument(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.arrayDimensions = calloc(top + 1, sizeof(UA_UInt32));
+		out.arrayDimensions = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.arrayDimensions == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -866,9 +866,9 @@ XS_unpack_UA_FindServersResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.servers = calloc(top + 1, sizeof(UA_ApplicationDescription));
+		out.servers = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION]);
 		if (out.servers == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1122,9 +1122,9 @@ XS_unpack_UA_FindServersOnNetworkResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.servers = calloc(top + 1, sizeof(UA_ServerOnNetwork));
+		out.servers = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
 		if (out.servers == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1339,9 +1339,9 @@ XS_unpack_UA_EndpointDescription(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.userIdentityTokens = calloc(top + 1, sizeof(UA_UserTokenPolicy));
+		out.userIdentityTokens = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
 		if (out.userIdentityTokens == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1528,9 +1528,9 @@ XS_unpack_UA_GetEndpointsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.endpoints = calloc(top + 1, sizeof(UA_EndpointDescription));
+		out.endpoints = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
 		if (out.endpoints == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1633,9 +1633,9 @@ XS_unpack_UA_RegisteredServer(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.serverNames = calloc(top + 1, sizeof(UA_LocalizedText));
+		out.serverNames = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
 		if (out.serverNames == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1844,7 +1844,7 @@ XS_unpack_UA_MdnsDiscoveryConfiguration(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.serverCapabilities = calloc(top + 1, sizeof(UA_String));
+		out.serverCapabilities = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.serverCapabilities == NULL) {
 			CROAKE("calloc");
 		}
@@ -1924,9 +1924,9 @@ XS_unpack_UA_RegisterServer2Request(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.discoveryConfiguration = calloc(top + 1, sizeof(UA_ExtensionObject));
+		out.discoveryConfiguration = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
 		if (out.discoveryConfiguration == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -2005,9 +2005,9 @@ XS_unpack_UA_RegisterServer2Response(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.configurationResults = calloc(top + 1, sizeof(UA_StatusCode));
+		out.configurationResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.configurationResults == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -2025,9 +2025,9 @@ XS_unpack_UA_RegisterServer2Response(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -2651,9 +2651,9 @@ XS_unpack_UA_CreateSessionResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.serverEndpoints = calloc(top + 1, sizeof(UA_EndpointDescription));
+		out.serverEndpoints = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
 		if (out.serverEndpoints == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -2671,9 +2671,9 @@ XS_unpack_UA_CreateSessionResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.serverSoftwareCertificates = calloc(top + 1, sizeof(UA_SignedSoftwareCertificate));
+		out.serverSoftwareCertificates = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIGNEDSOFTWARECERTIFICATE]);
 		if (out.serverSoftwareCertificates == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -3019,9 +3019,9 @@ XS_unpack_UA_ActivateSessionRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.clientSoftwareCertificates = calloc(top + 1, sizeof(UA_SignedSoftwareCertificate));
+		out.clientSoftwareCertificates = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIGNEDSOFTWARECERTIFICATE]);
 		if (out.clientSoftwareCertificates == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -3136,9 +3136,9 @@ XS_unpack_UA_ActivateSessionResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -3156,9 +3156,9 @@ XS_unpack_UA_ActivateSessionResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -3553,9 +3553,9 @@ XS_unpack_UA_VariableAttributes(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.arrayDimensions = calloc(top + 1, sizeof(UA_UInt32));
+		out.arrayDimensions = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.arrayDimensions == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -3867,9 +3867,9 @@ XS_unpack_UA_VariableTypeAttributes(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.arrayDimensions = calloc(top + 1, sizeof(UA_UInt32));
+		out.arrayDimensions = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.arrayDimensions == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -4338,9 +4338,9 @@ XS_unpack_UA_AddNodesRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.nodesToAdd = calloc(top + 1, sizeof(UA_AddNodesItem));
+		out.nodesToAdd = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ADDNODESITEM]);
 		if (out.nodesToAdd == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -4419,9 +4419,9 @@ XS_unpack_UA_AddNodesResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_AddNodesResult));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ADDNODESRESULT]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -4439,9 +4439,9 @@ XS_unpack_UA_AddNodesResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -4590,9 +4590,9 @@ XS_unpack_UA_AddReferencesRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.referencesToAdd = calloc(top + 1, sizeof(UA_AddReferencesItem));
+		out.referencesToAdd = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ADDREFERENCESITEM]);
 		if (out.referencesToAdd == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -4671,9 +4671,9 @@ XS_unpack_UA_AddReferencesResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -4691,9 +4691,9 @@ XS_unpack_UA_AddReferencesResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -4810,9 +4810,9 @@ XS_unpack_UA_DeleteNodesRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.nodesToDelete = calloc(top + 1, sizeof(UA_DeleteNodesItem));
+		out.nodesToDelete = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DELETENODESITEM]);
 		if (out.nodesToDelete == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -4891,9 +4891,9 @@ XS_unpack_UA_DeleteNodesResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -4911,9 +4911,9 @@ XS_unpack_UA_DeleteNodesResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5054,9 +5054,9 @@ XS_unpack_UA_DeleteReferencesRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.referencesToDelete = calloc(top + 1, sizeof(UA_DeleteReferencesItem));
+		out.referencesToDelete = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DELETEREFERENCESITEM]);
 		if (out.referencesToDelete == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5135,9 +5135,9 @@ XS_unpack_UA_DeleteReferencesResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5155,9 +5155,9 @@ XS_unpack_UA_DeleteReferencesResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5490,9 +5490,9 @@ XS_unpack_UA_BrowseResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.references = calloc(top + 1, sizeof(UA_ReferenceDescription));
+		out.references = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_REFERENCEDESCRIPTION]);
 		if (out.references == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5578,9 +5578,9 @@ XS_unpack_UA_BrowseRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.nodesToBrowse = calloc(top + 1, sizeof(UA_BrowseDescription));
+		out.nodesToBrowse = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSEDESCRIPTION]);
 		if (out.nodesToBrowse == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5659,9 +5659,9 @@ XS_unpack_UA_BrowseResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_BrowseResult));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSERESULT]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5679,9 +5679,9 @@ XS_unpack_UA_BrowseResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5759,9 +5759,9 @@ XS_unpack_UA_BrowseNextRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.continuationPoints = calloc(top + 1, sizeof(UA_ByteString));
+		out.continuationPoints = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BYTESTRING]);
 		if (out.continuationPoints == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5840,9 +5840,9 @@ XS_unpack_UA_BrowseNextResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_BrowseResult));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSERESULT]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5860,9 +5860,9 @@ XS_unpack_UA_BrowseNextResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -5987,9 +5987,9 @@ XS_unpack_UA_RelativePath(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.elements = calloc(top + 1, sizeof(UA_RelativePathElement));
+		out.elements = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_RELATIVEPATHELEMENT]);
 		if (out.elements == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6153,9 +6153,9 @@ XS_unpack_UA_BrowsePathResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.targets = calloc(top + 1, sizeof(UA_BrowsePathTarget));
+		out.targets = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSEPATHTARGET]);
 		if (out.targets == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6225,9 +6225,9 @@ XS_unpack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.browsePaths = calloc(top + 1, sizeof(UA_BrowsePath));
+		out.browsePaths = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSEPATH]);
 		if (out.browsePaths == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6306,9 +6306,9 @@ XS_unpack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_BrowsePathResult));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSEPATHRESULT]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6326,9 +6326,9 @@ XS_unpack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6398,9 +6398,9 @@ XS_unpack_UA_RegisterNodesRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.nodesToRegister = calloc(top + 1, sizeof(UA_NodeId));
+		out.nodesToRegister = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_NODEID]);
 		if (out.nodesToRegister == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6470,9 +6470,9 @@ XS_unpack_UA_RegisterNodesResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.registeredNodeIds = calloc(top + 1, sizeof(UA_NodeId));
+		out.registeredNodeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_NODEID]);
 		if (out.registeredNodeIds == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6542,9 +6542,9 @@ XS_unpack_UA_UnregisterNodesRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.nodesToUnregister = calloc(top + 1, sizeof(UA_NodeId));
+		out.nodesToUnregister = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_NODEID]);
 		if (out.nodesToUnregister == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6670,9 +6670,9 @@ XS_unpack_UA_ContentFilterElement(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.filterOperands = calloc(top + 1, sizeof(UA_ExtensionObject));
+		out.filterOperands = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
 		if (out.filterOperands == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6734,9 +6734,9 @@ XS_unpack_UA_ContentFilter(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.elements = calloc(top + 1, sizeof(UA_ContentFilterElement));
+		out.elements = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENT]);
 		if (out.elements == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -6980,9 +6980,9 @@ XS_unpack_UA_SimpleAttributeOperand(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.browsePath = calloc(top + 1, sizeof(UA_QualifiedName));
+		out.browsePath = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
 		if (out.browsePath == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7069,9 +7069,9 @@ XS_unpack_UA_ContentFilterElementResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.operandStatusCodes = calloc(top + 1, sizeof(UA_StatusCode));
+		out.operandStatusCodes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.operandStatusCodes == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7089,9 +7089,9 @@ XS_unpack_UA_ContentFilterElementResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.operandDiagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.operandDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.operandDiagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7162,9 +7162,9 @@ XS_unpack_UA_ContentFilterResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.elementResults = calloc(top + 1, sizeof(UA_ContentFilterElementResult));
+		out.elementResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENTRESULT]);
 		if (out.elementResults == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7182,9 +7182,9 @@ XS_unpack_UA_ContentFilterResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.elementDiagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.elementDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.elementDiagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7350,9 +7350,9 @@ XS_unpack_UA_ReadRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.nodesToRead = calloc(top + 1, sizeof(UA_ReadValueId));
+		out.nodesToRead = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_READVALUEID]);
 		if (out.nodesToRead == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7431,9 +7431,9 @@ XS_unpack_UA_ReadResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_DataValue));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATAVALUE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7451,9 +7451,9 @@ XS_unpack_UA_ReadResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7586,9 +7586,9 @@ XS_unpack_UA_WriteRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.nodesToWrite = calloc(top + 1, sizeof(UA_WriteValue));
+		out.nodesToWrite = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_WRITEVALUE]);
 		if (out.nodesToWrite == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7667,9 +7667,9 @@ XS_unpack_UA_WriteResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7687,9 +7687,9 @@ XS_unpack_UA_WriteResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7767,9 +7767,9 @@ XS_unpack_UA_CallMethodRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.inputArguments = calloc(top + 1, sizeof(UA_Variant));
+		out.inputArguments = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
 		if (out.inputArguments == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7857,9 +7857,9 @@ XS_unpack_UA_CallMethodResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.inputArgumentResults = calloc(top + 1, sizeof(UA_StatusCode));
+		out.inputArgumentResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.inputArgumentResults == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7877,9 +7877,9 @@ XS_unpack_UA_CallMethodResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.inputArgumentDiagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.inputArgumentDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.inputArgumentDiagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7897,9 +7897,9 @@ XS_unpack_UA_CallMethodResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.outputArguments = calloc(top + 1, sizeof(UA_Variant));
+		out.outputArguments = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
 		if (out.outputArguments == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -7969,9 +7969,9 @@ XS_unpack_UA_CallRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.methodsToCall = calloc(top + 1, sizeof(UA_CallMethodRequest));
+		out.methodsToCall = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_CALLMETHODREQUEST]);
 		if (out.methodsToCall == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -8050,9 +8050,9 @@ XS_unpack_UA_CallResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_CallMethodResult));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_CALLMETHODRESULT]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -8070,9 +8070,9 @@ XS_unpack_UA_CallResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -8244,9 +8244,9 @@ XS_unpack_UA_EventFilter(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.selectClauses = calloc(top + 1, sizeof(UA_SimpleAttributeOperand));
+		out.selectClauses = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIMPLEATTRIBUTEOPERAND]);
 		if (out.selectClauses == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -8459,9 +8459,9 @@ XS_unpack_UA_EventFilterResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.selectClauseResults = calloc(top + 1, sizeof(UA_StatusCode));
+		out.selectClauseResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.selectClauseResults == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -8479,9 +8479,9 @@ XS_unpack_UA_EventFilterResult(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.selectClauseDiagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.selectClauseDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.selectClauseDiagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -8768,9 +8768,9 @@ XS_unpack_UA_CreateMonitoredItemsRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.itemsToCreate = calloc(top + 1, sizeof(UA_MonitoredItemCreateRequest));
+		out.itemsToCreate = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMCREATEREQUEST]);
 		if (out.itemsToCreate == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -8849,9 +8849,9 @@ XS_unpack_UA_CreateMonitoredItemsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_MonitoredItemCreateResult));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMCREATERESULT]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -8869,9 +8869,9 @@ XS_unpack_UA_CreateMonitoredItemsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9067,9 +9067,9 @@ XS_unpack_UA_ModifyMonitoredItemsRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.itemsToModify = calloc(top + 1, sizeof(UA_MonitoredItemModifyRequest));
+		out.itemsToModify = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMMODIFYREQUEST]);
 		if (out.itemsToModify == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9148,9 +9148,9 @@ XS_unpack_UA_ModifyMonitoredItemsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_MonitoredItemModifyResult));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMMODIFYRESULT]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9168,9 +9168,9 @@ XS_unpack_UA_ModifyMonitoredItemsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9256,9 +9256,9 @@ XS_unpack_UA_SetMonitoringModeRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.monitoredItemIds = calloc(top + 1, sizeof(UA_UInt32));
+		out.monitoredItemIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.monitoredItemIds == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9337,9 +9337,9 @@ XS_unpack_UA_SetMonitoringModeResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9357,9 +9357,9 @@ XS_unpack_UA_SetMonitoringModeResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9454,9 +9454,9 @@ XS_unpack_UA_SetTriggeringRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.linksToAdd = calloc(top + 1, sizeof(UA_UInt32));
+		out.linksToAdd = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.linksToAdd == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9474,9 +9474,9 @@ XS_unpack_UA_SetTriggeringRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.linksToRemove = calloc(top + 1, sizeof(UA_UInt32));
+		out.linksToRemove = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.linksToRemove == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9573,9 +9573,9 @@ XS_unpack_UA_SetTriggeringResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.addResults = calloc(top + 1, sizeof(UA_StatusCode));
+		out.addResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.addResults == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9593,9 +9593,9 @@ XS_unpack_UA_SetTriggeringResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.addDiagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.addDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.addDiagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9613,9 +9613,9 @@ XS_unpack_UA_SetTriggeringResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.removeResults = calloc(top + 1, sizeof(UA_StatusCode));
+		out.removeResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.removeResults == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9633,9 +9633,9 @@ XS_unpack_UA_SetTriggeringResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.removeDiagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.removeDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.removeDiagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9713,9 +9713,9 @@ XS_unpack_UA_DeleteMonitoredItemsRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.monitoredItemIds = calloc(top + 1, sizeof(UA_UInt32));
+		out.monitoredItemIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.monitoredItemIds == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9794,9 +9794,9 @@ XS_unpack_UA_DeleteMonitoredItemsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -9814,9 +9814,9 @@ XS_unpack_UA_DeleteMonitoredItemsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10202,9 +10202,9 @@ XS_unpack_UA_SetPublishingModeRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.subscriptionIds = calloc(top + 1, sizeof(UA_UInt32));
+		out.subscriptionIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.subscriptionIds == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10283,9 +10283,9 @@ XS_unpack_UA_SetPublishingModeResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10303,9 +10303,9 @@ XS_unpack_UA_SetPublishingModeResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10383,9 +10383,9 @@ XS_unpack_UA_NotificationMessage(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.notificationData = calloc(top + 1, sizeof(UA_ExtensionObject));
+		out.notificationData = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
 		if (out.notificationData == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10502,9 +10502,9 @@ XS_unpack_UA_EventFieldList(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.eventFields = calloc(top + 1, sizeof(UA_Variant));
+		out.eventFields = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
 		if (out.eventFields == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10668,9 +10668,9 @@ XS_unpack_UA_PublishRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.subscriptionAcknowledgements = calloc(top + 1, sizeof(UA_SubscriptionAcknowledgement));
+		out.subscriptionAcknowledgements = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SUBSCRIPTIONACKNOWLEDGEMENT]);
 		if (out.subscriptionAcknowledgements == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10774,9 +10774,9 @@ XS_unpack_UA_PublishResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.availableSequenceNumbers = calloc(top + 1, sizeof(UA_UInt32));
+		out.availableSequenceNumbers = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.availableSequenceNumbers == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10802,9 +10802,9 @@ XS_unpack_UA_PublishResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10822,9 +10822,9 @@ XS_unpack_UA_PublishResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -10996,9 +10996,9 @@ XS_unpack_UA_DeleteSubscriptionsRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.subscriptionIds = calloc(top + 1, sizeof(UA_UInt32));
+		out.subscriptionIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
 		if (out.subscriptionIds == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -11077,9 +11077,9 @@ XS_unpack_UA_DeleteSubscriptionsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.results = calloc(top + 1, sizeof(UA_StatusCode));
+		out.results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
 		if (out.results == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -11097,9 +11097,9 @@ XS_unpack_UA_DeleteSubscriptionsResponse(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -11536,9 +11536,9 @@ XS_unpack_UA_DataChangeNotification(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.monitoredItems = calloc(top + 1, sizeof(UA_MonitoredItemNotification));
+		out.monitoredItems = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMNOTIFICATION]);
 		if (out.monitoredItems == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -11556,9 +11556,9 @@ XS_unpack_UA_DataChangeNotification(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.diagnosticInfos = calloc(top + 1, sizeof(UA_DiagnosticInfo));
+		out.diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
 		if (out.diagnosticInfos == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -11620,9 +11620,9 @@ XS_unpack_UA_EventNotificationList(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.events = calloc(top + 1, sizeof(UA_EventFieldList));
+		out.events = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_EVENTFIELDLIST]);
 		if (out.events == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);

--- a/Open62541-packed.xsh
+++ b/Open62541-packed.xsh
@@ -455,9 +455,9 @@ XS_unpack_UA_ApplicationDescription(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.discoveryUrls = calloc(top + 1, sizeof(UA_String));
+		out.discoveryUrls = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.discoveryUrls == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -642,9 +642,9 @@ XS_unpack_UA_ResponseHeader(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.stringTable = calloc(top + 1, sizeof(UA_String));
+		out.stringTable = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.stringTable == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -774,9 +774,9 @@ XS_unpack_UA_FindServersRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.localeIds = calloc(top + 1, sizeof(UA_String));
+		out.localeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.localeIds == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -794,9 +794,9 @@ XS_unpack_UA_FindServersRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.serverUris = calloc(top + 1, sizeof(UA_String));
+		out.serverUris = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.serverUris == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -954,9 +954,9 @@ XS_unpack_UA_ServerOnNetwork(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.serverCapabilities = calloc(top + 1, sizeof(UA_String));
+		out.serverCapabilities = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.serverCapabilities == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1042,9 +1042,9 @@ XS_unpack_UA_FindServersOnNetworkRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.serverCapabilityFilter = calloc(top + 1, sizeof(UA_String));
+		out.serverCapabilityFilter = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.serverCapabilityFilter == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1436,9 +1436,9 @@ XS_unpack_UA_GetEndpointsRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.localeIds = calloc(top + 1, sizeof(UA_String));
+		out.localeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.localeIds == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1456,9 +1456,9 @@ XS_unpack_UA_GetEndpointsRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.profileUris = calloc(top + 1, sizeof(UA_String));
+		out.profileUris = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.profileUris == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1661,9 +1661,9 @@ XS_unpack_UA_RegisteredServer(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.discoveryUrls = calloc(top + 1, sizeof(UA_String));
+		out.discoveryUrls = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.discoveryUrls == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -1846,7 +1846,7 @@ XS_unpack_UA_MdnsDiscoveryConfiguration(SV *in)
 		top = av_top_index(av);
 		out.serverCapabilities = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.serverCapabilities == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
@@ -3039,9 +3039,9 @@ XS_unpack_UA_ActivateSessionRequest(SV *in)
 		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
-		out.localeIds = calloc(top + 1, sizeof(UA_String));
+		out.localeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
 		if (out.localeIds == NULL) {
-			CROAKE("calloc");
+			CROAKE("UA_Array_new");
 		}
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -1976,6 +1976,8 @@ UA_Server_run(server, running)
 	sv_unmagicext(ST(1), PERL_MAGIC_ext, &server_run_mgvtbl);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_Boolean_clear(&running);
 
 UA_StatusCode
 UA_Server_run_startup(server)
@@ -1993,6 +1995,8 @@ UA_Server_run_iterate(server, waitInternal)
 	RETVAL = UA_Server_run_iterate(server->sv_server, waitInternal);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_Boolean_clear(&waitInternal);
 
 UA_StatusCode
 UA_Server_run_shutdown(server)
@@ -2019,6 +2023,8 @@ UA_Server_readValue(server, nodeId, outValue)
 		XS_pack_UA_Variant(SvRV(ST(2)), *outValue);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Server_writeValue(server, nodeId, value)
@@ -2029,6 +2035,9 @@ UA_Server_writeValue(server, nodeId, value)
 	RETVAL = UA_Server_writeValue(server->sv_server, nodeId, value);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&nodeId);
+	UA_Variant_clear(&value);
 
 # 11.5 Browsing
 
@@ -2041,6 +2050,9 @@ UA_Server_browse(server, maxReferences, bd)
 	RETVAL = UA_Server_browse(server->sv_server, maxReferences, &bd);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_UInt32_clear(&maxReferences);
+	UA_BrowseDescription_clear(&bd);
 
 # 11.9 Node Addition and Deletion
 
@@ -2061,6 +2073,13 @@ UA_Server_addVariableNode(server, requestedNewNodeId, parentNodeId, referenceTyp
 	    typeDefinition, attr, nodeContext, outNewNodeId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&requestedNewNodeId);
+	UA_NodeId_clear(&parentNodeId);
+	UA_NodeId_clear(&referenceTypeId);
+	UA_QualifiedName_clear(&browseName);
+	UA_NodeId_clear(&typeDefinition);
+	UA_VariableAttributes_clear(&attr);
 
 UA_StatusCode
 UA_Server_addVariableTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, typeDefinition, attr, nodeContext, outNewNodeId)
@@ -2079,6 +2098,13 @@ UA_Server_addVariableTypeNode(server, requestedNewNodeId, parentNodeId, referenc
 	    typeDefinition, attr, nodeContext, outNewNodeId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&requestedNewNodeId);
+	UA_NodeId_clear(&parentNodeId);
+	UA_NodeId_clear(&referenceTypeId);
+	UA_QualifiedName_clear(&browseName);
+	UA_NodeId_clear(&typeDefinition);
+	UA_VariableTypeAttributes_clear(&attr);
 
 UA_StatusCode
 UA_Server_addObjectNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, typeDefinition, attr, nodeContext, outNewNodeId)
@@ -2097,6 +2123,13 @@ UA_Server_addObjectNode(server, requestedNewNodeId, parentNodeId, referenceTypeI
 	    typeDefinition, attr, nodeContext, outNewNodeId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&requestedNewNodeId);
+	UA_NodeId_clear(&parentNodeId);
+	UA_NodeId_clear(&referenceTypeId);
+	UA_QualifiedName_clear(&browseName);
+	UA_NodeId_clear(&typeDefinition);
+	UA_ObjectAttributes_clear(&attr);
 
 UA_StatusCode
 UA_Server_addObjectTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outNewNodeId)
@@ -2114,6 +2147,12 @@ UA_Server_addObjectTypeNode(server, requestedNewNodeId, parentNodeId, referenceT
 	    attr, nodeContext, outNewNodeId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&requestedNewNodeId);
+	UA_NodeId_clear(&parentNodeId);
+	UA_NodeId_clear(&referenceTypeId);
+	UA_QualifiedName_clear(&browseName);
+	UA_ObjectTypeAttributes_clear(&attr);
 
 UA_StatusCode
 UA_Server_addViewNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outNewNodeId)
@@ -2131,6 +2170,12 @@ UA_Server_addViewNode(server, requestedNewNodeId, parentNodeId, referenceTypeId,
 	    attr, nodeContext, outNewNodeId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&requestedNewNodeId);
+	UA_NodeId_clear(&parentNodeId);
+	UA_NodeId_clear(&referenceTypeId);
+	UA_QualifiedName_clear(&browseName);
+	UA_ViewAttributes_clear(&attr);
 
 UA_StatusCode
 UA_Server_addReferenceTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outNewNodeId)
@@ -2148,6 +2193,12 @@ UA_Server_addReferenceTypeNode(server, requestedNewNodeId, parentNodeId, referen
 	    attr, nodeContext, outNewNodeId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&requestedNewNodeId);
+	UA_NodeId_clear(&parentNodeId);
+	UA_NodeId_clear(&referenceTypeId);
+	UA_QualifiedName_clear(&browseName);
+	UA_ReferenceTypeAttributes_clear(&attr);
 
 UA_StatusCode
 UA_Server_addDataTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outNewNodeId)
@@ -2165,6 +2216,12 @@ UA_Server_addDataTypeNode(server, requestedNewNodeId, parentNodeId, referenceTyp
 	    attr, nodeContext, outNewNodeId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&requestedNewNodeId);
+	UA_NodeId_clear(&parentNodeId);
+	UA_NodeId_clear(&referenceTypeId);
+	UA_QualifiedName_clear(&browseName);
+	UA_DataTypeAttributes_clear(&attr);
 
 UA_StatusCode
 UA_Server_deleteNode(server, nodeId, deleteReferences)
@@ -2176,6 +2233,9 @@ UA_Server_deleteNode(server, nodeId, deleteReferences)
 	    deleteReferences);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&nodeId);
+	UA_Boolean_clear(&deleteReferences);
 
 # 11.10 Reference Management
 
@@ -2191,6 +2251,11 @@ UA_Server_addReference(server, sourceId, refTypeId, targetId, isForward)
 	    targetId, isForward);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&sourceId);
+	UA_NodeId_clear(&refTypeId);
+	UA_ExpandedNodeId_clear(&targetId);
+	UA_Boolean_clear(&isForward);
 
 UA_StatusCode
 UA_Server_deleteReference(server, sourceNodeId, referenceTypeId, isForward, targetNodeId, deleteBidirectional)
@@ -2205,6 +2270,12 @@ UA_Server_deleteReference(server, sourceNodeId, referenceTypeId, isForward, targ
 	    referenceTypeId, isForward, targetNodeId, deleteBidirectional);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&sourceNodeId);
+	UA_NodeId_clear(&referenceTypeId);
+	UA_Boolean_clear(&isForward);
+	UA_ExpandedNodeId_clear(&targetNodeId);
+	UA_Boolean_clear(&deleteBidirectional);
 
 # Namespace Handling
 
@@ -2248,6 +2319,9 @@ UA_ServerConfig_setMinimal(config, portNumber, certificate)
 	    portNumber, &certificate);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_UInt16_clear(&portNumber);
+	UA_ByteString_clear(&certificate);
 
 void
 UA_ServerConfig_setCustomHostname(config, customHostname)
@@ -2256,6 +2330,8 @@ UA_ServerConfig_setCustomHostname(config, customHostname)
     CODE:
 	UA_ServerConfig_setCustomHostname(config->svc_serverconfig,
 	    customHostname);
+    CLEANUP:
+	UA_String_clear(&customHostname);
 
 OPCUA_Open62541_Logger
 UA_ServerConfig_getLogger(config)
@@ -2395,6 +2471,8 @@ UA_Client_run_iterate(client, timeout)
 	RETVAL = UA_Client_run_iterate(client->cl_client, timeout);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_UInt16_clear(&timeout);
 
 UA_StatusCode
 UA_Client_disconnect(client)
@@ -2448,6 +2526,8 @@ UA_Client_sendAsyncBrowseRequest(client, request, callback, data, reqId)
 		XS_pack_UA_UInt32(SvRV(ST(4)), *reqId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_BrowseRequest_clear(&request);
 
 UA_BrowseResponse
 UA_Client_Service_browse(client, request)
@@ -2457,6 +2537,8 @@ UA_Client_Service_browse(client, request)
 	RETVAL = UA_Client_Service_browse(client->cl_client, request);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_BrowseRequest_clear(&request);
 
 UA_StatusCode
 UA_Client_readValueAttribute_async(client, nodeId, callback, data, reqId)
@@ -2480,6 +2562,8 @@ UA_Client_readValueAttribute_async(client, nodeId, callback, data, reqId)
 		XS_pack_UA_UInt32(SvRV(ST(4)), *reqId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Client_readDisplayNameAttribute(client, nodeId, outDisplayName)
@@ -2496,6 +2580,8 @@ UA_Client_readDisplayNameAttribute(client, nodeId, outDisplayName)
 		XS_pack_UA_LocalizedText(SvRV(ST(2)), *outDisplayName);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Client_readDescriptionAttribute(client, nodeId, outDescription)
@@ -2512,6 +2598,8 @@ UA_Client_readDescriptionAttribute(client, nodeId, outDescription)
 		XS_pack_UA_LocalizedText(SvRV(ST(2)), *outDescription);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Client_readValueAttribute(client, nodeId, outValue)
@@ -2528,6 +2616,8 @@ UA_Client_readValueAttribute(client, nodeId, outValue)
 		XS_pack_UA_Variant(SvRV(ST(2)), *outValue);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Client_readDataTypeAttribute(client, nodeId, outDataType)
@@ -2556,6 +2646,8 @@ UA_Client_readDataTypeAttribute(client, nodeId, outDataType)
 		    &UA_TYPES[index]);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_NodeId_clear(&nodeId);
 
 #############################################################################
 MODULE = OPCUA::Open62541	PACKAGE = OPCUA::Open62541::ClientConfig	PREFIX = UA_ClientConfig_

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -330,15 +330,18 @@ static UA_String
 XS_unpack_UA_String(SV *in)
 {
 	dTHX;
+	char *str;
 	UA_String out;
 
-	/* XXX
-	 * Converting undef to NULL string may be dangerous, check
-	 * that all users of UA_String cope with NULL strings, before
-	 * implementing that feature.  Currently Perl will warn about
-	 * undef and convert to empty string.
-	 */
-	out.data = SvPVutf8(in, out.length);
+	str = SvPVutf8(in, out.length);
+	if (out.length > 0) {
+		out.data = UA_malloc(out.length);
+		if (out.data == NULL)
+			CROAKE("UA_malloc");
+		memcpy(out.data, str, out.length);
+	} else {
+		out.data = UA_EMPTY_ARRAY_SENTINEL;
+	}
 	return out;
 }
 
@@ -402,15 +405,18 @@ static UA_ByteString
 XS_unpack_UA_ByteString(SV *in)
 {
 	dTHX;
+	char *str;
 	UA_ByteString out;
 
-	/* XXX
-	 * Converting undef to NULL string may be dangerous, check
-	 * that all users of UA_ByteString cope with NULL strings, before
-	 * implementing that feature.  Currently Perl will warn about
-	 * undef and convert to empty string.
-	 */
-	out.data = SvPV(in, out.length);
+	str = SvPV(in, out.length);
+	if (out.length > 0) {
+		out.data = UA_malloc(out.length);
+		if (out.data == NULL)
+			CROAKE("UA_malloc");
+		memcpy(out.data, str, out.length);
+	} else {
+		out.data = UA_EMPTY_ARRAY_SENTINEL;
+	}
 	return out;
 }
 

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -1812,20 +1812,28 @@ UA_Variant_DESTROY(variant)
 UA_Boolean
 UA_Variant_isEmpty(variant)
 	OPCUA_Open62541_Variant		variant
+    CLEANUP:
+	UA_Boolean_clear(&RETVAL);
 
 UA_Boolean
 UA_Variant_isScalar(variant)
 	OPCUA_Open62541_Variant		variant
+    CLEANUP:
+	UA_Boolean_clear(&RETVAL);
 
 UA_Boolean
 UA_Variant_hasScalarType(variant, type)
 	OPCUA_Open62541_Variant		variant
 	OPCUA_Open62541_DataType	type
+    CLEANUP:
+	UA_Boolean_clear(&RETVAL);
 
 UA_Boolean
 UA_Variant_hasArrayType(variant, type)
 	OPCUA_Open62541_Variant		variant
 	OPCUA_Open62541_DataType	type
+    CLEANUP:
+	UA_Boolean_clear(&RETVAL);
 
 void
 UA_Variant_setScalar(variant, sv, type)
@@ -1852,6 +1860,8 @@ UA_Variant_getType(variant)
 	RETVAL = variant->type->typeIndex;
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_UInt16_clear(&RETVAL);
 
 SV *
 UA_Variant_getScalar(variant)
@@ -1977,6 +1987,7 @@ UA_Server_run(server, running)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_Boolean_clear(&running);
 
 UA_StatusCode
@@ -1986,6 +1997,8 @@ UA_Server_run_startup(server)
 	RETVAL = UA_Server_run_startup(server->sv_server);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 
 UA_UInt16
 UA_Server_run_iterate(server, waitInternal)
@@ -1996,6 +2009,7 @@ UA_Server_run_iterate(server, waitInternal)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_UInt16_clear(&RETVAL);
 	UA_Boolean_clear(&waitInternal);
 
 UA_StatusCode
@@ -2005,6 +2019,8 @@ UA_Server_run_shutdown(server)
 	RETVAL = UA_Server_run_shutdown(server->sv_server);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 
 
 # 11.4 Reading and Writing Node Attributes
@@ -2024,6 +2040,7 @@ UA_Server_readValue(server, nodeId, outValue)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
@@ -2036,6 +2053,7 @@ UA_Server_writeValue(server, nodeId, value)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&nodeId);
 	UA_Variant_clear(&value);
 
@@ -2051,6 +2069,7 @@ UA_Server_browse(server, maxReferences, bd)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_BrowseResult_clear(&RETVAL);
 	UA_UInt32_clear(&maxReferences);
 	UA_BrowseDescription_clear(&bd);
 
@@ -2074,6 +2093,7 @@ UA_Server_addVariableNode(server, requestedNewNodeId, parentNodeId, referenceTyp
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&requestedNewNodeId);
 	UA_NodeId_clear(&parentNodeId);
 	UA_NodeId_clear(&referenceTypeId);
@@ -2099,6 +2119,7 @@ UA_Server_addVariableTypeNode(server, requestedNewNodeId, parentNodeId, referenc
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&requestedNewNodeId);
 	UA_NodeId_clear(&parentNodeId);
 	UA_NodeId_clear(&referenceTypeId);
@@ -2124,6 +2145,7 @@ UA_Server_addObjectNode(server, requestedNewNodeId, parentNodeId, referenceTypeI
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&requestedNewNodeId);
 	UA_NodeId_clear(&parentNodeId);
 	UA_NodeId_clear(&referenceTypeId);
@@ -2148,6 +2170,7 @@ UA_Server_addObjectTypeNode(server, requestedNewNodeId, parentNodeId, referenceT
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&requestedNewNodeId);
 	UA_NodeId_clear(&parentNodeId);
 	UA_NodeId_clear(&referenceTypeId);
@@ -2171,6 +2194,7 @@ UA_Server_addViewNode(server, requestedNewNodeId, parentNodeId, referenceTypeId,
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&requestedNewNodeId);
 	UA_NodeId_clear(&parentNodeId);
 	UA_NodeId_clear(&referenceTypeId);
@@ -2194,6 +2218,7 @@ UA_Server_addReferenceTypeNode(server, requestedNewNodeId, parentNodeId, referen
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&requestedNewNodeId);
 	UA_NodeId_clear(&parentNodeId);
 	UA_NodeId_clear(&referenceTypeId);
@@ -2217,6 +2242,7 @@ UA_Server_addDataTypeNode(server, requestedNewNodeId, parentNodeId, referenceTyp
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&requestedNewNodeId);
 	UA_NodeId_clear(&parentNodeId);
 	UA_NodeId_clear(&referenceTypeId);
@@ -2234,6 +2260,7 @@ UA_Server_deleteNode(server, nodeId, deleteReferences)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&nodeId);
 	UA_Boolean_clear(&deleteReferences);
 
@@ -2252,6 +2279,7 @@ UA_Server_addReference(server, sourceId, refTypeId, targetId, isForward)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&sourceId);
 	UA_NodeId_clear(&refTypeId);
 	UA_ExpandedNodeId_clear(&targetId);
@@ -2271,6 +2299,7 @@ UA_Server_deleteReference(server, sourceNodeId, referenceTypeId, isForward, targ
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&sourceNodeId);
 	UA_NodeId_clear(&referenceTypeId);
 	UA_Boolean_clear(&isForward);
@@ -2287,6 +2316,8 @@ UA_Server_addNamespace(server, name)
 	RETVAL = UA_Server_addNamespace(server->sv_server, name);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_UInt16_clear(&RETVAL);
 
 #############################################################################
 MODULE = OPCUA::Open62541	PACKAGE = OPCUA::Open62541::ServerConfig	PREFIX = UA_ServerConfig_
@@ -2308,6 +2339,8 @@ UA_ServerConfig_setDefault(config)
 	RETVAL = UA_ServerConfig_setDefault(config->svc_serverconfig);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 
 UA_StatusCode
 UA_ServerConfig_setMinimal(config, portNumber, certificate)
@@ -2320,6 +2353,7 @@ UA_ServerConfig_setMinimal(config, portNumber, certificate)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_UInt16_clear(&portNumber);
 	UA_ByteString_clear(&certificate);
 
@@ -2355,6 +2389,8 @@ UA_ServerConfig_getBuildInfo(config)
 	RETVAL = config->svc_serverconfig->buildInfo;
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	# The buildinfo is part of the sever config, it must not be freed.
 
 #############################################################################
 MODULE = OPCUA::Open62541	PACKAGE = OPCUA::Open62541::Client		PREFIX = UA_Client_
@@ -2423,6 +2459,8 @@ UA_Client_connect(client, endpointUrl)
 	RETVAL = UA_Client_connect(client->cl_client, endpointUrl);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 
 UA_StatusCode
 UA_Client_connect_async(client, endpointUrl, callback, data)
@@ -2462,6 +2500,8 @@ UA_Client_connect_async(client, endpointUrl, callback, data)
 	}
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 
 UA_StatusCode
 UA_Client_run_iterate(client, timeout)
@@ -2472,6 +2512,7 @@ UA_Client_run_iterate(client, timeout)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_UInt16_clear(&timeout);
 
 UA_StatusCode
@@ -2481,6 +2522,8 @@ UA_Client_disconnect(client)
 	RETVAL = UA_Client_disconnect(client->cl_client);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 
 UA_StatusCode
 UA_Client_disconnect_async(client, requestId)
@@ -2495,6 +2538,8 @@ UA_Client_disconnect_async(client, requestId)
 		XS_pack_UA_UInt32(SvRV(ST(1)), *requestId);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 
 UA_ClientState
 UA_Client_getState(client)
@@ -2503,6 +2548,8 @@ UA_Client_getState(client)
 	RETVAL = UA_Client_getState(client->cl_client);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	# UA_ClientState has no clear function.
 
 UA_StatusCode
 UA_Client_sendAsyncBrowseRequest(client, request, callback, data, reqId)
@@ -2527,6 +2574,7 @@ UA_Client_sendAsyncBrowseRequest(client, request, callback, data, reqId)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_BrowseRequest_clear(&request);
 
 UA_BrowseResponse
@@ -2538,6 +2586,7 @@ UA_Client_Service_browse(client, request)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_BrowseResponse_clear(&RETVAL);
 	UA_BrowseRequest_clear(&request);
 
 UA_StatusCode
@@ -2563,6 +2612,7 @@ UA_Client_readValueAttribute_async(client, nodeId, callback, data, reqId)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
@@ -2581,6 +2631,7 @@ UA_Client_readDisplayNameAttribute(client, nodeId, outDisplayName)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
@@ -2599,6 +2650,7 @@ UA_Client_readDescriptionAttribute(client, nodeId, outDescription)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
@@ -2617,6 +2669,7 @@ UA_Client_readValueAttribute(client, nodeId, outValue)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
@@ -2647,6 +2700,7 @@ UA_Client_readDataTypeAttribute(client, nodeId, outDataType)
     OUTPUT:
 	RETVAL
     CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 	UA_NodeId_clear(&nodeId);
 
 #############################################################################
@@ -2668,6 +2722,8 @@ UA_ClientConfig_setDefault(config)
 	RETVAL = UA_ClientConfig_setDefault(config->clc_clientconfig);
     OUTPUT:
 	RETVAL
+    CLEANUP:
+	UA_StatusCode_clear(&RETVAL);
 
 OPCUA_Open62541_Logger
 UA_ClientConfig_getLogger(config)

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -700,7 +700,6 @@ OPCUA_Open62541_Variant_setScalar(OPCUA_Open62541_Variant variant, SV *in,
     OPCUA_Open62541_DataType type)
 {
 	void *scalar;
-	UA_StatusCode status;
 
 	if (unpack_UA_table[type->typeIndex] == NULL) {
 		CROAK("No unpack conversion for type '%s' index %u",
@@ -714,13 +713,7 @@ OPCUA_Open62541_Variant_setScalar(OPCUA_Open62541_Variant variant, SV *in,
 	}
 	(unpack_UA_table[type->typeIndex])(in, scalar);
 
-	status = UA_Variant_setScalarCopy(variant, scalar, type);
-	/* Free, not destroy.  The nested data structures belong to Perl. */
-	UA_free(scalar);
-	if (status != UA_STATUSCODE_GOOD) {
-		CROAKS(status, "UA_Variant_setScalarCopy type '%s' index %u",
-		    type->typeName, type->typeIndex);
-	}
+	UA_Variant_setScalar(variant, scalar, type);
 }
 
 static void
@@ -733,7 +726,6 @@ OPCUA_Open62541_Variant_setArray(OPCUA_Open62541_Variant variant, SV *in,
 	ssize_t i, top;
 	char *p;
 	void *array;
-	UA_StatusCode status;
 
 	if (!SvOK(in)) {
 		UA_Variant_setArray(variant, NULL, 0, type);
@@ -761,15 +753,7 @@ OPCUA_Open62541_Variant_setArray(OPCUA_Open62541_Variant variant, SV *in,
 		p += type->memSize;
 	}
 
-	status = UA_Variant_setArrayCopy(variant, array, top + 1, type);
-	/* Free, not destroy.  The nested data structures belong to Perl. */
-	if (array != UA_EMPTY_ARRAY_SENTINEL)
-		UA_free(array);
-	if (status != UA_STATUSCODE_GOOD) {
-		CROAKS(status,
-		    "UA_Variant_setArrayCopy size %zd, type '%s' index %u",
-		    top + 1, type->typeName, type->typeIndex);
-	}
+	UA_Variant_setArray(variant, array, top + 1, type);
 }
 
 static UA_Variant


### PR DESCRIPTION
Main leak was that the generated pack input functions called calloc() without free() to convert arrays.  Use UA_Array for that and also allocate the strings.  Then all nested memory is allocated and can be freed with clear() or delete().  Unfortunately this has to be done manually in the cleanup section.