### PR TITLE
Use MonitoredItemArrays to implement callback memory management.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -189,8 +189,15 @@ typedef struct {
 typedef struct MonitoredItemContext {
 	ClientCallbackData	mc_change;
 	ClientCallbackData	mc_delete;
-	struct MonitoredItemContext **	mc_callbackdataref;
+	SV *			mc_arrays;
 } * MonitoredItemContext;
+
+typedef struct MonitoredItemArrays {
+	MonitoredItemContext				ma_mon;
+	void **						ma_context;
+	UA_Client_DataChangeNotificationCallback *	ma_change;
+	UA_Client_DeleteMonitoredItemCallback *		ma_delete;
+} * OPCUA_Open62541_MonitoredItemArrays;
 
 static void XS_pack_OPCUA_Open62541_DataType(SV *, OPCUA_Open62541_DataType)
     __attribute__((unused));
@@ -2150,11 +2157,7 @@ clientDeleteMonitoredItemCallback(UA_Client *client, UA_UInt32 subId,
 	if (mon->mc_change)
 		deleteClientCallbackData(mon->mc_change);
 
-	/* The callback data is freed now, do not remember to free it later. */
-	if (mon->mc_callbackdataref != NULL)
-		*mon->mc_callbackdataref = NULL;
-
-	free(mon);
+	SvREFCNT_dec(mon->mc_arrays);
 }
 
 static void
@@ -2668,6 +2671,23 @@ INCLUDE: Open62541-statuscode.xsh
 
 #############################################################################
 INCLUDE: Open62541-destroy.xsh
+
+#############################################################################
+MODULE = OPCUA::Open62541	PACKAGE = OPCUA::Open62541::MonitoredItemArrays
+
+void
+MonitoredItemArrays_DESTROY(marr)
+	OPCUA_Open62541_MonitoredItemArrays		marr;
+    CODE:
+	DPRINTF("marr %p, ma_mon %p, ma_context %p, ma_change %p, "
+	    "ma_delete %p",
+	    marr, marr->ma_mon, marr->ma_context, marr->ma_change,
+	    marr->ma_delete);
+	free(marr->ma_delete);
+	free(marr->ma_change);
+	free(marr->ma_context);
+	free(marr->ma_mon);
+	free(marr);
 
 #############################################################################
 MODULE = OPCUA::Open62541	PACKAGE = OPCUA::Open62541::Variant	PREFIX = UA_Variant_
@@ -4265,15 +4285,14 @@ UA_Client_MonitoredItems_createDataChanges(client, request, contextsSV, callback
 	size_t						itemsToCreateSize;
 	size_t						i;
 	ssize_t						top;
-	UA_Client_DataChangeNotificationCallback *	callbacks;
-	UA_Client_DeleteMonitoredItemCallback *		deleteCallbacks;
 	AV *						contextsAV;
 	AV *						callbacksAV;
 	AV *						deleteCallbacksAV;
 	SV **						contextSV;
 	SV **						callbackSV;
 	SV **						deleteCallbackSV;
-	MonitoredItemContext *				mons;
+	OPCUA_Open62541_MonitoredItemArrays		marr;
+	SV *						marrSV;
 	SV *						sv;
     CODE:
 	itemsToCreateSize = request->itemsToCreateSize;
@@ -4293,7 +4312,8 @@ UA_Client_MonitoredItems_createDataChanges(client, request, contextsSV, callback
 		contextsAV = NULL;
 	}
 	if (SvOK(callbacksSV)) {
-		if (!SvROK(callbacksSV) || SvTYPE(SvRV(callbacksSV)) != SVt_PVAV)
+		if (!SvROK(callbacksSV) ||
+		    SvTYPE(SvRV(callbacksSV)) != SVt_PVAV)
 			CROAK("Not an ARRAY reference for callbacks");
 
 		callbacksAV = (AV*)SvRV(callbacksSV);
@@ -4307,7 +4327,8 @@ UA_Client_MonitoredItems_createDataChanges(client, request, contextsSV, callback
 		callbacksAV = NULL;
 	}
 	if (SvOK(deleteCallbacksSV)) {
-		if (!SvROK(deleteCallbacksSV) || SvTYPE(SvRV(deleteCallbacksSV)) != SVt_PVAV)
+		if (!SvROK(deleteCallbacksSV) ||
+		    SvTYPE(SvRV(deleteCallbacksSV)) != SVt_PVAV)
 			CROAK("Not an ARRAY reference for deleteCallbacks");
 
 		deleteCallbacksAV = (AV*)SvRV(deleteCallbacksSV);
@@ -4321,37 +4342,29 @@ UA_Client_MonitoredItems_createDataChanges(client, request, contextsSV, callback
 		deleteCallbacksAV = NULL;
 	}
 
-	callbacks = calloc(itemsToCreateSize,
-	    sizeof(UA_Client_DataChangeNotificationCallback*));
-	if (callbacks == NULL)
+	marr = calloc(1, sizeof(*marr));
+	if (marr == NULL)
 		CROAKE("calloc");
+	/*
+	 * Convert struct MonitoredItemArrays into a PV.  This
+	 * allows to use Perl's ref counting for memory management.
+	 * The destroy function will free everything.  Leaks can
+	 * be found with Test::LeakTrace.
+	 */
+	marrSV = sv_2mortal(sv_setref_pv(newSV(0),
+	    "OPCUA::Open62541::MonitoredItemArrays", marr));
 
-	deleteCallbacks = calloc(itemsToCreateSize,
-	    sizeof(UA_Client_DeleteMonitoredItemCallback*));
-	if (deleteCallbacks == NULL) {
-		free(callbacks);
-		CROAKE("calloc");
-	}
-
-	mons = calloc(itemsToCreateSize, sizeof(*mons));
-	if (mons == NULL) {
-		free(deleteCallbacks);
-		free(callbacks);
+	marr->ma_mon = calloc(itemsToCreateSize, sizeof(*marr->ma_mon));
+	marr->ma_context = calloc(itemsToCreateSize, sizeof(*marr->ma_context));
+	marr->ma_change = calloc(itemsToCreateSize, sizeof(*marr->ma_change));
+	marr->ma_delete = calloc(itemsToCreateSize, sizeof(*marr->ma_delete));
+	if (marr->ma_mon == NULL || marr->ma_context == NULL ||
+	    marr->ma_change == NULL || marr->ma_delete == NULL) {
+		/* The destroy function of the mortal marrSV will free. */
 		CROAKE("calloc");
 	}
 
 	for (i = 0; i < itemsToCreateSize; i++) {
-		mons[i] = calloc(2, sizeof(**mons));
-		if (mons[i] == NULL) {
-			for (i = 0; i < itemsToCreateSize; i++) {
-				free(mons[i]);
-			}
-			free(mons);
-			free(deleteCallbacks);
-			free(callbacks);
-			CROAKE("calloc");
-		}
-
 		if (contextsAV != NULL)
 			contextSV = av_fetch(contextsAV, i, 0);
 		else {
@@ -4370,40 +4383,40 @@ UA_Client_MonitoredItems_createDataChanges(client, request, contextsSV, callback
 			deleteCallbackSV = NULL;
 
 		if (callbackSV != NULL && SvOK(*callbackSV))
-			mons[i]->mc_change = newClientCallbackData(
+			marr->ma_mon[i].mc_change = newClientCallbackData(
 			    *callbackSV, ST(0), *contextSV);
-
 		if (deleteCallbackSV != NULL && SvOK(*deleteCallbackSV))
-			mons[i]->mc_delete = newClientCallbackData(
+			marr->ma_mon[i].mc_delete = newClientCallbackData(
 			    *deleteCallbackSV, ST(0), *contextSV);
+		marr->ma_mon[i].mc_arrays = SvREFCNT_inc(marrSV);
 
-		callbacks[i] = clientDataChangeNotificationCallback;
-		deleteCallbacks[i] = clientDeleteMonitoredItemCallback;
-		mons[i]->mc_callbackdataref = &mons[i];
+		marr->ma_context[i] = &marr->ma_mon[i];
+		marr->ma_change[i] = clientDataChangeNotificationCallback;
+		marr->ma_delete[i] = clientDeleteMonitoredItemCallback;
 	}
 
-	DPRINTF("client %p, items %zu, mons %p",
-	    client, itemsToCreateSize, mons);
+	DPRINTF("client %p, items %zu, marr %p, ma_mon %p, ma_context %p, "
+	    "ma_change %p, ma_delete %p",
+	    client, itemsToCreateSize, marr, marr->ma_mon, marr->ma_context,
+	    marr->ma_change, marr->ma_delete);
 
 	RETVAL = UA_Client_MonitoredItems_createDataChanges(client->cl_client,
-	    *request, (void **)mons, callbacks, deleteCallbacks);
-	if (RETVAL.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+	    *request, marr->ma_context, marr->ma_change, marr->ma_delete);
+
+	if (SvREFCNT(marrSV) > 1 &&
+	    RETVAL.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
 		for (i = 0; i < itemsToCreateSize; i++) {
-			if (mons[i] == NULL)
-				continue;
-			if (mons[i]->mc_delete)
-				deleteClientCallbackData(mons[i]->mc_delete);
-			if (mons[i]->mc_change)
-				deleteClientCallbackData(mons[i]->mc_change);
-			free(mons[i]);
-		}
-		/* XXX these three arrays are never freed if successful */
-		free(mons);
-		free(deleteCallbacks);
-		free(callbacks);
-	} else {
-		for (i = 0; i < itemsToCreateSize; i++) {
-			mons[i]->mc_callbackdataref = NULL;
+			if (marr->ma_mon[i].mc_delete)
+				deleteClientCallbackData(
+				    marr->ma_mon[i].mc_delete);
+			if (marr->ma_mon[i].mc_change)
+				deleteClientCallbackData(
+				    marr->ma_mon[i].mc_change);
+			/*
+			 * When mc_arrays ref count reaches 0, Perl will free
+			 * everything in MonitoredItemArrays destroy function.
+			 */
+			SvREFCNT_dec(marr->ma_mon[i].mc_arrays);
 		}
 	}
     OUTPUT:
@@ -4419,36 +4432,53 @@ UA_Client_MonitoredItems_createDataChange(client, subscriptionId, timestampsToRe
 	SV *						callback
 	SV *						deleteCallback
     PREINIT:
-	MonitoredItemContext				mon;
+	OPCUA_Open62541_MonitoredItemArrays		marr;
+	SV *						marrSV;
     CODE:
-	mon = calloc(1, sizeof(*mon));
-	if (mon == NULL)
+	marr = calloc(1, sizeof(*marr));
+	if (marr == NULL)
 		CROAKE("calloc");
+	/*
+	 * Convert struct MonitoredItemArrays into a PV.  This
+	 * allows to use Perl's ref counting for memory management.
+	 * The destroy function will free everything.  Leaks can
+	 * be found with Test::LeakTrace.
+	 */
+	marrSV = sv_2mortal(sv_setref_pv(newSV(0),
+	    "OPCUA::Open62541::MonitoredItemArrays", marr));
+
+	marr->ma_mon = calloc(1, sizeof(*marr->ma_mon));
+	if (marr->ma_mon == NULL) {
+		/* The destroy function of the mortal marrSV will free. */
+		CROAKE("calloc");
+	}
 	if (SvOK(callback))
-		mon->mc_change = newClientCallbackData(
+		marr->ma_mon[0].mc_change = newClientCallbackData(
 		    callback, ST(0), context);
 	if (SvOK(deleteCallback))
-		mon->mc_delete = newClientCallbackData(
+		marr->ma_mon[0].mc_delete = newClientCallbackData(
 		    deleteCallback, ST(0), context);
-	mon->mc_callbackdataref = &mon;
+	marr->ma_mon[0].mc_arrays = SvREFCNT_inc(marrSV);
 
-	DPRINTF("client %p, mon %p, mc_change %p, mc_delete %p",
-	    client, mon, mon->mc_change, mon->mc_delete);
+	DPRINTF("client %p, marr %p, ma_mon %p, mc_change %p, mc_delete %p",
+	    client, marr, marr->ma_mon,
+	    marr->ma_mon[0].mc_change, marr->ma_mon[0].mc_delete);
 
 	RETVAL = UA_Client_MonitoredItems_createDataChange(client->cl_client,
-	    subscriptionId, timestampsToReturn, *item, mon,
+	    subscriptionId, timestampsToReturn, *item, &marr->ma_mon[0],
 	    clientDataChangeNotificationCallback,
 	    clientDeleteMonitoredItemCallback);
-	if (mon != NULL) {
-		if (RETVAL.statusCode != UA_STATUSCODE_GOOD) {
-			if (mon->mc_delete)
-				deleteClientCallbackData(mon->mc_delete);
-			if (mon->mc_change)
-				deleteClientCallbackData(mon->mc_change);
-			free(mon);
-		} else {
-			mon->mc_callbackdataref = NULL;
-		}
+
+	if (SvREFCNT(marrSV) > 1 && RETVAL.statusCode != UA_STATUSCODE_GOOD) {
+		if (marr->ma_mon[0].mc_delete)
+			deleteClientCallbackData(marr->ma_mon[0].mc_delete);
+		if (marr->ma_mon[0].mc_change)
+			deleteClientCallbackData(marr->ma_mon[0].mc_change);
+		/*
+		 * When mc_arrays ref count reaches 0, Perl will free
+		 * everything in MonitoredItemArrays destroy function.
+		 */
+		SvREFCNT_dec(marr->ma_mon[0].mc_arrays);
 	}
     OUTPUT:
 	RETVAL

--- a/t/client-monitoreditems.t
+++ b/t/client-monitoreditems.t
@@ -7,7 +7,7 @@ use OPCUA::Open62541::Test::Server;
 
 use Test::More tests =>
     OPCUA::Open62541::Test::Server::planning() +
-    OPCUA::Open62541::Test::Client::planning() + 42;
+    OPCUA::Open62541::Test::Client::planning() + 41;
 use Test::Deep;
 use Test::Exception;
 use Test::LeakTrace;
@@ -249,6 +249,7 @@ no_leaks_ok {
 } "MonitoredItemCreateRequest_default leak";
 
 no_leaks_ok {
+    $i = 0;
     $response = $client->{client}->MonitoredItems_createDataChange(
 	$subid,
 	TIMESTAMPSTORETURN_BOTH,
@@ -257,11 +258,10 @@ no_leaks_ok {
 	undef,
 	undef,
     );
+    # iterate until all delete callbacks have been called
+    $client->iterate(sub {sleep 1; ++$i > 10 &&
+	$response->{MonitoredItemCreateResult_statusCode} eq 'Good'});
 } "MonitoredItems_createDataChange leak";
-
-is($response->{MonitoredItemCreateResult_statusCode},
-   "Good",
-   "monitored items create response statuscode");
 
 no_leaks_ok {
     $response = $client->{client}->MonitoredItems_createDataChange(

--- a/typemap
+++ b/typemap
@@ -80,6 +80,7 @@ OPCUA_Open62541_ServerConfig		T_PTROBJ_SPECIAL
 OPCUA_Open62541_Client			T_PTROBJ_SPECIAL
 OPCUA_Open62541_ClientConfig		T_PTROBJ_SPECIAL
 OPCUA_Open62541_Logger			T_PTROBJ_SPECIAL
+OPCUA_Open62541_MonitoredItemArrays	T_PTROBJ_SPECIAL
 
 #############################################################################
 INPUT


### PR DESCRIPTION
The UA_Client_MonitoredItems_createDataChanges() has ugly callback
semantics.  It does not expect a void pointer where we could store
all our data structures, but an array of void pointers.  Create a
Perl PV object that contains the C arrays needed by the open62541
function.  This container is referenced by every callback context.
Each time a delete callback is executed, the reference counter is
decremented.  After all delete callbacks have been called, the C
memory is freed by the Perl destroy function.
Also monitored items without Perl callback need this data structure.
So the test has to iterate and free the memory as it its detected
by the leak tracer.