### PR TITLE
Fix ValueRank in Tests

### DIFF
--- a/lib/OPCUA/Open62541/Test/Server.pm
+++ b/lib/OPCUA/Open62541/Test/Server.pm
@@ -3,7 +3,7 @@ use warnings;
 
 package OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Logger;
-use OPCUA::Open62541 qw(:ACCESSLEVELMASK :NODEIDTYPE :STATUSCODE :TYPES);
+use OPCUA::Open62541 qw(:ACCESSLEVELMASK :NODEIDTYPE :STATUSCODE :TYPES :VALUERANK);
 use Carp 'croak';
 use Errno 'EINTR';
 use Net::EmptyPort qw(empty_port);
@@ -121,6 +121,7 @@ sub setup_complex_objects {
 	    VariableTypeAttributes_description => {
 		LocalizedText_text	=> 'This defines some variable type'
 	    },
+	    VariableTypeAttributes_valueRank	=> VALUERANK_SCALAR,
 	},
     };
     $nodes{some_object_type} = {
@@ -186,6 +187,7 @@ sub setup_complex_objects {
 		Variant_type		=> TYPES_INT32,
 		Variant_scalar		=> 42,
 	    },
+	    VariableAttributes_valueRank	=> VALUERANK_SCALAR,
 	    VariableAttributes_accessLevel	=>
 		ACCESSLEVELMASK_READ | ACCESSLEVELMASK_WRITE,
 	},

--- a/t/server-client-variable.t
+++ b/t/server-client-variable.t
@@ -55,6 +55,7 @@ my %attr = (
 	Variant_type                    => TYPES_INT32,
 	Variant_scalar                  => 42,
     },
+    VariableAttributes_valueRank        => VALUERANK_SCALAR,
     VariableAttributes_dataType         => TYPES_INT32,
     VariableAttributes_accessLevel      =>
 	ACCESSLEVELMASK_READ | ACCESSLEVELMASK_WRITE,

--- a/t/server-variable.t
+++ b/t/server-variable.t
@@ -49,6 +49,7 @@ my %attr = (
 	Variant_type			=> TYPES_INT32,
 	Variant_scalar			=> 42,
     },
+    VariableAttributes_valueRank        => VALUERANK_SCALAR,
     VariableAttributes_dataType		=> TYPES_INT32,
     VariableAttributes_accessLevel	=>
 	ACCESSLEVELMASK_READ | ACCESSLEVELMASK_WRITE,

--- a/t/test-server-runtimeaction.t
+++ b/t/test-server-runtimeaction.t
@@ -44,6 +44,7 @@ my %attr = (
 	Variant_type                    => TYPES_INT32,
 	Variant_scalar                  => 42,
     },
+    VariableAttributes_valueRank        => VALUERANK_SCALAR,
     VariableAttributes_dataType         => TYPES_INT32,
     VariableAttributes_accessLevel      =>
 	ACCESSLEVELMASK_READ | ACCESSLEVELMASK_WRITE,

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -63,6 +63,7 @@ my %attr = (
 	Variant_type			=> TYPES_BYTESTRING,
 	Variant_scalar			=> "bytestring $octets unicode",
     },
+    VariableAttributes_valueRank	=> VALUERANK_SCALAR,
     VariableAttributes_dataType		=> TYPES_BYTESTRING,
     VariableAttributes_accessLevel	=>
 	ACCESSLEVELMASK_READ | ACCESSLEVELMASK_WRITE,


### PR DESCRIPTION
* Until now the ValueRank was not explicitly set for variable nodes,
  which meant that the value was 0 (indicating an array). This was wrong
  and also will not work with newer versions of open62541.
* Fixed the ValueRank attribute in all addVariableNode calls.