### PR TITLE
UA_String unpack NULL string

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -409,6 +409,11 @@ XS_unpack_UA_ByteString(SV *in)
 	char *str;
 	UA_ByteString out;
 
+	if (!SvOK(in)) {
+		UA_ByteString_init(&out);
+		return out;
+	}
+
 	str = SvPV(in, out.length);
 	if (out.length > 0) {
 		out.data = UA_malloc(out.length);

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -329,6 +329,11 @@ XS_unpack_UA_String(SV *in)
 	char *str;
 	UA_String out;
 
+	if (!SvOK(in)) {
+		UA_String_init(&out);
+		return out;
+	}
+
 	str = SvPVutf8(in, out.length);
 	if (out.length > 0) {
 		out.data = UA_malloc(out.length);

--- a/t/server-references.t
+++ b/t/server-references.t
@@ -58,7 +58,10 @@ is(
     $server->{server}->addReference(
 	$node_objecttypes,
 	$node_organizes,
-	{ ExpandedNodeId_nodeId => $nodes{some_object_type}{nodeId} },
+	{
+	    ExpandedNodeId_namespaceUri => undef,
+	    ExpandedNodeId_nodeId => $nodes{some_object_type}{nodeId}
+	},
 	1,
     ),
     STATUSCODE_GOOD, "add reference");


### PR DESCRIPTION
* NULL strings are already converted to undef in pack. Now the reverse
  is happening in unpack.
* Extended a reference test where the library checks for NULL strings.