### PR TITLE
Server Config set Custom Hostname function has been removed.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -47,6 +47,14 @@ check_lib(
     libpath		=> '/usr/local/lib',
     incpath		=> '/usr/local/include',
 ) and push @have, uc('UA_Client_connectAsync');
+check_lib(
+    function		=> "UA_ServerConfig_setCustomHostname(NULL, NULL);",
+    not_execute		=> 1,
+    lib			=> 'open62541',
+    header		=> 'open62541/client.h',
+    libpath		=> '/usr/local/lib',
+    incpath		=> '/usr/local/include',
+) and push @have, uc('UA_ServerConfig_setCustomHostname');
 my @defines = map { "-DHAVE_$_=1" } @have;
 
 WriteMakefile(

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -3352,6 +3352,8 @@ UA_ServerConfig_setMinimal(config, portNumber, certificate)
     OUTPUT:
 	RETVAL
 
+#ifdef HAVE_UA_SERVERCONFIG_SETCUSTOMHOSTNAME
+
 void
 UA_ServerConfig_setCustomHostname(config, customHostname)
 	OPCUA_Open62541_ServerConfig	config
@@ -3359,6 +3361,8 @@ UA_ServerConfig_setCustomHostname(config, customHostname)
     CODE:
 	UA_ServerConfig_setCustomHostname(config->svc_serverconfig,
 	    *customHostname);
+
+#endif
 
 #ifdef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
 


### PR DESCRIPTION
UA_ServerConfig_setCustomHostname() has been deprecated in open62541
version 1.2 and removed in 1.3.  Use #ifdef to create the Perl
wrapper only if the function exists.