### PR TITLE
Move context and callback destruction to client destroy.

### DIFF
--- a/t/client-config-context.t
+++ b/t/client-config-context.t
@@ -25,4 +25,5 @@ no_leaks_ok {
     my $client = OPCUA::Open62541::Client->new();
     my $config = $client->getConfig();
     $config->setClientContext("foo");
+    $config->setClientContext("bar");
 } "context leak";

--- a/t/client-config.t
+++ b/t/client-config.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use OPCUA::Open62541;
 
-use Test::More tests => 12;
+use Test::More tests => 17;
 use Test::Exception;
 use Test::LeakTrace;
 use Test::NoWarnings;
@@ -32,3 +32,20 @@ ok(my $config1 = $client->getConfig(), "config get first");
 }
 no_leaks_ok { $client->getConfig() }
     "config get second leak";
+
+# config gets destroyed when leaving scope
+$client = OPCUA::Open62541::Client->new();
+{
+    ok(my $scope1 = $client->getConfig(), "config scope first");
+    # client context must be freed with client, not with config
+    lives_ok { $scope1->setClientContext("foo") }
+	"config scope context";
+    lives_ok { $scope1->setStateCallback(sub {"bar"}) }
+	"config scope callback";
+    {
+	ok(my $scope2 = $client->getConfig(), "config scope second");
+    }
+    {
+	ok(my $scope3 = $client->getConfig(), "config scope third");
+    }
+}


### PR DESCRIPTION
Client config may be destroyed multiple times as its memory life
time is coupled to the client lifetime.  The same object is contructed
multiple times in getConfig().  This resulted in double frees of
its members.  Move the client context and state callback destruction
from client config destroy to client destroy.  Test client config
destroy with context and callback refcount.  Make client config
context leak test a bit more paranoid.