### PR TITLE
Subscriptions - Limits

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -3470,6 +3470,105 @@ UA_ServerConfig_setMaxMonitoredItemsPerCall(config, maxMonitoredItemsPerCall)
 	config->svc_serverconfig->maxMonitoredItemsPerCall =
 	    maxMonitoredItemsPerCall;
 
+# Limits for Subscriptions
+
+UA_UInt32
+UA_ServerConfig_getMaxSubscriptions(config)
+	OPCUA_Open62541_ServerConfig	config
+    CODE:
+	RETVAL = config->svc_serverconfig->maxSubscriptions;
+    OUTPUT:
+	RETVAL
+
+void
+UA_ServerConfig_setMaxSubscriptions(config, maxSubscriptions)
+	OPCUA_Open62541_ServerConfig	config
+	UA_UInt32			maxSubscriptions
+    CODE:
+	config->svc_serverconfig->maxSubscriptions = maxSubscriptions;
+
+UA_UInt32
+UA_ServerConfig_getMaxSubscriptionsPerSession(config)
+	OPCUA_Open62541_ServerConfig	config
+    CODE:
+	RETVAL = config->svc_serverconfig->maxSubscriptionsPerSession;
+    OUTPUT:
+	RETVAL
+
+void
+UA_ServerConfig_setMaxSubscriptionsPerSession(config, maxSubscriptionsPerSession)
+	OPCUA_Open62541_ServerConfig	config
+	UA_UInt32			maxSubscriptionsPerSession
+    CODE:
+	config->svc_serverconfig->maxSubscriptionsPerSession =
+	    maxSubscriptionsPerSession;
+
+UA_UInt32
+UA_ServerConfig_getMaxNotificationsPerPublish(config)
+	OPCUA_Open62541_ServerConfig	config
+    CODE:
+	RETVAL = config->svc_serverconfig->maxNotificationsPerPublish;
+    OUTPUT:
+	RETVAL
+
+void
+UA_ServerConfig_setMaxNotificationsPerPublish(config, maxNotificationsPerPublish)
+	OPCUA_Open62541_ServerConfig	config
+	UA_UInt32			maxNotificationsPerPublish
+    CODE:
+	config->svc_serverconfig->maxNotificationsPerPublish =
+	    maxNotificationsPerPublish;
+
+UA_Boolean
+UA_ServerConfig_getEnableRetransmissionQueue(config)
+	OPCUA_Open62541_ServerConfig	config
+    CODE:
+	RETVAL = config->svc_serverconfig->enableRetransmissionQueue;
+    OUTPUT:
+	RETVAL
+
+void
+UA_ServerConfig_setEnableRetransmissionQueue(config, enableRetransmissionQueue)
+	OPCUA_Open62541_ServerConfig	config
+	UA_Boolean			enableRetransmissionQueue
+    CODE:
+	config->svc_serverconfig->enableRetransmissionQueue =
+	    enableRetransmissionQueue;
+
+UA_UInt32
+UA_ServerConfig_getMaxRetransmissionQueueSize(config)
+	OPCUA_Open62541_ServerConfig	config
+    CODE:
+	RETVAL = config->svc_serverconfig->maxRetransmissionQueueSize;
+    OUTPUT:
+	RETVAL
+
+void
+UA_ServerConfig_setMaxRetransmissionQueueSize(config, maxRetransmissionQueueSize)
+	OPCUA_Open62541_ServerConfig	config
+	UA_UInt32			maxRetransmissionQueueSize
+    CODE:
+	config->svc_serverconfig->maxRetransmissionQueueSize = maxRetransmissionQueueSize;
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
+
+UA_UInt32
+UA_ServerConfig_getMaxEventsPerNode(config)
+	OPCUA_Open62541_ServerConfig	config
+    CODE:
+	RETVAL = config->svc_serverconfig->maxEventsPerNode;
+    OUTPUT:
+	RETVAL
+
+void
+UA_ServerConfig_setMaxEventsPerNode(config, maxEventsPerNode)
+	OPCUA_Open62541_ServerConfig	config
+	UA_UInt32			maxEventsPerNode
+    CODE:
+	config->svc_serverconfig->maxEventsPerNode = maxEventsPerNode;
+
+#endif /* UA_ENABLE_SUBSCRIPTIONS_EVENTS */
+
 
 # AccessControl plugin callbacks
 
