### PR TITLE
CI open62541 1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build & Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     container:
-      image: ubuntu:18.04
+      image: ubuntu:20.04
     steps:
     - uses: actions/checkout@v2
     - name: apt update

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,6 +31,22 @@ check_lib(
     libpath		=> '/usr/local/lib',
     incpath		=> '/usr/local/include',
 ) and push @have, uc('UA_Server_readContainsNoLoops');
+check_lib(
+    function		=> "UA_Client_getState(NULL, NULL, NULL, NULL);",
+    not_execute		=> 1,
+    lib			=> 'open62541',
+    header		=> 'open62541/client.h',
+    libpath		=> '/usr/local/lib',
+    incpath		=> '/usr/local/include',
+) and push @have, uc('UA_Client_getState_3');
+check_lib(
+    function		=> "UA_Client_connectAsync(NULL, NULL);",
+    not_execute		=> 1,
+    lib			=> 'open62541',
+    header		=> 'open62541/client.h',
+    libpath		=> '/usr/local/lib',
+    incpath		=> '/usr/local/include',
+) and push @have, uc('UA_Client_connectAsync');
 my @defines = map { "-DHAVE_$_=1" } @have;
 
 WriteMakefile(

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,15 @@ check_lib(
     libpath		=> '/usr/local/lib',
     incpath		=> '/usr/local/include',
 ) and push @have, uc('UA_Server_setAdminSessionContext');
+check_lib(
+    function		=>
+	"UA_NodeId ni; UA_Server_readContainsNoLoops(NULL, ni, NULL);",
+    not_execute		=> 1,
+    lib			=> 'open62541',
+    header		=> 'open62541/server.h',
+    libpath		=> '/usr/local/lib',
+    incpath		=> '/usr/local/include',
+) and push @have, uc('UA_Server_readContainsNoLoops');
 my @defines = map { "-DHAVE_$_=1" } @have;
 
 WriteMakefile(

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -1392,11 +1392,13 @@ server_run_mgset(pTHX_ SV* sv, MAGIC* mg)
 
 static MGVTBL server_run_mgvtbl = { 0, server_run_mgset, 0, 0, 0, 0, 0, 0 };
 
+#ifndef HAVE_UA_SERVER_READCONTAINSNOLOOPS
+
 /*
- * There is a typo in open62541 server read readContainsNoLoops,
+ * There is a typo in open62541 1.0 server read readContainsNoLoops,
  * the final s in the function name is missing.  Translate it to
  * get standard conforming name in Perl.
- * This code will break and can be removed when upstream fixes the bug.
+ * This code is not needed for open62541 1.1 as upstream has fixed the bug.
  */
 static UA_StatusCode
 UA_Server_readContainsNoLoops(UA_Server *server, const UA_NodeId nodeId,
@@ -1404,6 +1406,8 @@ UA_Server_readContainsNoLoops(UA_Server *server, const UA_NodeId nodeId,
 {
     return UA_Server_readContainsNoLoop(server, nodeId, outContainsNoLoops);
 }
+
+#endif /* HAVE_UA_SERVER_READCONTAINSNOLOOPS */
 
 /* 11.7.1 Node Lifecycle: Constructors, Destructors and Node Contexts */
 

--- a/t/client-connect-async.t
+++ b/t/client-connect-async.t
@@ -7,9 +7,16 @@ use Time::HiRes qw(sleep);
 
 use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
-use Test::More tests =>
-    OPCUA::Open62541::Test::Server::planning() +
-    OPCUA::Open62541::Test::Client::planning() * 4 + 8;
+use Test::More;
+BEGIN {
+    if (OPCUA::Open62541::Client->can('connect_async')) {
+	plan tests =>
+	    OPCUA::Open62541::Test::Server::planning() +
+	    OPCUA::Open62541::Test::Client::planning() * 4 + 8;
+    } else {
+	plan skip_all => "No UA_Client_connect_async in open62541";
+    }
+}
 use Test::Exception;
 use Test::NoWarnings;
 use Test::LeakTrace;

--- a/t/client-disconnect-async.t
+++ b/t/client-disconnect-async.t
@@ -5,9 +5,16 @@ use Scalar::Util qw(looks_like_number);
 
 use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
-use Test::More tests =>
-    OPCUA::Open62541::Test::Server::planning() +
-    OPCUA::Open62541::Test::Client::planning() * 3 + 5;
+use Test::More;
+BEGIN {
+    if (OPCUA::Open62541::Client->can('disconnect_async')) {
+	plan tests =>
+	    OPCUA::Open62541::Test::Server::planning() +
+	    OPCUA::Open62541::Test::Client::planning() * 3 + 5;
+    } else {
+	plan skip_all => "No UA_Client_disconnect_async in open62541";
+    }
+}
 use Test::Exception;
 use Test::NoWarnings;
 use Test::LeakTrace;

--- a/t/client-leak.t
+++ b/t/client-leak.t
@@ -46,6 +46,9 @@ my $server = IO::Socket::INET->new(
 ok($server, "server") or diag "server new and listen failed: $!";
 my $port = $server->sockport();
 
+SKIP: {
+    skip "No UA_Client_disconnect_async in open62541", 5
+	unless OPCUA::Open62541::Client->can('connect_async');
 ($sok, $cok, $dok, my $aok) = (0, 0, 0, 0);
 no_leaks_ok {
     my $client = OPCUA::Open62541::Client->new();
@@ -67,3 +70,4 @@ ok($sok, "client async new");
 ok($cok, "config async get");
 ok($dok, "default async set");
 ok($aok, "client async connect");
+}  # SKIP

--- a/t/test-server-singlestep.t
+++ b/t/test-server-singlestep.t
@@ -4,7 +4,14 @@ use OPCUA::Open62541 qw(:STATUSCODE :CLIENTSTATE);
 
 use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
-use Test::More tests => OPCUA::Open62541::Test::Server::planning() + 20;
+use Test::More;
+BEGIN {
+    if (OPCUA::Open62541::Client->can('connect_async')) {
+	plan tests => OPCUA::Open62541::Test::Server::planning() + 20;
+    } else {
+	plan skip_all => "No UA_Client_connect_async in open62541";
+    }
+}
 use Test::LeakTrace;
 use Test::NoWarnings;
 use Time::HiRes qw(sleep);


### PR DESCRIPTION
github CI uses open62541 library version 1.1 now.  Add some #ifdef to make p5-opcua-open62541 compile with the new library.  Update to Ubuntu 20.4.  Tests still fail, logger-client.t causes a segmentation fault.