### PR TITLE
Pack/unpack empty variants

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -764,6 +764,7 @@ XS_unpack_UA_Variant(SV *in)
 	OPCUA_Open62541_DataType type;
 	SV **svp, **scalar, **array;
 	HV *hv;
+	int count;
 
 	SvGETMAGIC(in);
 	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
@@ -771,6 +772,10 @@ XS_unpack_UA_Variant(SV *in)
 	}
 	UA_Variant_init(&out);
 	hv = (HV*)SvRV(in);
+
+	count = hv_iterinit(hv);
+	if (count == 0)
+		return out;
 
 	svp = hv_fetchs(hv, "Variant_type", 0);
 	if (svp == NULL)
@@ -844,11 +849,11 @@ XS_pack_UA_Variant(SV *out, UA_Variant in)
 	SV *sv;
 	HV *hv;
 
+	hv = newHV();
 	if (UA_Variant_isEmpty(&in)) {
-		sv_set_undef(out);
+		sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 		return;
 	}
-	hv = newHV();
 
 	sv = newSV(0);
 	XS_pack_OPCUA_Open62541_DataType(sv, in.type);

--- a/t/typemap.t
+++ b/t/typemap.t
@@ -5,7 +5,7 @@ use warnings;
 use OPCUA::Open62541 qw(:STATUSCODE :TYPES);
 
 use OPCUA::Open62541::Test::Server;
-use Test::More tests => OPCUA::Open62541::Test::Server::planning_nofork() + 103;
+use Test::More tests => OPCUA::Open62541::Test::Server::planning_nofork() + 105;
 use Test::Exception;
 use Test::LeakTrace;
 use Test::NoWarnings;
@@ -142,6 +142,11 @@ my $outvalue;
 
 # server method writeValue with input variant
 
+is($server->{server}->writeValue(\%nodeid, {}), STATUSCODE_GOOD,
+    "write empty value");
+no_leaks_ok { $server->{server}->writeValue(\%nodeid, {}) }
+    "write empty value leak";
+
 is($server->{server}->writeValue(\%nodeid, \%value), STATUSCODE_GOOD,
     "write value");
 no_leaks_ok { $server->{server}->writeValue(\%nodeid, \%value) }
@@ -179,10 +184,10 @@ throws_ok { $server->{server}->writeValue(\%nodeid, []) }
 no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, []) } }
     "write value array leak";
 
-throws_ok { $server->{server}->writeValue(\%nodeid, {}) }
+throws_ok { $server->{server}->writeValue(\%nodeid, {foo=>"bar"}) }
     (qr/Variant: No Variant_type in HASH /,
     "write value hash");
-no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, {}) } }
+no_leaks_ok { eval { $server->{server}->writeValue(\%nodeid, {foo=>"bar"}) } }
     "write value hash leak";
 
 $outvalue = {};


### PR DESCRIPTION
* An empty UA_Variant is now represented as an empty hash in perl.
* This allows using empty Variants in functions (e. g. writeValue).
* If a variant hash is malformed (e. g. missing Variant_type key), the
  pack function will only croak if there are other keys in the hash.