### PR TITLE
Pack and unpack Guid to formated Perl string.

### DIFF
--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -136,6 +136,17 @@ This method is only available if open62541 library supports it.
 
 =item $server_config->setCustomHostname($custom_hostname)
 
+=item $server_config->setGlobalNodeLifecycle(\%lifecycle)
+
+=over 8
+
+=item $lifecycle{GlobalNodeLifecycle_constructor} = sub { my ($server, $sessionId, $sessionContext, $nodeId, \$nodeContext) = @_ }
+
+=back
+
+Call $server->setAdminSessionContext() to set $server and $sessionContext
+in the callback.
+
 =item $logger = $server_config->getLogger()
 
 =item $buildinfo = $server_config->getBuildInfo()

--- a/t/server-node-lifecycle.t
+++ b/t/server-node-lifecycle.t
@@ -1,0 +1,124 @@
+use strict;
+use warnings;
+use OPCUA::Open62541 qw(:all);
+
+use OPCUA::Open62541::Test::Server;
+use Test::More;
+BEGIN {
+    if (OPCUA::Open62541::Server->can('setAdminSessionContext')) {
+	plan tests => OPCUA::Open62541::Test::Server::planning_nofork() + 26;
+    } else {
+	plan skip_all => "No UA_Server_setAdminSessionContext in open62541";
+    }
+}
+use Test::Exception;
+use Test::LeakTrace;
+use Test::NoWarnings;
+
+my $server = OPCUA::Open62541::Test::Server->new();
+$server->start();
+my %nodes = $server->setup_complex_objects();
+
+sub addNodeNotest {
+    return $server->{server}->addVariableNode(
+	$nodes{some_variable_0}{nodeId},
+	$nodes{some_variable_0}{parentNodeId},
+	$nodes{some_variable_0}{referenceTypeId},
+	$nodes{some_variable_0}{browseName},
+	$nodes{some_variable_0}{typeDefinition},
+	$nodes{some_variable_0}{attributes},
+	0, undef);
+}
+
+sub addNode {
+    is(addNodeNotest(), STATUSCODE_GOOD, "add node");
+}
+
+sub deleteNodeNotest {
+    return $server->{server}->deleteNode($nodes{some_variable_0}{nodeId}, 1);
+}
+
+sub deleteNode {
+    is(deleteNodeNotest(), STATUSCODE_GOOD, "delete node");
+}
+
+lives_ok {
+    $server->{config}->setGlobalNodeLifecycle({
+	GlobalNodeLifecycle_constructor =>
+	    sub { note "constructor", explain [ @_ ] },
+	GlobalNodeLifecycle_destructor =>
+	    sub { note "destructor", explain [ @_ ] },
+	GlobalNodeLifecycle_createOptionalChild =>
+	    sub { note "createOptionalChild", explain [ @_ ] },
+	GlobalNodeLifecycle_generateChildNodeId =>
+	    sub { note "generateChildNodeId", explain [ @_ ] },
+    });
+} "set global node livecycle";
+
+deleteNode();
+addNode();
+deleteNode();
+
+my %admin_session_guid = (
+    NodeId_namespaceIndex	=> 0,
+    NodeId_identifierType	=> 4,
+    NodeId_identifier		=> "00000001-0000-0000-0000-000000000000",
+);
+
+$server->{config}->setGlobalNodeLifecycle({
+    GlobalNodeLifecycle_constructor => sub {
+	my ($srv, $sid, $sctx, $nid, $nctx) = @_;
+	is($srv, undef, "callback server");
+	is_deeply($sid, \%admin_session_guid, "callback session id");
+	is($sctx, undef, "callback session context");
+	is_deeply($nid, $nodes{some_variable_0}{nodeId}, "callback node id");
+	like($nctx, qr/^\d+$/, "callback node context");
+    }
+});
+addNode();
+deleteNode();
+
+my $data = "foo";
+lives_ok {
+    $server->{server}->setAdminSessionContext(\$data);
+} "set admin sessio context";
+
+$server->{config}->setGlobalNodeLifecycle({
+    GlobalNodeLifecycle_constructor => sub {
+	my ($srv, $sid, $sctx, $nid, $nctx) = @_;
+	is($srv, $server->{server}, "callback server scalar");
+	is($$sctx, "foo", "callback session context in");
+	$$sctx = "bar";
+    }
+});
+addNode();
+is($data, "bar", "callback session context out");
+deleteNode();
+
+no_leaks_ok {
+    $server->{server}->setAdminSessionContext("foobar");
+    $server->{config}->setGlobalNodeLifecycle({
+	GlobalNodeLifecycle_constructor => sub {
+	    my ($srv, $sid, $sctx, $nid, $nctx) = @_;
+	}
+    });
+    addNodeNotest();
+    deleteNodeNotest();
+} "callback leak";
+
+$data = "foo";
+{
+    my $callback = sub {
+	my ($srv, $sid, $sctx, $nid, $nctx) = @_;
+	is($$sctx, "foo", "callback livetime in");
+	$$sctx = "bar";
+    };
+    $server->{config}->setGlobalNodeLifecycle({
+	GlobalNodeLifecycle_constructor => $callback,
+    });
+    undef $callback;
+    $server->{server}->setAdminSessionContext(\$data);
+}
+addNode();
+is($data, "bar", "callback livetime out");
+deleteNode();

