### PR TITLE
Handle NULL node context.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -1510,6 +1510,8 @@ serverGlobalNodeLifecycleConstructor(UA_Server *ua_server,
 	}
 	PUSHs(sv);
 	/* Constructor uses reference to context, pass a reference to Perl. */
+	if (*nodeContext == NULL)
+		*nodeContext = newSV(0);
 	sv = *nodeContext;
 	mPUSHs(newRV_inc(sv));
 	PUTBACK;
@@ -2392,6 +2394,8 @@ UA_Server_addVariableNode(server, requestedNewNodeId, parentNodeId, referenceTyp
 	SV *				nodeContext
 	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
+	if (!SvOK(nodeContext))
+		nodeContext = NULL;
 #ifndef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
 	nodeContext = NULL;
 #endif
@@ -2415,6 +2419,8 @@ UA_Server_addVariableTypeNode(server, requestedNewNodeId, parentNodeId, referenc
 	SV *				nodeContext
 	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
+	if (!SvOK(nodeContext))
+		nodeContext = NULL;
 #ifndef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
 	nodeContext = NULL;
 #endif
@@ -2438,6 +2444,8 @@ UA_Server_addObjectNode(server, requestedNewNodeId, parentNodeId, referenceTypeI
 	SV *				nodeContext
 	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
+	if (!SvOK(nodeContext))
+		nodeContext = NULL;
 #ifndef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
 	nodeContext = NULL;
 #endif
@@ -2460,6 +2468,8 @@ UA_Server_addObjectTypeNode(server, requestedNewNodeId, parentNodeId, referenceT
 	SV *				nodeContext
 	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
+	if (!SvOK(nodeContext))
+		nodeContext = NULL;
 #ifndef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
 	nodeContext = NULL;
 #endif
@@ -2482,6 +2492,8 @@ UA_Server_addViewNode(server, requestedNewNodeId, parentNodeId, referenceTypeId,
 	SV *				nodeContext
 	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
+	if (!SvOK(nodeContext))
+		nodeContext = NULL;
 #ifndef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
 	nodeContext = NULL;
 #endif
@@ -2504,6 +2516,8 @@ UA_Server_addReferenceTypeNode(server, requestedNewNodeId, parentNodeId, referen
 	SV *				nodeContext
 	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
+	if (!SvOK(nodeContext))
+		nodeContext = NULL;
 #ifndef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
 	nodeContext = NULL;
 #endif
@@ -2526,6 +2540,8 @@ UA_Server_addDataTypeNode(server, requestedNewNodeId, parentNodeId, referenceTyp
 	SV *				nodeContext
 	OPCUA_Open62541_NodeId		outoptNewNodeId
     CODE:
+	if (!SvOK(nodeContext))
+		nodeContext = NULL;
 #ifndef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
 	nodeContext = NULL;
 #endif


### PR DESCRIPTION
According to documentation, server node context may be NULL if node
is created by client.  Store undef context as NULL and handle NULL
properly in the gobal node lifecycle constructor.