### PR TITLE
Detect call to monitored item delete callback.

### DIFF
--- a/t/client-monitoreditems.t
+++ b/t/client-monitoreditems.t
@@ -7,7 +7,7 @@ use OPCUA::Open62541::Test::Server;
 
 use Test::More tests =>
     OPCUA::Open62541::Test::Server::planning() +
-    OPCUA::Open62541::Test::Client::planning() + 41;
+    OPCUA::Open62541::Test::Client::planning() + 42;
 use Test::Deep;
 use Test::Exception;
 use Test::LeakTrace;
@@ -100,8 +100,16 @@ is($response->{MonitoredItemCreateResult_statusCode},
    "BadSubscriptionIdInvalid",
    "monitored items create fail response statuscode");
 
-ok($deleted,
-   "subscription deleted callback");
+ok(my $buildinfo = $server->{config}->getBuildInfo());
+note explain $buildinfo;
+# the semantics whether the callback is called in case of error has changed
+if ($buildinfo->{BuildInfo_softwareVersion} =~ /^1\.0\./) {
+    ok($deleted,
+       "subscription deleted callback");
+} else {
+    is($deleted, undef,
+       "subscription deleted callback");
+}
 
 my $expected_response = {
     MonitoredItemCreateResult_filterResult => ignore(),


### PR DESCRIPTION
The open62541 library behaves inconsistently whether callbacks will
be called if registering the callback fails.  This make memory
managent hard, especially when multiple versions of the library
should be supported.
Register a pointer to the monitored item context and delete it if
the delete callback is called.  If the pointer is not NULL, the
callback data is still pending and must be freed.