@@ -3981,7 +4080,7 @@ UA_Client_Subscriptions_create(client, request, subscriptionContext, statusChang
 	    ccds, clientStatusChangeNotificationCallback, clientDeleteSubscriptionCallback);
 
 	if (RETVAL.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
-		if (ccds[OPEN62541_PERLCB_CLIENTSTATUSCHANGENOTIFICATION])
+		if (ccds[OPEN62541_PERLCB_CLIENTDELETESUBSCRIPTION])
 			deleteClientCallbackData(ccds[OPEN62541_PERLCB_CLIENTDELETESUBSCRIPTION]);
 		if (ccds[OPEN62541_PERLCB_CLIENTSTATUSCHANGENOTIFICATION])
 			deleteClientCallbackData(ccds[OPEN62541_PERLCB_CLIENTSTATUSCHANGENOTIFICATION]);

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -273,6 +273,30 @@ in the callback.
 
 =item $server_config->setMaxMonitoredItemsPerCall($maxMonitoredItemsPerCall)
 
+=item $limit = $server_config->getMaxSubscriptions()
+
+=item $server_config->setMaxSubscriptions($maxSubscriptions)
+
+=item $limit = $server_config->getMaxSubscriptionsPerSession()
+
+=item $server_config->setMaxSubscriptionsPerSession($maxSubscriptionsPerSession)
+
+=item $limit = $server_config->getMaxNotificationsPerPublish()
+
+=item $server_config->setMaxNotificationsPerPublish($maxNotificationsPerPublish)
+
+=item $limit = $server_config->getEnableRetransmissionQueue()
+
+=item $server_config->setEnableRetransmissionQueue($enableRetransmissionQueue)
+
+=item $limit = $server_config->getMaxRetransmissionQueueSize()
+
+=item $server_config->setMaxRetransmissionQueueSize($maxRetransmissionQueueSize)
+
+=item $limit = $server_config->getMaxEventsPerNode()
+
+=item $server_config->setMaxEventsPerNode($maxEventsPerNode)
+
 =item $server_config->setUserRightsMaskReadonly($readonly)
 
 If $readonly is set to true, only reading of attributes is allowed.

--- a/t/server-config-default.t
+++ b/t/server-config-default.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use OPCUA::Open62541;
 
-use Test::More tests => 69;
+use Test::More tests => 94;
 use Test::Deep;
 use Test::Exception;
 use Test::LeakTrace;
@@ -159,3 +159,58 @@ ok(my $maxmonitoreditemspercall = $config->getMaxMonitoredItemsPerCall(),
 no_leaks_ok { $config->getMaxMonitoredItemsPerCall() }
     "max monitored items per call leak";
 is($maxmonitoreditemspercall, 10008, "max max monitored items per call");
+
+lives_ok { $config->setMaxSubscriptions(42) }
+    "set max subscriptions";
+no_leaks_ok { $config->setMaxSubscriptions(42) }
+    "set max subscriptions leak";
+
+ok(my $maxsubscriptions = $config->getMaxSubscriptions(),
+    "get max subscriptions");
+no_leaks_ok { $config->getMaxSubscriptions() }
+    "get max subscriptions leak";
+is($maxsubscriptions, 42, "custom max subscriptions");
+
+lives_ok { $config->setMaxSubscriptionsPerSession(42) }
+    "set max subscriptions per session";
+no_leaks_ok { $config->setMaxSubscriptionsPerSession(42) }
+    "set max subscriptions per session leak";
+
+ok(my $maxsubscriptionspersession = $config->getMaxSubscriptionsPerSession(),
+    "get max subscriptions per session");
+no_leaks_ok { $config->getMaxSubscriptionsPerSession() }
+    "get max subscriptions per session leak";
+is($maxsubscriptionspersession, 42, "custom max subscriptions per session");
+
+lives_ok { $config->setMaxNotificationsPerPublish(42) }
+    "set max notifications per publish";
+no_leaks_ok { $config->setMaxNotificationsPerPublish(42) }
+    "set max notifications per publish leak";
+
+ok(my $maxnotificationsperpublish = $config->getMaxNotificationsPerPublish(),
+    "get max notifications per publish");
+no_leaks_ok { $config->getMaxNotificationsPerPublish() }
+    "get max notifications per publish leak";
+is($maxnotificationsperpublish, 42, "custom max notifications per publish");
+
+lives_ok { $config->setEnableRetransmissionQueue(1) }
+    "set enable retransmission queue";
+no_leaks_ok { $config->setEnableRetransmissionQueue(1) }
+    "set enable retransmission queue leak";
+
+ok(my $enableretransmissionqueue = $config->getEnableRetransmissionQueue(),
+    "get enable retransmission queue");
+no_leaks_ok { $config->getEnableRetransmissionQueue() }
+    "get enable retransmission queue leak";
+is($enableretransmissionqueue, 1, "custom enable retransmission queue");
+
+lives_ok { $config->setMaxRetransmissionQueueSize(42) }
+    "set max retransmission queue size";
+no_leaks_ok { $config->setMaxRetransmissionQueueSize(42) }
+    "set max retransmission queue size leak";
+
+ok(my $maxretransmissionqueuesize = $config->getMaxRetransmissionQueueSize(),
+    "get max retransmission queue size");
+no_leaks_ok { $config->getMaxRetransmissionQueueSize() }
+    "get max retransmission queue size leak";
+is($maxretransmissionqueuesize, 42, "custom max retransmission queue size");


### PR DESCRIPTION
* Most of the subscription limits from server_config.h can now be read
  and written with get/set functions.
* "publishingIntervalLimits", "lifeTimeCountLimits" and
  "keepAliveCountLimits" are skipped because the underlying range data
  structures are missing some initialization functions in the open62541
  library and the pack/unpack functions would need special handling.
* There is also now a test that looks for leaks if the
  Subscriptions_create() function fails and this test also uncovered a
  typo/bug in the existing cleanup code.
* I also adapted one of the subscription callback tests, to actually get
  the context from the callback arguments and not use the context
  variable from outside the callback.