### PR TITLE
Subscriptions - Cleanup

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -38,6 +38,7 @@ t/client-leak.t
 t/client-read-async.t
 t/client-server-read-write.t
 t/client-statecallback.t
+t/client-subscription.t
 t/client-variant.t
 t/client.t
 t/critic.t

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -672,9 +672,9 @@ run_iterate() or open62541 may try to operate on a non existent socket.
 
 =over 8
 
-=item $statusChangeCallback = sub { my ($client, $subscriptionContext, $subscriptionId, $notification) = @_ }
+=item $statusChangeCallback = sub { my ($client, $subscriptionId, $subscriptionContext, $notification) = @_ }
 
-=item $deleteCallback = sub { my ($client, $subscriptionContext, $subscriptionId) = @_ }
+=item $deleteCallback = sub { my ($client, $subscriptionId, $subscriptionContext) = @_ }
 
 =back
 

--- a/t/client-subscription.t
+++ b/t/client-subscription.t
@@ -55,7 +55,7 @@ my $response = $client->{client}->Subscriptions_create(
     \$context,
     sub {$context++},
     sub {
-	my ($client, $ctx, $id) = @_;
+	my ($client, $id, $ctx) = @_;
 	$deleted = 1;
 	$$ctx = $id;
     },


### PR DESCRIPTION
* Reorder callback defines according to order in client_subscriptions.h
* Print C callback debug message regardless of perl callback
* Reorder perl callback arguments to be the same as the C callback
* Renamed generic "sv" to a better name
* Added missing subscription test to MANIFEST