### PR TITLE
CI: manually build different open62541 versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,18 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build & Test
-    runs-on: ubuntu-20.04
+    name: Build & Test (${{matrix.config.v}})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {v: '1.0.6'}
+          - {v: '1.1.6'}
+          - {v: '1.2.4'}
+          - {v: '1.3'}
     container:
-      image: ubuntu:20.04
+      image: ubuntu:latest
     steps:
     - uses: actions/checkout@v2
     - name: apt update
@@ -17,16 +25,26 @@ jobs:
         apt-get install --yes \
         gpg \
         make \
-        software-properties-common
-    - name: Add OPC UA ppa
-      run: add-apt-repository ppa:open62541-team/ppa && apt-get update
+        software-properties-common \
+        git build-essential gcc pkg-config cmake python2 \
+        libmbedtls-dev
+    - name: Install open62541
+      run: |
+        cd /tmp
+        git clone https://github.com/open62541/open62541
+        cd open62541
+        git checkout -b v${{matrix.config.v}} v${{matrix.config.v}}
+        git submodule update --init --recursive
+        mkdir build
+        cd build
+        cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_NAMESPACE_ZERO=FULL ..
+        make
+        make install
+        ldconfig /usr/local/lib
     - name: Install Perl modules for testing and libopen62541
       run: |
         apt-get install --yes \
         libdevel-checklib-perl \
-        libopen62541-1 \
-        libopen62541-1-dev \
-        libopen62541-1-tools \
         libtest-deep-perl \
         libtest-eol-perl \
         libtest-exception-perl \

--- a/t/server-config-default.t
+++ b/t/server-config-default.t
@@ -34,7 +34,7 @@ ok(my $buildinfo = $config->getBuildInfo(), "buildinfo get");
 no_leaks_ok { $config->getBuildInfo() } "buildinfo leak";
 my %info = (
     BuildInfo_buildDate => re(qr/^\d+$/),  # '132325380645571530',
-    BuildInfo_buildNumber => re(qr/^\w+$/),  # 'deb',
+    BuildInfo_buildNumber => re(qr/^.+$/),  # 'deb',
     BuildInfo_manufacturerName => 'open62541',
     BuildInfo_productName => 'open62541 OPC UA Server',
     BuildInfo_productUri => 'http://open62541.org',


### PR DESCRIPTION
* We build open62541 manually now, because we want to test multiple
  versions simultaneously and 1.3 is not availably in the apt repo yet.
* Build and dependency installation are adjusted to what we need.
* We switch from ubuntu:20.04 to ubuntu:latest because this seems more
  future proof (also 20.04 is equal to latest at the moment).
* We build open62541 in /tmp, because ExtUtils will otherwise complain,
  if it finds multiple versions of the same library.
* Since we now build from the git repository, the buildNumber seems to
  be the build date. The server-config-default.t was adjusted
  accordingly.