### PR TITLE
Set client context in config.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -168,6 +168,7 @@ typedef struct ClientCallbackData {
 typedef struct OPCUA_Open62541_ClientConfig {
 	struct OPCUA_Open62541_Logger	clc_logger;
 	UA_ClientConfig *	clc_clientconfig;
+	SV *			clc_clientcontext;
 	SV *			clc_storage;
 } * OPCUA_Open62541_ClientConfig;
 
@@ -3367,6 +3368,7 @@ UA_ClientConfig_DESTROY(config)
     CODE:
 	DPRINTF("config %p, clc_clientconfig %p, clc_storage %p",
 	    config, config->clc_clientconfig, config->clc_storage);
+	SvREFCNT_dec(config->clc_clientcontext);
 	/* Delayed client destroy after client config destroy. */
 	SvREFCNT_dec(config->clc_storage);
 
@@ -3377,6 +3379,22 @@ UA_ClientConfig_setDefault(config)
 	RETVAL = UA_ClientConfig_setDefault(config->clc_clientconfig);
     OUTPUT:
 	RETVAL
+
+SV *
+UA_ClientConfig_getClientContext(config)
+	OPCUA_Open62541_ClientConfig	config
+    CODE:
+	RETVAL = newSVsv(config->clc_clientcontext);
+    OUTPUT:
+	RETVAL
+
+void
+UA_ClientConfig_setClientContext(config, context)
+	OPCUA_Open62541_ClientConfig	config
+	SV *				context
+    CODE:
+	SvREFCNT_dec(config->clc_clientcontext);
+	config->clc_clientcontext = newSVsv(context);
 
 OPCUA_Open62541_Logger
 UA_ClientConfig_getLogger(config)

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -222,6 +222,10 @@ run_iterate() or open62541 may try to operate on a non existent socket.
 
 =item $status_code = $client_config->setDefault()
 
+=item $context = $client_config->getClientContext()
+
+=item $client_config->setClientContext($context)
+
 =item $logger = $client_config->getLogger()
 
 =back

--- a/t/client-config-context.t
+++ b/t/client-config-context.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use OPCUA::Open62541;
+
+use Test::More tests => 11;
+use Test::Exception;
+use Test::LeakTrace;
+use Test::NoWarnings;
+
+ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+ok(my $config = $client->getConfig(), "config get");
+
+is(my $context = $config->getClientContext(), undef, "context undef");
+no_leaks_ok { $config->getClientContext() } "context undef leak";
+
+$context = "foo";
+lives_ok { $config->setClientContext($context) } "set context";
+no_leaks_ok { $config->setClientContext($context) } "set context leak";
+is($config->getClientContext(), "foo", "context foo");
+$context = "bar";
+is($config->getClientContext(), "foo", "context not bar");
+no_leaks_ok { $config->getClientContext() } "context foo leak";
+
+no_leaks_ok {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setClientContext("foo");
+} "context leak";


### PR DESCRIPTION
Implement a wrapper for client context.  This can be used for client
callbacks later.