### PR TITLE
Avoid warning in test server.

### DIFF
--- a/lib/OPCUA/Open62541/Test/Server.pm
+++ b/lib/OPCUA/Open62541/Test/Server.pm
@@ -168,6 +168,7 @@ sub setup_complex_objects {
 	    NodeId_identifier		=> "SOME_VARIABLE_TYPE",
 	},
 	attributes => {
+	    VariableAttributes_dataType	=> TYPES_INT32,
 	    VariableAttributes_displayName => {
 		LocalizedText_text	=> 'Some Variable 0'
 	    },


### PR DESCRIPTION
The test server setup_complex_objects() method printed a warning
"AddNodes: No datatype given; Copy the datatype attribute from the
TypeDefinition".  Adding a VariableAttributes_dataType fixes this.