### PR TITLE
Set admin session context.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,17 @@ check_lib_or_exit(
     incpath		=> '/usr/local/include',
 );
 
+my @have;
+check_lib(
+    function		=> "UA_Server_setAdminSessionContext(NULL, NULL);",
+    not_execute		=> 1,
+    lib			=> 'open62541',
+    header		=> 'open62541/server.h',
+    libpath		=> '/usr/local/lib',
+    incpath		=> '/usr/local/include',
+) and push @have, uc('UA_Server_setAdminSessionContext');
+my @defines = map { "-DHAVE_$_=1" } @have;
+
 WriteMakefile(
     NAME		=> 'OPCUA::Open62541',
     VERSION_FROM	=> 'lib/OPCUA/Open62541.pm',
@@ -31,6 +42,7 @@ WriteMakefile(
     LIBS		=> ['-L/usr/local/lib -lopen62541'],
     DEFINE		=> '',
     INC			=> '-I. -I/usr/local/include '.
+	"@defines ".
 	'-Wall -Wpointer-arith -Wuninitialized -Wstrict-prototypes '.
 	'-Wmissing-prototypes -Wunused -Wsign-compare -Wshadow '.
 	'-Wno-pointer-sign',

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -144,6 +144,7 @@ typedef struct OPCUA_Open62541_ServerConfig {
 typedef struct {
 	struct OPCUA_Open62541_ServerConfig sv_config;
 	UA_Server *		sv_server;
+	SV *			sv_context;
 } * OPCUA_Open62541_Server;
 
 /* client.h */
@@ -1962,6 +1963,7 @@ UA_Server_DESTROY(server)
 	SvREFCNT_dec(logger->lg_log);
 	SvREFCNT_dec(logger->lg_context);
 	SvREFCNT_dec(logger->lg_clear);
+	SvREFCNT_dec(server->sv_context);
 	free(server);
 
 OPCUA_Open62541_ServerConfig
@@ -2103,6 +2105,21 @@ UA_Server_browse(server, maxReferences, bd)
 	RETVAL = UA_Server_browse(server->sv_server, maxReferences, bd);
     OUTPUT:
 	RETVAL
+
+# 11.7 Information Model Callbacks
+
+#ifdef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
+
+void
+UA_Server_setAdminSessionContext(server, context)
+	OPCUA_Open62541_Server		server
+	SV *				context
+    CODE:
+	UA_Server_setAdminSessionContext(server->sv_server, server);
+	SvREFCNT_dec(server->sv_context);
+	server->sv_context = SvREFCNT_inc(context);
+
+#endif  /* HAVE_UA_SERVER_SETADMINSESSIONCONTEXT */
 
 # 11.9 Node Addition and Deletion
 

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -98,6 +98,10 @@ magically.
 
 =item \%browseResult = $server->browse($maxReferences, \%browseDescription)
 
+=item $server->setAdminSessionContext($context)
+
+This method is only available if open62541 library supports it.
+
 =item $status_code = $server->addVariableNode(\%requestedNewNodeId, \%parentNodeId, \%referenceTypeId, \%browseName, \%typeDefinition, \%attr, $nodeContext, \%outNewNodeId)
 
 =item $status_code = $server->addVariableTypeNode(\%requestedNewNodeId, \%parentNodeId, \%referenceTypeId, \%browseName, \%typeDefinition, \%attr, $nodeContext, \%outNewNodeId)

--- a/t/server-context.t
+++ b/t/server-context.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use OPCUA::Open62541;
+
+use Test::More;
+BEGIN {
+    if (OPCUA::Open62541::Server->can('setAdminSessionContext')) {
+	plan tests => 6;
+    } else {
+	plan skip_all => "No UA_Server_setAdminSessionContext in open62541";
+    }
+}
+use Test::Exception;
+use Test::LeakTrace;
+use Test::NoWarnings;
+
+ok(my $server = OPCUA::Open62541::Server->new(), "server new");
+lives_ok { $server->setAdminSessionContext(undef) } "server context";
+no_leaks_ok {
+    my $server = OPCUA::Open62541::Server->new();
+    $server->setAdminSessionContext(undef);
+} "server context leak";
+
+lives_ok { $server->setAdminSessionContext("foobar") } "server context twice";
+no_leaks_ok {
+    my $server = OPCUA::Open62541::Server->new();
+    $server->setAdminSessionContext("foo");
+    $server->setAdminSessionContext("bar");
+} "server context twice leak";


### PR DESCRIPTION
To provide a context for the global node livecycle callbacks,
implement server setAdminSessionContext() method.  As this is a new
API function, generate it only if it exists in the open62541 library.