### PR TITLE
Search for constants in common header.

### DIFF
--- a/lib/OPCUA/Open62541/Constant.pm
+++ b/lib/OPCUA/Open62541/Constant.pm
@@ -9,7 +9,7 @@ use strict;
 use warnings;
 use Carp;
 
-our $VERSION = '0.020';
+our $VERSION = '0.030';
 
 # Even if we declare more than 10k constants, this is a fast way to do it.
 my $consts = <<'EOCONST';

--- a/script/constant.pl
+++ b/script/constant.pl
@@ -17,12 +17,12 @@ close($fh);
 # type, prefix, header of generated Perl constants
 my @consts = (
   # constants used in define and enum tests
-  [qw(	enum	ATTRIBUTEID		constants	)],
-  [qw(	define	ACCESSLEVELMASK		constants	)],
-  [qw(	define	WRITEMASK		constants	)],
-  [qw(	define	VALUERANK		constants	)],
-  [qw(	enum	RULEHANDLING		constants	)],
-  [qw(	enum	ORDER			constants	)],
+  [qw(	enum	ATTRIBUTEID		constants;common	)],
+  [qw(	define	ACCESSLEVELMASK		constants;common	)],
+  [qw(	define	WRITEMASK		constants;common	)],
+  [qw(	define	VALUERANK		constants;common	)],
+  [qw(	enum	RULEHANDLING		constants;common	)],
+  [qw(	enum	ORDER			constants;common	)],
   [qw(	enum	VARIANT			types		)],
   # We need UA_StatusCode as C type to run special typemap conversion.
   [qw(	define	STATUSCODE		statuscodes	UA_StatusCode	)],
@@ -82,9 +82,14 @@ sub parse_consts {
 sub parse_prefix {
     my ($pmf, $podf, $type, $prefix, $header, $typedef) = @_;
 
-    my $cfile = "/usr/local/include/open62541/$header.h";
-    open(my $cf, '<', $cfile)
-	or die "Open '$cfile' for reading failed: $!";
+    # header files were renamed over open62541 versions, find one of them
+    my ($cf, $cfile);
+    foreach my $h (split(/;/, $header)) {
+	$cfile = "/usr/local/include/open62541/$h.h";
+	open($cf, '<', $cfile)
+	    and last;
+    }
+    $cf or die "Open '$cfile' for reading failed: $!";
 
     my ($xsfile, $xsf);
     if ($typedef) {


### PR DESCRIPTION
Header file constants.h has been renamed to common.h.  Script
constant.pl searches in both files.  Result is the same.