### PR TITLE
Make copy of client callback.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -1611,21 +1611,18 @@ newClientCallbackData(SV *callback, SV *client, SV *data)
 	DPRINTF("ccd %p", ccd);
 
 	/*
-	 * XXX should we make a copy of the callback?
+	 * Make a copy of the callback.
 	 * see perlcall, Using call_sv, newSVsv()
 	 */
-	ccd->ccd_callback = callback;
-	ccd->ccd_client = client;
-	ccd->ccd_data = data;
-
+	ccd->ccd_callback = newSVsv(callback);
 	/*
 	 * Client remembers a ref to callback data and destroys it when freed.
 	 * So we must not increase the Perl refcount of the client.  Perl must
 	 * free the client and then the callback data is destroyed.
 	 * This API sucks.  Callbacks that may be called are hard to handle.
 	 */
-	SvREFCNT_inc(callback);
-	SvREFCNT_inc(data);
+	ccd->ccd_client = client;
+	ccd->ccd_data = SvREFCNT_inc(data);
 
 	return ccd;
 }

--- a/t/client-browse-async.t
+++ b/t/client-browse-async.t
@@ -6,7 +6,7 @@ use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
 use Test::More tests =>
     OPCUA::Open62541::Test::Server::planning() +
-    OPCUA::Open62541::Test::Client::planning() + 50;
+    OPCUA::Open62541::Test::Client::planning() + 53;
 use Test::Deep;
 use Test::Exception;
 use Test::NoWarnings;
@@ -384,6 +384,27 @@ no_leaks_ok { eval {
 	undef,
     );
 } } "sendAsyncBrowseRequest bad callback leak";
+
+### callback changed
+
+$browsed = 0;
+my $callback = sub {
+    my ($c, $d, $i, $r) = @_;
+    pass "callback correct";
+    $browsed = 1;
+};
+is($client->{client}->sendAsyncBrowseRequest(
+    $request,
+    $callback,
+    undef,
+    undef,
+), STATUSCODE_GOOD, "sendAsyncBrowseRequest callback correct");
+$callback = sub {
+    my ($c, $d, $i, $r) = @_;
+    fail "callback correct";
+    $browsed = 1;
+};
+$client->iterate(\$browsed, "callback correct");
 
 ### multiple requests
 # Call sendAsyncBrowseRequest() multiple times.  Check that request


### PR DESCRIPTION
Perl callbacks should be copied from the CV, not referenced.
Otherwise they can be changed after setting them.