### PR TITLE
Create mortal UA object in parameter typemap.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -2028,34 +2028,27 @@ UA_Server_run_shutdown(server)
 UA_StatusCode
 UA_Server_readValue(server, nodeId, outValue)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			nodeId
+	OPCUA_Open62541_NodeId		nodeId
 	OPCUA_Open62541_Variant		outValue
-    INIT:
-	if (!SvOK(ST(2)) || !(SvROK(ST(2)) && SvTYPE(SvRV(ST(2))) < SVt_PVAV))
-		CROAK("outValue is not a scalar reference");
     CODE:
-	RETVAL = UA_Server_readValue(server->sv_server, nodeId, outValue);
-	if (outValue != NULL)
-		XS_pack_UA_Variant(SvRV(ST(2)), *outValue);
+	RETVAL = UA_Server_readValue(server->sv_server, *nodeId, outValue);
+	XS_pack_UA_Variant(SvRV(ST(2)), *outValue);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Server_writeValue(server, nodeId, value)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			nodeId
-	UA_Variant			value
+	OPCUA_Open62541_NodeId		nodeId
+	OPCUA_Open62541_Variant		value
     CODE:
-	RETVAL = UA_Server_writeValue(server->sv_server, nodeId, value);
+	RETVAL = UA_Server_writeValue(server->sv_server, *nodeId, *value);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&nodeId);
-	UA_Variant_clear(&value);
 
 # 11.5 Browsing
 
@@ -2076,206 +2069,181 @@ UA_Server_browse(server, maxReferences, bd)
 # 11.9 Node Addition and Deletion
 
 UA_StatusCode
-UA_Server_addVariableNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, typeDefinition, attr, nodeContext, outNewNodeId)
+UA_Server_addVariableNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, typeDefinition, attr, nodeContext, outoptNewNodeId)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			requestedNewNodeId
-	UA_NodeId			parentNodeId
-	UA_NodeId			referenceTypeId
+	OPCUA_Open62541_NodeId		requestedNewNodeId
+	OPCUA_Open62541_NodeId		parentNodeId
+	OPCUA_Open62541_NodeId		referenceTypeId
 	UA_QualifiedName		browseName
-	UA_NodeId			typeDefinition
+	OPCUA_Open62541_NodeId		typeDefinition
 	UA_VariableAttributes		attr
 	void *				nodeContext
-	OPCUA_Open62541_NodeId		outNewNodeId
+	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
 	RETVAL = UA_Server_addVariableNode(server->sv_server,
-	    requestedNewNodeId, parentNodeId, referenceTypeId, browseName,
-	    typeDefinition, attr, nodeContext, outNewNodeId);
-	if (outNewNodeId != NULL)
-		XS_pack_UA_NodeId(SvRV(ST(8)), *outNewNodeId);
+	    *requestedNewNodeId, *parentNodeId, *referenceTypeId, browseName,
+	    *typeDefinition, attr, nodeContext, outoptNewNodeId);
+	if (outoptNewNodeId != NULL)
+		XS_pack_UA_NodeId(SvRV(ST(8)), *outoptNewNodeId);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&requestedNewNodeId);
-	UA_NodeId_clear(&parentNodeId);
-	UA_NodeId_clear(&referenceTypeId);
 	UA_QualifiedName_clear(&browseName);
-	UA_NodeId_clear(&typeDefinition);
 	UA_VariableAttributes_clear(&attr);
 
 UA_StatusCode
-UA_Server_addVariableTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, typeDefinition, attr, nodeContext, outNewNodeId)
+UA_Server_addVariableTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, typeDefinition, attr, nodeContext, outoptNewNodeId)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			requestedNewNodeId
-	UA_NodeId			parentNodeId
-	UA_NodeId			referenceTypeId
+	OPCUA_Open62541_NodeId		requestedNewNodeId
+	OPCUA_Open62541_NodeId		parentNodeId
+	OPCUA_Open62541_NodeId		referenceTypeId
 	UA_QualifiedName		browseName
-	UA_NodeId			typeDefinition
+	OPCUA_Open62541_NodeId		typeDefinition
 	UA_VariableTypeAttributes	attr
 	void *				nodeContext
-	OPCUA_Open62541_NodeId		outNewNodeId
+	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
 	RETVAL = UA_Server_addVariableTypeNode(server->sv_server,
-	    requestedNewNodeId, parentNodeId, referenceTypeId, browseName,
-	    typeDefinition, attr, nodeContext, outNewNodeId);
-	if (outNewNodeId != NULL)
-		XS_pack_UA_NodeId(SvRV(ST(8)), *outNewNodeId);
+	    *requestedNewNodeId, *parentNodeId, *referenceTypeId, browseName,
+	    *typeDefinition, attr, nodeContext, outoptNewNodeId);
+	if (outoptNewNodeId != NULL)
+		XS_pack_UA_NodeId(SvRV(ST(8)), *outoptNewNodeId);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&requestedNewNodeId);
-	UA_NodeId_clear(&parentNodeId);
-	UA_NodeId_clear(&referenceTypeId);
 	UA_QualifiedName_clear(&browseName);
-	UA_NodeId_clear(&typeDefinition);
 	UA_VariableTypeAttributes_clear(&attr);
 
 UA_StatusCode
-UA_Server_addObjectNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, typeDefinition, attr, nodeContext, outNewNodeId)
+UA_Server_addObjectNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, typeDefinition, attr, nodeContext, outoptNewNodeId)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			requestedNewNodeId
-	UA_NodeId			parentNodeId
-	UA_NodeId			referenceTypeId
+	OPCUA_Open62541_NodeId		requestedNewNodeId
+	OPCUA_Open62541_NodeId		parentNodeId
+	OPCUA_Open62541_NodeId		referenceTypeId
 	UA_QualifiedName		browseName