--- a/t/variant-guid.t
+++ b/t/variant-guid.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+use OPCUA::Open62541 qw(:TYPES);
+
+use Test::More tests => 24;
+use Test::Exception;
+use Test::LeakTrace;
+use Test::NoWarnings;
+
+ok(my $variant = OPCUA::Open62541::Variant->new(), "variant new");
+
+my $guid = "00000001-0002-0003-4142-434344454647";
+no_leaks_ok { $variant->setScalar($guid, TYPES_GUID) } "scalar set leak";
+ok($variant->isScalar(), "scalar is");
+is($variant->getScalar(), $guid, "scalar get");
+no_leaks_ok { $variant->getScalar() } "scalar get leak";
+
+$guid = "00000001-0002-0003-4142-434344454647-";
+throws_ok { $variant->setScalar($guid, TYPES_GUID) }
+    (qr/Guid string length 37 is not 36 /, "scalar long");
+no_leaks_ok { eval { $variant->setScalar($guid, TYPES_GUID) } }
+    "scalar long leak";
+
+$guid = "00000001-0002-0003-4142-43434445464";
+throws_ok { $variant->setScalar($guid, TYPES_GUID) }
+    (qr/Guid string length 35 is not 36 /, "scalar short");
+no_leaks_ok { eval { $variant->setScalar($guid, TYPES_GUID) } }
+    "scalar short leak";
+
+$guid = "00000001a0002-0003-4142-434344454647";
+throws_ok { $variant->setScalar($guid, TYPES_GUID) }
+    (qr/Guid string character 'a' at 8 is not - separator /,
+    "scalar separator 1");
+no_leaks_ok { eval { $variant->setScalar($guid, TYPES_GUID) } }
+    "scalar separator 1 leak";
+
+$guid = "00000001-0002b0003-4142-434344454647";
+throws_ok { $variant->setScalar($guid, TYPES_GUID) }
+    (qr/Guid string character 'b' at 13 is not - separator /,
+    "scalar separator 2");
+no_leaks_ok { eval { $variant->setScalar($guid, TYPES_GUID) } }
+    "scalar separator 2 leak";
+
+$guid = "00000001-0002-0003c4142-434344454647";
+throws_ok { $variant->setScalar($guid, TYPES_GUID) }
+    (qr/Guid string character 'c' at 18 is not - separator /,
+    "scalar separator 3");
+no_leaks_ok { eval { $variant->setScalar($guid, TYPES_GUID) } }
+    "scalar separator 3 leak";
+
+$guid = "00000001-0002-0003-4142d434344454647";
+throws_ok { $variant->setScalar($guid, TYPES_GUID) }
+    (qr/Guid string character 'd' at 23 is not - separator /,
+    "scalar separator 4");
+no_leaks_ok { eval { $variant->setScalar($guid, TYPES_GUID) } }
+    "scalar separator 4 leak";
+
+$guid = "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF";
+lives_ok { $variant->setScalar($guid, TYPES_GUID) } "scalar max lives";
+is($variant->getScalar(), $guid, "scalar max");
+
+$guid = "01234567-89ab-acdf-1234-aAbBcCdDeEfF";
+lives_ok { $variant->setScalar($guid, TYPES_GUID) } "scalar case lives";
+is($variant->getScalar(), uc($guid), "scalar case");
+
+$guid = "01234567-89ab-acdf-ghij-klmnopqrstuv";
+throws_ok { $variant->setScalar($guid, TYPES_GUID) }
+    (qr/Guid string character 'g' at 19 is not hex digit /, "scalar hex");
+no_leaks_ok { eval { $variant->setScalar($guid, TYPES_GUID) } }
+    "scalar scalar leak";

--- a/typemap
+++ b/typemap
@@ -21,6 +21,8 @@ UA_LogLevel				T_PACKED
 UA_LogCategory				T_PACKED
 # data type is special as it points to constant data
 OPCUA_Open62541_DataType		T_PACKED
+# struct with Perl callbacks converted from hash
+OPCUA_Open62541_GlobalNodeLifecycle	T_PACKED
 # these are used only as return value
 UA_BrowseResponse			T_RETVAL_PACKED
 UA_BrowseResult				T_RETVAL_PACKED


### PR DESCRIPTION
The formated Guid string as in Part 6, 5.1.3. seems to be the
easiest way to handle the Guid in Perl programs.  It can be printed
like all other node types.  The binary data we used before was
hard to work with.