### PR TITLE
Client iterate has 32 bit timeout.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -3995,8 +3995,9 @@ UA_Client_connect_async(client, endpointUrl, callback, data)
 UA_StatusCode
 UA_Client_run_iterate(client, timeout)
 	OPCUA_Open62541_Client		client
-	UA_UInt16			timeout
+	UA_UInt32			timeout
     CODE:
+	/* open62541 1.0 had UA_UInt16 timeout, it is implicitly casted */
 	RETVAL = UA_Client_run_iterate(client->cl_client, timeout);
     OUTPUT:
 	RETVAL


### PR DESCRIPTION
open62531 1.1 API changed timeout parameter of UA_Client_run_iterate()
from UA_UInt16 to UA_UInt32.  Adapt types in wrapper.