### PR TITLE
Implement client async connect and disconnect with 1.1 API.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -3950,7 +3950,14 @@ UA_Client_connect(client, endpointUrl)
 
 #ifdef HAVE_UA_CLIENT_CONNECTASYNC
 
-# XXX UA_Client_connectAsync not implemented
+UA_StatusCode
+UA_Client_connectAsync(client, endpointUrl)
+	OPCUA_Open62541_Client		client
+	char *				endpointUrl
+    CODE:
+	RETVAL = UA_Client_connectAsync(client->cl_client, endpointUrl);
+    OUTPUT:
+	RETVAL
 
 #else /* HAVE_UA_CLIENT_CONNECTASYNC */
 
@@ -4013,7 +4020,17 @@ UA_Client_disconnect(client)
     OUTPUT:
 	RETVAL
 
-#ifndef HAVE_UA_CLIENT_CONNECTASYNC
+#ifdef HAVE_UA_CLIENT_CONNECTASYNC
+
+UA_StatusCode
+UA_Client_disconnectAsync(client)
+	OPCUA_Open62541_Client		client
+    CODE:
+	RETVAL = UA_Client_disconnectAsync(client->cl_client);
+    OUTPUT:
+	RETVAL
+
+#else /* HAVE_UA_CLIENT_CONNECTASYNC */
 
 UA_StatusCode
 UA_Client_disconnect_async(client, outoptReqId)

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -371,6 +371,12 @@ If set to false, historical data can be deleted (this is the default).
 
 =item $status_code = $client->connect_async($endpointUrl, $callback, $userdata)
 
+1.0 API
+
+=item $status_code = $client->connectAsync($endpointUrl)
+
+1.1 API
+
 =over 8
 
 =item $callback = sub { my ($client, $userdata, $requestId, $status_code) = @_ }
@@ -387,6 +393,14 @@ run_iterate() or open62541 may try to operate on a non existent socket.
 =item $status_code = $client->disconnect_async(\$requestId)
 
 =item $client_state = $client->getState()
+
+1.0 API
+
+=item ($channel_state, $session_state, $connect_status) = $client->getState()
+
+1.1 API
+
+In scalar context return 1.0 API compatible $client_state.
 
 =item $status_code = $client->sendAsyncBrowseRequest(\%request, \&callback, $data, \$reqId)
 


### PR DESCRIPTION
The API for client async connect and disconnect has changed in
open62541 1.1.  Provide old and new implementation with ifdef.  Also
update client getState() documentation.  The tests for the new API
are more complicated due to new semantics of UA_Client_connectAsync()
and UA_Client_disconnectAsync().  Just provide the new functions
for now.  Using them correctly is the next step.