-	UA_NodeId			typeDefinition
+	OPCUA_Open62541_NodeId		typeDefinition
 	UA_ObjectAttributes		attr
 	void *				nodeContext
-	OPCUA_Open62541_NodeId		outNewNodeId
+	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
 	RETVAL = UA_Server_addObjectNode(server->sv_server,
-	    requestedNewNodeId, parentNodeId, referenceTypeId, browseName,
-	    typeDefinition, attr, nodeContext, outNewNodeId);
-	if (outNewNodeId != NULL)
-		XS_pack_UA_NodeId(SvRV(ST(8)), *outNewNodeId);
+	    *requestedNewNodeId, *parentNodeId, *referenceTypeId, browseName,
+	    *typeDefinition, attr, nodeContext, outoptNewNodeId);
+	if (outoptNewNodeId != NULL)
+		XS_pack_UA_NodeId(SvRV(ST(8)), *outoptNewNodeId);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&requestedNewNodeId);
-	UA_NodeId_clear(&parentNodeId);
-	UA_NodeId_clear(&referenceTypeId);
 	UA_QualifiedName_clear(&browseName);
-	UA_NodeId_clear(&typeDefinition);
 	UA_ObjectAttributes_clear(&attr);
 
 UA_StatusCode
-UA_Server_addObjectTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outNewNodeId)
+UA_Server_addObjectTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outoptNewNodeId)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			requestedNewNodeId
-	UA_NodeId			parentNodeId
-	UA_NodeId			referenceTypeId
+	OPCUA_Open62541_NodeId		requestedNewNodeId
+	OPCUA_Open62541_NodeId		parentNodeId
+	OPCUA_Open62541_NodeId		referenceTypeId
 	UA_QualifiedName		browseName
 	UA_ObjectTypeAttributes		attr
 	void *				nodeContext
-	OPCUA_Open62541_NodeId		outNewNodeId
+	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
 	RETVAL = UA_Server_addObjectTypeNode(server->sv_server,
-	    requestedNewNodeId, parentNodeId, referenceTypeId, browseName,
-	    attr, nodeContext, outNewNodeId);
-	if (outNewNodeId != NULL)
-		XS_pack_UA_NodeId(SvRV(ST(7)), *outNewNodeId);
+	    *requestedNewNodeId, *parentNodeId, *referenceTypeId, browseName,
+	    attr, nodeContext, outoptNewNodeId);
+	if (outoptNewNodeId != NULL)
+		XS_pack_UA_NodeId(SvRV(ST(7)), *outoptNewNodeId);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&requestedNewNodeId);
-	UA_NodeId_clear(&parentNodeId);
-	UA_NodeId_clear(&referenceTypeId);
 	UA_QualifiedName_clear(&browseName);
 	UA_ObjectTypeAttributes_clear(&attr);
 
 UA_StatusCode
-UA_Server_addViewNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outNewNodeId)
+UA_Server_addViewNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outoptNewNodeId)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			requestedNewNodeId
-	UA_NodeId			parentNodeId
-	UA_NodeId			referenceTypeId
+	OPCUA_Open62541_NodeId		requestedNewNodeId
+	OPCUA_Open62541_NodeId		parentNodeId
+	OPCUA_Open62541_NodeId		referenceTypeId
 	UA_QualifiedName		browseName
 	UA_ViewAttributes		attr
 	void *				nodeContext
-	OPCUA_Open62541_NodeId		outNewNodeId
+	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
 	RETVAL = UA_Server_addViewNode(server->sv_server,
-	    requestedNewNodeId, parentNodeId, referenceTypeId, browseName,
-	    attr, nodeContext, outNewNodeId);
-	if (outNewNodeId != NULL)
-		XS_pack_UA_NodeId(SvRV(ST(7)), *outNewNodeId);
+	    *requestedNewNodeId, *parentNodeId, *referenceTypeId, browseName,
+	    attr, nodeContext, outoptNewNodeId);
+	if (outoptNewNodeId != NULL)
+		XS_pack_UA_NodeId(SvRV(ST(7)), *outoptNewNodeId);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&requestedNewNodeId);
-	UA_NodeId_clear(&parentNodeId);
-	UA_NodeId_clear(&referenceTypeId);
 	UA_QualifiedName_clear(&browseName);
 	UA_ViewAttributes_clear(&attr);
 
 UA_StatusCode
-UA_Server_addReferenceTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outNewNodeId)
+UA_Server_addReferenceTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outoptNewNodeId)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			requestedNewNodeId
-	UA_NodeId			parentNodeId
-	UA_NodeId			referenceTypeId
+	OPCUA_Open62541_NodeId		requestedNewNodeId
+	OPCUA_Open62541_NodeId		parentNodeId
+	OPCUA_Open62541_NodeId		referenceTypeId
 	UA_QualifiedName		browseName
 	UA_ReferenceTypeAttributes	attr
 	void *				nodeContext
-	OPCUA_Open62541_NodeId		outNewNodeId
+	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
 	RETVAL = UA_Server_addReferenceTypeNode(server->sv_server,
-	    requestedNewNodeId, parentNodeId, referenceTypeId, browseName,
-	    attr, nodeContext, outNewNodeId);
-	if (outNewNodeId != NULL)
-		XS_pack_UA_NodeId(SvRV(ST(7)), *outNewNodeId);
+	    *requestedNewNodeId, *parentNodeId, *referenceTypeId, browseName,
+	    attr, nodeContext, outoptNewNodeId);
+	if (outoptNewNodeId != NULL)
+		XS_pack_UA_NodeId(SvRV(ST(7)), *outoptNewNodeId);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&requestedNewNodeId);
-	UA_NodeId_clear(&parentNodeId);
-	UA_NodeId_clear(&referenceTypeId);
 	UA_QualifiedName_clear(&browseName);
 	UA_ReferenceTypeAttributes_clear(&attr);
 
 UA_StatusCode
