### PR TITLE
Make pack/unpack of ExtensionObject consistent

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -1040,6 +1040,7 @@ XS_pack_UA_ExtensionObject(SV *out, UA_ExtensionObject in)
 	OPCUA_Open62541_DataType type;
 	SV *sv;
 	HV *hv = newHV();
+	HV *content = newHV();
 
 	sv = newSV(0);
 	XS_pack_UA_Int32(sv, in.encoding);
@@ -1051,11 +1052,11 @@ XS_pack_UA_ExtensionObject(SV *out, UA_ExtensionObject in)
 	case UA_EXTENSIONOBJECT_ENCODED_XML:
 		sv = newSV(0);
 		XS_pack_UA_NodeId(sv, in.content.encoded.typeId);
-		hv_stores(hv, "ExtensionObject_content_typeId", sv);
+		hv_stores(content, "ExtensionObject_content_typeId", sv);
 
 		sv = newSV(0);
 		XS_pack_UA_ByteString(sv, in.content.encoded.body);
-		hv_stores(hv, "ExtensionObject_content_body", sv);
+		hv_stores(content, "ExtensionObject_content_body", sv);
 
 		break;
 	case UA_EXTENSIONOBJECT_DECODED:
@@ -1069,17 +1070,18 @@ XS_pack_UA_ExtensionObject(SV *out, UA_ExtensionObject in)
 
 		sv = newSV(0);
 		XS_pack_OPCUA_Open62541_DataType(sv, type);
-		hv_stores(hv, "ExtensionObject_content_type", sv);
+		hv_stores(content, "ExtensionObject_content_type", sv);
 
 		sv = newSV(0);
 		(pack_UA_table[type->typeIndex])(sv, in.content.decoded.data);
-		hv_stores(hv, "ExtensionObject_content_data", sv);
+		hv_stores(content, "ExtensionObject_content_data", sv);
 
 		break;
 	default:
 		CROAK("ExtensionObject_encoding %d unknown", (int)in.encoding);
 	}
 
+	hv_stores(hv, "ExtensionObject_content", newRV_noinc((SV*)content));
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 }
 

--- a/t/client-browse-async.t
+++ b/t/client-browse-async.t
@@ -204,12 +204,14 @@ my $response = {
     },
     'ResponseHeader_serviceResult' => 'Good',
     'ResponseHeader_additionalHeader' => {
-      'ExtensionObject_content_typeId' => {
-	'NodeId_identifier' => 0,
-	'NodeId_identifierType' => 0,
-	'NodeId_namespaceIndex' => 0
+      'ExtensionObject_content' => {
+	'ExtensionObject_content_typeId' => {
+	  'NodeId_identifier' => 0,
+	  'NodeId_identifierType' => 0,
+	  'NodeId_namespaceIndex' => 0
+	},
+	'ExtensionObject_content_body' => undef,
       },
-      'ExtensionObject_content_body' => undef,
       'ExtensionObject_encoding' => 0
     }
   }

--- a/t/client-browse.t
+++ b/t/client-browse.t
@@ -202,12 +202,14 @@ my %response = (
     },
     'ResponseHeader_serviceResult' => 'Good',
     'ResponseHeader_additionalHeader' => {
-      'ExtensionObject_content_typeId' => {
-	'NodeId_identifier' => 0,
-	'NodeId_identifierType' => 0,
-	'NodeId_namespaceIndex' => 0
+      'ExtensionObject_content' => {
+	'ExtensionObject_content_typeId' => {
+	  'NodeId_identifier' => 0,
+	  'NodeId_identifierType' => 0,
+	  'NodeId_namespaceIndex' => 0
+	},
+	'ExtensionObject_content_body' => undef,
       },
-      'ExtensionObject_content_body' => undef,
       'ExtensionObject_encoding' => 0
     }
   }

--- a/t/client-browsenext-async.t
+++ b/t/client-browsenext-async.t
@@ -99,12 +99,14 @@ my $responses = [{
     },
     'ResponseHeader_serviceResult' => 'Good',
     'ResponseHeader_additionalHeader' => {
-      'ExtensionObject_content_typeId' => {
-	'NodeId_identifier' => 0,
-	'NodeId_identifierType' => 0,
-	'NodeId_namespaceIndex' => 0
+      'ExtensionObject_content' => {
+	'ExtensionObject_content_typeId' => {
+	  'NodeId_identifier' => 0,
+	  'NodeId_identifierType' => 0,
+	  'NodeId_namespaceIndex' => 0
+	},
+	'ExtensionObject_content_body' => undef,
       },
-      'ExtensionObject_content_body' => undef,
       'ExtensionObject_encoding' => 0
     }
   }
@@ -174,12 +176,14 @@ my $responses = [{
     },
     'ResponseHeader_serviceResult' => 'Good',
     'ResponseHeader_additionalHeader' => {
-      'ExtensionObject_content_typeId' => {
-	'NodeId_identifier' => 0,
-	'NodeId_identifierType' => 0,
-	'NodeId_namespaceIndex' => 0
+      'ExtensionObject_content' => {
+	'ExtensionObject_content_typeId' => {
+	  'NodeId_identifier' => 0,
+	  'NodeId_identifierType' => 0,
+	  'NodeId_namespaceIndex' => 0
+	},
+	'ExtensionObject_content_body' => undef,
       },
-      'ExtensionObject_content_body' => undef,
       'ExtensionObject_encoding' => 0
     }
   }

--- a/t/client-read-async.t
+++ b/t/client-read-async.t
@@ -63,12 +63,14 @@ my $response = {
 	},
 	'ResponseHeader_serviceResult' => 'Good',
 	'ResponseHeader_additionalHeader' => {
-	    'ExtensionObject_content_typeId' => {
+	    'ExtensionObject_content' => {
+	      'ExtensionObject_content_typeId' => {
 		'NodeId_identifier' => 0,
 		'NodeId_identifierType' => 0,
 		'NodeId_namespaceIndex' => 0
+	      },
+	      'ExtensionObject_content_body' => undef,
 	    },
-	    'ExtensionObject_content_body' => undef,
 	    'ExtensionObject_encoding' => 0
 	}
     }


### PR DESCRIPTION
* The original idea for ExtensionObjects in perl was to have the content
  in a separate hash. But XS_pack_UA_ExtensionObject() did not do this
  until now and placed the content keys directly into th ExtensionObject
  hash.
* This caused issues when trying to unpack previously packed
  ExtensionObjects.