### PR TITLE
SVt_PVNV is not the correct way to detect scalars.

### DIFF
--- a/typemap
+++ b/typemap
@@ -104,7 +104,8 @@ T_PTROBJ_PACKED
 			abort(); /* NOTREACHED */
 		}
 	} else if (${my $out=($var=~/^out/)?1:0; \$out}) {
-		if (!(SvROK($arg) && SvTYPE(SvRV($arg)) <= SVt_PVNV)) {
+		if (!(SvROK($arg) && SvTYPE(SvRV($arg)) < SVt_PVAV) ||
+		    sv_isobject($arg)) {
 			CROAK(\"Output parameter %s is not a scalar reference\",
 			    \"$var\");
 		}


### PR DESCRIPTION
Use the recommended SvTYPE(SvRV(SV*)) < SVt_PVAV to detect scalar
references.  Put an additional sv_isobject() check to be stricter
and avoid a crash in the test.