-UA_Server_addDataTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outNewNodeId)
+UA_Server_addDataTypeNode(server, requestedNewNodeId, parentNodeId, referenceTypeId, browseName, attr, nodeContext, outoptNewNodeId)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			requestedNewNodeId
-	UA_NodeId			parentNodeId
-	UA_NodeId			referenceTypeId
+	OPCUA_Open62541_NodeId		requestedNewNodeId
+	OPCUA_Open62541_NodeId		parentNodeId
+	OPCUA_Open62541_NodeId		referenceTypeId
 	UA_QualifiedName		browseName
 	UA_DataTypeAttributes		attr
 	void *				nodeContext
-	OPCUA_Open62541_NodeId		outNewNodeId
+	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
 	RETVAL = UA_Server_addDataTypeNode(server->sv_server,
-	    requestedNewNodeId, parentNodeId, referenceTypeId, browseName,
-	    attr, nodeContext, outNewNodeId);
-	if (outNewNodeId != NULL)
-		XS_pack_UA_NodeId(SvRV(ST(7)), *outNewNodeId);
+	    *requestedNewNodeId, *parentNodeId, *referenceTypeId, browseName,
+	    attr, nodeContext, outoptNewNodeId);
+	if (outoptNewNodeId != NULL)
+		XS_pack_UA_NodeId(SvRV(ST(7)), *outoptNewNodeId);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&requestedNewNodeId);
-	UA_NodeId_clear(&parentNodeId);
-	UA_NodeId_clear(&referenceTypeId);
 	UA_QualifiedName_clear(&browseName);
 	UA_DataTypeAttributes_clear(&attr);
 
 UA_StatusCode
 UA_Server_deleteNode(server, nodeId, deleteReferences)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			nodeId
+	OPCUA_Open62541_NodeId		nodeId
 	UA_Boolean			deleteReferences
     CODE:
-	RETVAL = UA_Server_deleteNode(server->sv_server, nodeId,
+	RETVAL = UA_Server_deleteNode(server->sv_server, *nodeId,
 	    deleteReferences);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&nodeId);
 	UA_Boolean_clear(&deleteReferences);
 
 # 11.10 Reference Management
@@ -2283,39 +2251,35 @@ UA_Server_deleteNode(server, nodeId, deleteReferences)
 UA_StatusCode
 UA_Server_addReference(server, sourceId, refTypeId, targetId, isForward)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			sourceId
-	UA_NodeId			refTypeId
+	OPCUA_Open62541_NodeId		sourceId
+	OPCUA_Open62541_NodeId		refTypeId
 	UA_ExpandedNodeId		targetId
 	UA_Boolean			isForward
     CODE:
-	RETVAL = UA_Server_addReference(server->sv_server, sourceId, refTypeId,
-	    targetId, isForward);
+	RETVAL = UA_Server_addReference(server->sv_server, *sourceId,
+	    *refTypeId, targetId, isForward);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&sourceId);
-	UA_NodeId_clear(&refTypeId);
 	UA_ExpandedNodeId_clear(&targetId);
 	UA_Boolean_clear(&isForward);
 
 UA_StatusCode
 UA_Server_deleteReference(server, sourceNodeId, referenceTypeId, isForward, targetNodeId, deleteBidirectional)
 	OPCUA_Open62541_Server		server
-	UA_NodeId			sourceNodeId
-	UA_NodeId			referenceTypeId
+	OPCUA_Open62541_NodeId		sourceNodeId
+	OPCUA_Open62541_NodeId		referenceTypeId
 	UA_Boolean			isForward
 	UA_ExpandedNodeId		targetNodeId
 	UA_Boolean			deleteBidirectional
     CODE:
-	RETVAL = UA_Server_deleteReference(server->sv_server, sourceNodeId,
-	    referenceTypeId, isForward, targetNodeId, deleteBidirectional);
+	RETVAL = UA_Server_deleteReference(server->sv_server, *sourceNodeId,
+	    *referenceTypeId, isForward, targetNodeId, deleteBidirectional);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&sourceNodeId);
-	UA_NodeId_clear(&referenceTypeId);
 	UA_Boolean_clear(&isForward);
 	UA_ExpandedNodeId_clear(&targetNodeId);
 	UA_Boolean_clear(&deleteBidirectional);
@@ -2606,7 +2570,7 @@ UA_Client_Service_browse(client, request)
 UA_StatusCode
 UA_Client_readValueAttribute_async(client, nodeId, callback, data, reqId)
 	OPCUA_Open62541_Client		client
-	UA_NodeId			nodeId
+	OPCUA_Open62541_NodeId		nodeId
 	SV *				callback
 	SV *				data
 	OPCUA_Open62541_UInt32		reqId
@@ -2617,7 +2581,7 @@ UA_Client_readValueAttribute_async(client, nodeId, callback, data, reqId)
 		CROAK("reqId is not a scalar reference");
     CODE:
 	ccd = newClientCallbackData(callback, ST(0), data);
