### PR TITLE
CI: remove python2 dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         gpg \
         make \
         software-properties-common \
-        git build-essential gcc pkg-config cmake python2 \
+        git build-essential gcc pkg-config cmake \
         libmbedtls-dev
     - name: Install open62541
       run: |


### PR DESCRIPTION
* python3 is already installed in the image and we don't need python2.