### PR TITLE
Pack Guid to hash instead of a binary string.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -455,6 +455,17 @@ XS_pack_UA_Guid(SV *out, UA_Guid in)
 	}
 	hv_stores(hv, "Guid_data4", newRV_inc((SV*)av));
 
+	/*
+	 * Print the Guid format defined in Part 6, 5.1.3.
+	 * Format: C496578A-0DFE-4B8F-870A-745238C6AEAE
+	 * Use to print hash with magic, it is not parsed by unpack.
+	 */
+	sv = newSVpvf("%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+	    in.data1, in.data2, in.data3, in.data4[0], in.data4[1],
+	    in.data4[2], in.data4[3], in.data4[4],
+	    in.data4[5], in.data4[6], in.data4[7]);
+	hv_stores(hv, "Guid_string", sv);
+
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 }
 

--- a/t/variant-guid.t
+++ b/t/variant-guid.t
@@ -13,7 +13,7 @@ my %guid = (
     Guid_data1	=> 1,
     Guid_data2	=> 2,
     Guid_data3	=> 3,
-    Guid_data4	=> [41 .. 48],
+    Guid_data4	=> [0x41 .. 0x48],
 );
 
 no_leaks_ok { $variant->setScalar(\%guid, TYPES_GUID) } "scalar set leak";
@@ -21,18 +21,20 @@ no_leaks_ok { $variant->setScalar(\%guid, TYPES_GUID) } "scalar set leak";
 ok($variant->isScalar(), "scalar is");
 ok(my $guid = $variant->getScalar(), "scalar get");
 no_leaks_ok { $variant->getScalar() } "scalar get leak";
+$guid{Guid_string} = "00000001-0002-0003-4142-434445464748";
 is_deeply($guid, \%guid, "guid deep");
 
 %guid = (
-    Guid_data4 => [1 .. 100],
-    Guid_data5 => 5,
+    Guid_data4	=> [1 .. 100],
+    Guid_data5	=> 5,
 );
 $variant->setScalar(\%guid, TYPES_GUID);
 is_deeply($variant->getScalar(), {
-    Guid_data1 => 0,
-    Guid_data2 => 0,
-    Guid_data3 => 0,
-    Guid_data4 => [1 .. 8],
+    Guid_data1	=> 0,
+    Guid_data2	=> 0,
+    Guid_data3	=> 0,
+    Guid_data4	=> [1 .. 8],
+    Guid_string	=> "00000000-0000-0000-0102-030405060708",
 }, "guid ignore");
 
 %guid = (
@@ -40,6 +42,7 @@ is_deeply($variant->getScalar(), {
     Guid_data2	=> (2**16)-1,
     Guid_data3	=> (2**16)-1,
     Guid_data4	=> [(255) x 8],
+    Guid_string	=> "ffffffff-ffff-ffff-ffff-ffffffffffff",
 );
 $variant->setScalar(\%guid, TYPES_GUID);
 is_deeply($variant->getScalar(), \%guid, "guid max");

--- a/t/variant-guid.t
+++ b/t/variant-guid.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+use OPCUA::Open62541 qw(:TYPES);
+
+use Test::More tests => 12;
+use Test::Exception;
+use Test::LeakTrace;
+use Test::NoWarnings;
+
+ok(my $variant = OPCUA::Open62541::Variant->new(), "variant new");
+
+my %guid = (
+    Guid_data1	=> 1,
+    Guid_data2	=> 2,
+    Guid_data3	=> 3,
+    Guid_data4	=> [41 .. 48],
+);
+
+no_leaks_ok { $variant->setScalar(\%guid, TYPES_GUID) } "scalar set leak";
+
+ok($variant->isScalar(), "scalar is");
+ok(my $guid = $variant->getScalar(), "scalar get");
+no_leaks_ok { $variant->getScalar() } "scalar get leak";
+is_deeply($guid, \%guid, "guid deep");
+
+%guid = (
+    Guid_data4 => [1 .. 100],
+    Guid_data5 => 5,
+);
+$variant->setScalar(\%guid, TYPES_GUID);
+is_deeply($variant->getScalar(), {
+    Guid_data1 => 0,
+    Guid_data2 => 0,
+    Guid_data3 => 0,
+    Guid_data4 => [1 .. 8],
+}, "guid ignore");
+
+%guid = (
+    Guid_data1	=> (2**32)-1,
+    Guid_data2	=> (2**16)-1,
+    Guid_data3	=> (2**16)-1,
+    Guid_data4	=> [(255) x 8],
+);
+$variant->setScalar(\%guid, TYPES_GUID);
+is_deeply($variant->getScalar(), \%guid, "guid max");
+
+throws_ok { $variant->setScalar(
+    {Guid_data1 => 0, Guid_data4 => [0, 256]}, TYPES_GUID) }
+    (qr/Unsigned value 256 greater than UA_BYTE_MAX /, "guid big croak");
+no_leaks_ok { eval { $variant->setScalar(
+    {Guid_data1 => 0, Guid_data4 => [0, 256]}, TYPES_GUID) } }
+    "guid big leak";
+is_deeply($variant->getScalar(), \%guid, "guid big");


### PR DESCRIPTION
We want a human readable guid.  Use hash representation instead of
binary string.