-	RETVAL = UA_Client_readValueAttribute_async(client->cl_client, nodeId,
+	RETVAL = UA_Client_readValueAttribute_async(client->cl_client, *nodeId,
 	    clientAsyncReadValueAttributeCallback, ccd, reqId);
 	if (RETVAL != UA_STATUSCODE_GOOD)
 		deleteClientCallbackData(ccd);
@@ -2627,18 +2591,17 @@ UA_Client_readValueAttribute_async(client, nodeId, callback, data, reqId)
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Client_readDisplayNameAttribute(client, nodeId, outDisplayName)
 	OPCUA_Open62541_Client		client
-	UA_NodeId			nodeId
+	OPCUA_Open62541_NodeId		nodeId
 	OPCUA_Open62541_LocalizedText	outDisplayName
     INIT:
 	if (!SvOK(ST(2)) || !(SvROK(ST(2)) && SvTYPE(SvRV(ST(2))) < SVt_PVAV))
 		CROAK("outDisplayName is not a scalar reference");
     CODE:
-	RETVAL = UA_Client_readDisplayNameAttribute(client->cl_client, nodeId,
+	RETVAL = UA_Client_readDisplayNameAttribute(client->cl_client, *nodeId,
 	    outDisplayName);
 	if (outDisplayName != NULL)
 		XS_pack_UA_LocalizedText(SvRV(ST(2)), *outDisplayName);
@@ -2646,18 +2609,17 @@ UA_Client_readDisplayNameAttribute(client, nodeId, outDisplayName)
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Client_readDescriptionAttribute(client, nodeId, outDescription)
 	OPCUA_Open62541_Client		client
-	UA_NodeId			nodeId
+	OPCUA_Open62541_NodeId		nodeId
 	OPCUA_Open62541_LocalizedText	outDescription
     INIT:
 	if (!SvOK(ST(2)) || !(SvROK(ST(2)) && SvTYPE(SvRV(ST(2))) < SVt_PVAV))
 		CROAK("outDescription is not a scalar reference");
     CODE:
-	RETVAL = UA_Client_readDescriptionAttribute(client->cl_client, nodeId,
+	RETVAL = UA_Client_readDescriptionAttribute(client->cl_client, *nodeId,
 	    outDescription);
 	if (outDescription != NULL)
 		XS_pack_UA_LocalizedText(SvRV(ST(2)), *outDescription);
@@ -2665,31 +2627,25 @@ UA_Client_readDescriptionAttribute(client, nodeId, outDescription)
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Client_readValueAttribute(client, nodeId, outValue)
 	OPCUA_Open62541_Client		client
-	UA_NodeId			nodeId
+	OPCUA_Open62541_NodeId		nodeId
 	OPCUA_Open62541_Variant		outValue
-    INIT:
-	if (!SvOK(ST(2)) || !(SvROK(ST(2)) && SvTYPE(SvRV(ST(2))) < SVt_PVAV))
-		CROAK("outValue is not a scalar reference");
     CODE:
-	RETVAL = UA_Client_readValueAttribute(client->cl_client, nodeId,
+	RETVAL = UA_Client_readValueAttribute(client->cl_client, *nodeId,
 	    outValue);
-	if (outValue != NULL)
-		XS_pack_UA_Variant(SvRV(ST(2)), *outValue);
+	XS_pack_UA_Variant(SvRV(ST(2)), *outValue);
     OUTPUT:
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&nodeId);
 
 UA_StatusCode
 UA_Client_readDataTypeAttribute(client, nodeId, outDataType)
 	OPCUA_Open62541_Client		client
-	UA_NodeId			nodeId
+	OPCUA_Open62541_NodeId		nodeId
 	SV *				outDataType
     PREINIT:
 	UA_NodeId			outNodeId;
@@ -2698,7 +2654,7 @@ UA_Client_readDataTypeAttribute(client, nodeId, outDataType)
 	if (!SvOK(ST(2)) || !(SvROK(ST(2)) && SvTYPE(SvRV(ST(2))) < SVt_PVAV))
 		CROAK("outDataType is not a scalar reference");
     CODE:
-	RETVAL = UA_Client_readDataTypeAttribute(client->cl_client, nodeId,
+	RETVAL = UA_Client_readDataTypeAttribute(client->cl_client, *nodeId,
 	    &outNodeId);
 	/*
 	 * Convert NodeId to DataType, see XS_unpack_UA_NodeId() for
@@ -2715,7 +2671,6 @@ UA_Client_readDataTypeAttribute(client, nodeId, outDataType)
 	RETVAL
     CLEANUP:
 	UA_StatusCode_clear(&RETVAL);
-	UA_NodeId_clear(&nodeId);
 
 #############################################################################
 MODULE = OPCUA::Open62541	PACKAGE = OPCUA::Open62541::ClientConfig	PREFIX = UA_ClientConfig_

--- a/t/server-variable.t
+++ b/t/server-variable.t
@@ -85,7 +85,7 @@ throws_ok {
     $server->{server}->addVariableNode(\%requestedNewNodeId, \%parentNodeId,
 	\%referenceTypeId, \%browseName, \%typeDefinition, \%attr, 0,
 	\%outNewNodeId);
-} (qr/outNewNodeId is not a scalar reference/, "empty out node");
+} (qr/outoptNewNodeId is not a scalar reference/, "empty out node");
 no_leaks_ok { eval {
     $server->{server}->addVariableNode(\%requestedNewNodeId, \%parentNodeId,
 	\%referenceTypeId, \%browseName, \%typeDefinition, \%attr, 0,

--- a/t/typemap.t
+++ b/t/typemap.t
@@ -36,6 +36,8 @@ is(ref($client), "OPCUA::Open62541::Client", "client ref");
 
 ### variant has simple constructor, so it is easy to test
 
+my $package = 'OPCUA::Open62541';
+
 # variant constructor new
 
 ok(my $variant = OPCUA::Open62541::Variant->new(), "new");
@@ -43,13 +45,13 @@ is(ref($variant), "OPCUA::Open62541::Variant", "new ref");
 no_leaks_ok { OPCUA::Open62541::Variant->new() } "new leak";
 
 throws_ok { OPCUA::Open62541::Variant::new() }
-    (qr/Usage: OPCUA::Open62541::Variant::new\(class\) /,
+    (qr/Usage: ${package}::Variant::new\(class\) /,
     "new usage class");
 no_leaks_ok { eval { OPCUA::Open62541::Variant::new() } }
     "new usage class leak";
 
 throws_ok { OPCUA::Open62541::Variant->new("") }
-    (qr/Usage: OPCUA::Open62541::Variant::new\(class\) /,
+    (qr/Usage: ${package}::Variant::new\(class\) /,
     "new usage parameter");
 no_leaks_ok { eval { OPCUA::Open62541::Variant->new("") } }
     "new usage parameter leak";
@@ -57,7 +59,7 @@ no_leaks_ok { eval { OPCUA::Open62541::Variant->new("") } }
 throws_ok {
     no warnings;
     OPCUA::Open62541::Variant::new(undef);
-} (qr/new: Class '' is not OPCUA::Open62541::Variant /,
+} (qr/new: Class '' is not ${package}::Variant /,
     "new undef");
 warning_like { eval { OPCUA::Open62541::Variant::new(undef) } }
     (qr/Use of uninitialized value in subroutine entry at /,
@@ -68,7 +70,7 @@ no_leaks_ok { eval {
 } } "new undef leak";
 
 throws_ok { OPCUA::Open62541::Variant::new("OPCUA::Open62541::Client") }
-    (qr/new: Class 'OPCUA::Open62541::Client' is not \w+::Open62541::Variant /,
+    (qr/new: Class 'OPCUA::Open62541::Client' is not ${package}::Variant /,
     "new class type");
 no_leaks_ok { eval {
     OPCUA::Open62541::Variant::new("OPCUA::Open62541::Client");
@@ -88,19 +90,19 @@ no_leaks_ok { OPCUA::Open62541::Variant::DESTROY($variant) }
 }
 
 throws_ok { OPCUA::Open62541::Variant::DESTROY() }
-    (qr/Usage: OPCUA::Open62541::Variant::DESTROY\(variant\) /,
+    (qr/Usage: ${package}::Variant::DESTROY\(variant\) /,
     "destroy usage class");
 no_leaks_ok { eval { OPCUA::Open62541::Variant::DESTROY() } }
     "destroy usage class leak";
 
 throws_ok { OPCUA::Open62541::Variant::DESTROY($variant, "") }
-    (qr/Usage: OPCUA::Open62541::Variant::DESTROY\(variant\) /,
+    (qr/Usage: ${package}::Variant::DESTROY\(variant\) /,
     "destroy usage parameter");
 no_leaks_ok { eval { OPCUA::Open62541::Variant::DESTROY($variant, "") } }
     "destroy usage parameter leak";
 
 throws_ok { OPCUA::Open62541::Variant::DESTROY($client) }
-    (qr/DESTROY: Self variant is not a OPCUA::Open62541::Variant /,
+    (qr/DESTROY: Self variant is not a ${package}::Variant /,
     "destroy self type");
 no_leaks_ok { eval {
     OPCUA::Open62541::Variant::DESTROY($client);
@@ -111,19 +113,19 @@ no_leaks_ok { eval {
 ok(OPCUA::Open62541::Variant::isEmpty($variant), "isempty");
 
 throws_ok { OPCUA::Open62541::Variant::isEmpty() }
-    (qr/Usage: OPCUA::Open62541::Variant::isEmpty\(variant\) /,
+    (qr/Usage: ${package}::Variant::isEmpty\(variant\) /,
     "isempty usage class");
 no_leaks_ok { eval { OPCUA::Open62541::Variant::isEmpty() } }
     "isempty usage class leak";
 
 throws_ok { OPCUA::Open62541::Variant::isEmpty($variant, "") }
-    (qr/Usage: OPCUA::Open62541::Variant::isEmpty\(variant\) /,
+    (qr/Usage: ${package}::Variant::isEmpty\(variant\) /,
     "isempty usage parameter");
 no_leaks_ok { eval { OPCUA::Open62541::Variant::isEmpty($variant, "") } }
     "isempty usage parameter leak";
 
 throws_ok { OPCUA::Open62541::Variant::isEmpty($client) }
-    (qr/isEmpty: Self variant is not a OPCUA::Open62541::Variant /,
+    (qr/isEmpty: Self variant is not a ${package}::Variant /,
     "isempty self type");
 no_leaks_ok { eval {
     OPCUA::Open62541::Variant::isEmpty($client);
@@ -146,26 +148,23 @@ no_leaks_ok { $server->{server}->writeValue(\%nodeid, \%value) }
     "write value leak";
 
 throws_ok { $server->{server}->writeValue(\%nodeid) }
-    (qr/Usage: \w+::Open62541::Server::writeValue\(server, nodeId, value\) /,
+    (qr/Usage: ${package}::Server::writeValue\(server, nodeId, value\) /,
     "write value usage");
 no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid) } }
     "write value usage leak";
 
-# XXX expect a more specific error message
 throws_ok { $server->{server}->writeValue(\%nodeid, undef) }
-    (qr/Variant: Not a HASH reference /,
+    (qr/writeValue: Parameter value is not scalar or array or hash /,
     "write value undef");
 no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, undef) } }
     "write value undef leak";
 
-# XXX expect a more specific error message
 throws_ok { $server->{server}->writeValue(\%nodeid, 77) }
     (qr/Variant: Not a HASH reference /,
     "write value number");
 no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, 77) } }
     "write value number leak";
 
-# XXX expect a more specific error message
 $outvalue = 5;
 throws_ok { $server->{server}->writeValue(\%nodeid, $outvalue) }
     (qr/Variant: Not a HASH reference /,
@@ -174,7 +173,6 @@ $outvalue = 5;
 no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, $outvalue) } }
     "write value variable leak";
 
-# XXX expect a more specific error message
 throws_ok { $server->{server}->writeValue(\%nodeid, []) }
     (qr/Variant: Not a HASH reference /,
     "write value array");
@@ -189,23 +187,21 @@ no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, {}) } }
 
 $outvalue = {};
 throws_ok { $server->{server}->writeValue(\%nodeid, \$outvalue) }
-    (qr/Variant: Not a HASH reference /,
+    (qr/writeValue: Parameter value is not scalar or array or hash /,
     "write value hashref");
 $outvalue = {};
 no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, \$outvalue) } }
     "write value hashref leak";
 
-# XXX expect a more specific error message
 throws_ok { $server->{server}->writeValue(\%nodeid, $client) }
-    (qr/Variant: Not a HASH reference /,
+    (qr/writeValue: Parameter value is not scalar or array or hash /,
     "write client type");
 is(ref($client), 'OPCUA::Open62541::Client', "write client ref");
 no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, $client) } }
     "write client type leak";
 
-# XXX expect a more specific error message
 throws_ok { $server->{server}->writeValue(\%nodeid, $variant) }
-    (qr/Variant: Not a HASH reference /,
+    (qr/writeValue: Parameter value is not scalar or array or hash /,
     "write variant type");
 is(ref($variant), 'OPCUA::Open62541::Variant', "write variant ref");
 no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, $variant) } }
@@ -223,39 +219,39 @@ no_leaks_ok { $server->{server}->readValue(\%nodeid, \$outvalue) }
     "read value leak";
 
 throws_ok { $server->{server}->readValue(\%nodeid) }
-    (qr/Usage: \w+::Open62541::Server::readValue\(server, nodeId, outValue\) /,
+    (qr/Usage: ${package}::Server::readValue\(server, nodeId, outValue\) /,
     "read outvalue usage");
 no_leaks_ok { eval { $server->{server}->readValue(\%nodeid) } }
     "read outvalue usage leak";
 
 throws_ok { $server->{server}->readValue(\%nodeid, undef) }
-    (qr/readValue: Parameter outValue is not a scalar reference /,
+    (qr/readValue: Output parameter outValue is not a scalar reference /,
     "read outvalue undef");
 no_leaks_ok { eval { $server->{server}->readValue(\%nodeid, undef) } }
     "read outvalue undef leak";
 
 throws_ok { $server->{server}->readValue(\%nodeid, 77) }
-    (qr/readValue: Parameter outValue is not a scalar reference /,
+    (qr/readValue: Output parameter outValue is not a scalar reference /,
     "read outvalue number");
 no_leaks_ok { eval { $server->{server}->readValue(\%nodeid, 77) } }
     "read outvalue number leak";
 
 $outvalue = 5;
 throws_ok { $server->{server}->readValue(\%nodeid, $outvalue) }
-    (qr/readValue: Parameter outValue is not a scalar reference /,
+    (qr/readValue: Output parameter outValue is not a scalar reference /,
     "read outvalue variable");
 $outvalue = 5;
 no_leaks_ok { eval { $server->{server}->readValue(\%nodeid, $outvalue) } }
     "read outvalue variable leak";
 
 throws_ok { $server->{server}->readValue(\%nodeid, []) }
-    (qr/readValue: Parameter outValue is not a scalar reference /,
+    (qr/readValue: Output parameter outValue is not a scalar reference /,
     "read outvalue array");
 no_leaks_ok { eval { $server->{server}->readValue(\%nodeid, []) } }
     "read outvalue array leak";
 
 throws_ok { $server->{server}->readValue(\%nodeid, {}) }
-    (qr/readValue: Parameter outValue is not a scalar reference /,
+    (qr/readValue: Output parameter outValue is not a scalar reference /,
     "read outvalue hash");
 no_leaks_ok { eval { $server->{server}->readValue(\%nodeid, {}) } }
     "read outvalue hash leak";
@@ -276,14 +272,14 @@ no_leaks_ok { $server->{server}->readValue(\%nodeid, \$outvalue) }
     "read outvalue hashref leak";
 
 throws_ok { $server->{server}->readValue(\%nodeid, $client) }
-    (qr/readValue: Parameter outValue is not a scalar reference /,
+    (qr/readValue: Output parameter outValue is not a scalar reference /,
     "read client type");
 no_leaks_ok { eval { $server->{server}->readValue(\%nodeid, $client) } }
     "read client type leak";
 is(ref($client), 'OPCUA::Open62541::Client', "read client ref");
 
 throws_ok { $server->{server}->readValue(\%nodeid, $variant) }
-    (qr/readValue: Parameter outValue is not a scalar reference /,
+    (qr/readValue: Output parameter outValue is not a scalar reference /,
     "read outvalue variant");
 no_leaks_ok { eval { $server->{server}->readValue(\%nodeid, $variant) } }
     "read outvalue variant leak";
@@ -308,23 +304,24 @@ is($server->{server}->addVariableNode(@addargs, undef),
 # server method addVariableNode with output nodeid
 
 my $addparams = "server, requestedNewNodeId, parentNodeId, referenceTypeId, ".
-    "browseName, typeDefinition, attr, nodeContext, outNewNodeId";
+    "browseName, typeDefinition, attr, nodeContext, outoptNewNodeId";
+my $outnode = "Output parameter outoptNewNodeId";
 
 throws_ok { $server->{server}->addVariableNode(@addargs) }
-    (qr/Usage: \w+::Open62541::Server::addVariableNode\($addparams\) /,
+    (qr/Usage: ${package}::Server::addVariableNode\($addparams\) /,
     "add node usage");
 no_leaks_ok { eval { $server->{server}->addVariableNode(@addargs) } }
     "add node usage leak";
 
 throws_ok { $server->{server}->addVariableNode(@addargs, 77) }
-    (qr/addVariableNode: Parameter outNewNodeId is not a scalar reference /,
+    (qr/addVariableNode: ${outnode} is not a scalar reference /,
     "add node out number");
 no_leaks_ok { eval { $server->{server}->addVariableNode(@addargs, 77) } }
     "add node out number leak";
 
 my $outnodeid = 5;
 throws_ok { $server->{server}->addVariableNode(@addargs, $outnodeid) }
-    (qr/addVariableNode: Parameter outNewNodeId is not a scalar reference /,
+    (qr/addVariableNode: ${outnode} is not a scalar reference /,
     "add node out variable");
 $outnodeid = 5;
 no_leaks_ok { eval {
@@ -332,14 +329,14 @@ no_leaks_ok { eval {
 } } "add node out variable leak";
 
 throws_ok { $server->{server}->addVariableNode(@addargs, []) }
-    (qr/addVariableNode: Parameter outNewNodeId is not a scalar reference /,
+    (qr/addVariableNode: ${outnode} is not a scalar reference /,
     "add node out array");
 no_leaks_ok { eval {
     $server->{server}->addVariableNode(@addargs, [])
 } } "add node out array leak";
 
 throws_ok { $server->{server}->addVariableNode(@addargs, {}) }
-    (qr/addVariableNode: Parameter outNewNodeId is not a scalar reference /,
+    (qr/addVariableNode: ${outnode} is not a scalar reference /,
     "add node out hash");
 no_leaks_ok { eval {
     $server->{server}->addVariableNode(@addargs, {})
@@ -358,7 +355,7 @@ no_leaks_ok {
 } "add node out hashref leak";
 
 throws_ok { $server->{server}->addVariableNode(@addargs, $client) }
-    (qr/addVariableNode: Parameter outNewNodeId is not a scalar reference /,
+    (qr/addVariableNode: ${outnode} is not a scalar reference /,
     "add node client type");
 no_leaks_ok { eval { $server->{server}->addVariableNode(@addargs, $client) } }
     "add node client type leak";

--- a/typemap
+++ b/typemap
@@ -16,18 +16,16 @@ UA_StatusCode				T_PACKED
 UA_String				T_PACKED
 UA_Guid					T_PACKED
 UA_ByteString				T_PACKED
-UA_Variant				T_PACKED
 enum UA_NodeIdType			T_ENUM
-UA_NodeId				T_PACKED
 UA_BrowseDescription			T_PACKED
 UA_BrowseRequest			T_PACKED
 UA_BrowseResponse			T_PACKED
 UA_BrowseResult				T_PACKED
-OPCUA_Open62541_NodeId			T_PTROBJ_OPTIONAL
+OPCUA_Open62541_NodeId			T_PTROBJ_PACKED
 OPCUA_Open62541_LocalizedText		T_PTROBJ_REFERENCE
 UA_QualifiedName			T_PACKED
 OPCUA_Open62541_DataType		T_PACKED
-OPCUA_Open62541_Variant			T_PTROBJ_REFERENCE
+OPCUA_Open62541_Variant			T_PTROBJ_PACKED
 UA_DataTypeAttributes			T_PACKED
 UA_ObjectAttributes			T_PACKED
 UA_ObjectTypeAttributes			T_PACKED
@@ -48,6 +46,101 @@ UA_ExpandedNodeId			T_PACKED
 
 #############################################################################
 INPUT
+T_PTROBJ_PACKED
+	if ($argoff == 0) {
+		if (!(${(my $ntt=${ntype})=~s/_/::/g;
+		    # isself will be 1 for self pointer, 0 for other parameter
+		    # a self pointer of wrong type will cause C syntax error
+		    my $isself = $ntt eq $Package ? 1 : \"bad self\";
+		    $isself = 0 if $argoff != 0; 
+		    \$isself}) ||
+		    (!(SvOK($arg) && SvROK($arg) &&
+		    sv_derived_from($arg, \"$Package\")))) {
+			CROAK(\"Self %s is not a %s\", \"$var\", \"$Package\");
+		}
+		/*
+		 * object reference of the correct type
+		 *
+		 * Use the existing object.
+		 *
+		 * This is needed for the DESTROY function and
+		 * self pointer of variant method.
+		 */
+		$var = INT2PTR($type, SvIV(SvRV($arg)));
+	} else if (${my $outopt=(${var}=~/^outopt/)?1:0; \$outopt} &&
+	    !SvOK($arg)) {
+		/*
+		 * undef
+		 *
+		 * Parameter is optional, do create an object pointer.
+		 * Optional output parameter have the prefix outopt.
+		 *
+		 * This is needed for passing optional output parameter.
+		 * Note that the code using this feature should
+		 * cope with the NULL pointer.
+		 */
+		$var = NULL;
+	} else if (${my $out=(${var}=~/^out/)?1:0; \$out}) {
+		if (!SvOK($arg) ||
+		    !(SvROK($arg) && SvTYPE(SvRV($arg)) <= SVt_PVNV)) {
+			CROAK(\"Output parameter %s is not a scalar reference\",
+			    \"$var\");
+		}
+		/*
+		 * scalar reference
+		 *
+		 * Create an object pointer of the correct type
+		 * using the UA_new() function.  Store it in a new
+		 * mortal SV, then it will be destroyed at the end
+		 * of the XS function.  Note that a DESTROY function
+		 * that calls US_delete() should exist!
+		 *
+		 * This is needed for passing output parameter.
+		 * Output parameter have the prefix out.
+		 * Note that the pack into the output object should be
+		 * be done manually in the XS function.
+		 */
+		SV *svm_${var} = sv_newmortal();
+		$var = UA_${(my $ntt=${ntype})=~s/.*_//g;\$ntt}_new();
+		if ($var == NULL) {
+			CROAKE(
+			    \"UA_${(my $ntt=${ntype})=~s/.*_//g;\$ntt}_new\");
+		}
+		DPRINTF(\"${(my $ntt=lc(${ntype}))=~s/.*_//g;\$ntt} %p\", $var);
+		sv_setref_pv(svm_${var},
+		    \"${(my $ntt=${ntype})=~s/_/::/g;\$ntt}\", $var);
+	} else if (SvOK($arg) &&
+	    (!SvROK($arg) || (SvTYPE(SvRV($arg)) == SVt_PVAV) ||
+	    (SvTYPE(SvRV($arg)) == SVt_PVHV))) {
+		/*
+		 * scalar or array or hash
+		 *
+		 * Create an object pointer of the correct type
+		 * using the UA_new() function.  Store it in a new
+		 * mortal SV, then it will be destroyed at the end
+		 * of the XS function.  Note that a DESTROY function
+		 * that calls US_delete() should exist!  The input
+		 * SV is unpacked into the object at the mortal SV.
+		 *
+		 * This is needed for passing input parameter.
+		 */
+		SV *svm_${var} = sv_newmortal();
+		$var = UA_${(my $ntt=${ntype})=~s/.*_//g;\$ntt}_new();
+		if ($var == NULL) {
+			CROAKE(
+			    \"UA_${(my $ntt=${ntype})=~s/.*_//g;\$ntt}_new\");
+		}
+		DPRINTF(\"${(my $ntt=lc(${ntype}))=~s/.*_//g;\$ntt} %p\", $var);
+		sv_setref_pv(svm_${var},
+		    \"${(my $ntt=${ntype})=~s/_/::/g;\$ntt}\", $var);
+		*$var =
+		    XS_unpack_UA_${(my $ntt=${ntype})=~s/.*_//g;\$ntt}($arg);
+	} else {
+		CROAK(\"Parameter %s is not scalar or array or hash\",
+		    \"$var\");
+		/* NOTREACHED, but cppcheck does not know this. */
+		exit(255);
+	}
 T_PTROBJ_OPTIONAL
 	if ($argoff == 0) {
 		if (!(SvOK($arg) && SvROK($arg) &&
@@ -90,13 +183,35 @@ T_PTROBJ_REFERENCE
 		CROAK(\"Parameter %s is not a scalar reference\", \"$var\");
 	}
 T_PTROBJ_SPECIAL
-	if ($argoff == 0 && !(SvOK($arg) && SvROK($arg) &&
-	    sv_derived_from($arg, \"$Package\"))) {
-		CROAK(\"Self %s is not a %s\", \"$var\", \"$Package\");
-	}
-	if (SvROK($arg) && sv_derived_from($arg,
+	if ($argoff == 0) {
+		if (!(${(my $ntt=${ntype})=~s/_/::/g;
+		    # isself will be 1 for self pointer, 0 for other parameter
+		    # a self pointer of wrong type will cause C syntax error
+		    my $isself = $ntt eq $Package ? 1 : \"bad self\";
+		    $isself = 0 if $argoff != 0; 
+		    \$isself}) ||
+		    (!(SvOK($arg) && SvROK($arg) &&
+		    sv_derived_from($arg, \"$Package\")))) {
+			CROAK(\"Self %s is not a %s\", \"$var\", \"$Package\");
+		}
+		/*
+		 * object reference of the correct type
+		 *
+		 * Use the existing object.
+		 *
+		 * This is needed for the DESTROY function and
+		 * self pointer of server, client, config, logger method.
+		 */
+		$var = INT2PTR($type, SvIV(SvRV($arg)));
+	} else if (SvOK($arg) && SvROK($arg) && sv_derived_from($arg,
 	    \"${(my $ntt=${ntype})=~s/_/::/g;\$ntt}\")) {
-		/* Already an object pointer. */
+		/*
+		 * object reference of the correct type
+		 *
+		 * Use the existing object.
+		 *
+		 * This is needed for method parameter.
+		 */
 		$var = INT2PTR($type, SvIV(SvRV($arg)));
 	} else {
 		CROAK(\"Parameter %s is not a %s\",
@@ -107,6 +222,8 @@ T_PTROBJ_SPECIAL
 
 #############################################################################
 OUTPUT
+T_PTROBJ_PACKED
+	sv_setref_pv($arg, \"${(my $ntt=${ntype})=~s/_/::/g;\$ntt}\", $var);
 T_PTROBJ_REFERENCE
 	sv_setref_pv($arg, \"${(my $ntt=${ntype})=~s/_/::/g;\$ntt}\", $var);
 T_PTROBJ_SPECIAL


### PR DESCRIPTION
Move more of the parameter checks and memory management into the
typemap definitions.  The T_PTROBJ_PACKED typemap handles this.
The paramter name specifies whether it is a regular input, output
or optional output parameter.  The UA object for the input and
output parameter is generated on the fly and stored in a mortal SV.
The input parameter are unpacked automatically.  The mortal UA
object is available while the XS function is running.  After that
it is deleted by the DESTROY destructor.  The parameter checks and
explicit clear function in the funtions are no longer necessary.

Convert all UA_Node and UA_Variant parameter for now.