### PR TITLE
Test client async connect and disconnect with 1.1 API.

### DIFF
--- a/t/client-connect-async.t
+++ b/t/client-connect-async.t
@@ -1,22 +1,16 @@
 use strict;
 use warnings;
-use OPCUA::Open62541 qw(:STATUSCODE :CLIENTSTATE);
+use OPCUA::Open62541 qw(:STATUSCODE :CLIENTSTATE :SESSIONSTATE
+    :SECURECHANNELSTATE);
 use IO::Socket::INET;
 use Scalar::Util qw(looks_like_number);
 use Time::HiRes qw(sleep);
 
 use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
-use Test::More;
-BEGIN {
-    if (OPCUA::Open62541::Client->can('connect_async')) {
-	plan tests =>
-	    OPCUA::Open62541::Test::Server::planning() +
-	    OPCUA::Open62541::Test::Client::planning() * 4 + 9;
-    } else {
-	plan skip_all => "No UA_Client_connect_async in open62541";
-    }
-}
+use Test::More tests =>
+    OPCUA::Open62541::Test::Server::planning() +
+    OPCUA::Open62541::Test::Client::planning() * 4 + 9;
 use Test::Exception;
 use Test::NoWarnings;
 use Test::LeakTrace;
@@ -47,28 +41,64 @@ my $client = OPCUA::Open62541::Test::Client->new(port => $server->port());
 $client->start();
 $server->run();
 
+my $async = OPCUA::Open62541::Client->can('connect_async');
+
 my $data = ['foo'];
 my $connected = 0;
-is($client->{client}->connect_async(
-    $client->url(),
-    sub {
-	my ($c, $d, $i, $r) = @_;
+if ($async) {
+    is($client->{client}->connect_async(
+	$client->url(),
+	sub {
+	    my ($c, $d, $i, $r) = @_;
 
-	is($c->getState(), CLIENTSTATE_SESSION, "callback client state");
-	is($d->[0], "foo", "callback data in");
-	push @$d, 'bar';
-	ok(looks_like_number $i, "callback request id")
-	    or diag "request id not a number: $i";
-	is($r, STATUSCODE_GOOD, "callback response");
+	    is($c->getState(), CLIENTSTATE_SESSION, "callback client state");
+	    is($d->[0], "foo", "callback data in");
+	    push @$d, 'bar';
+	    ok(looks_like_number $i, "callback request id")
+		or diag "request id not a number: $i";
+	    is($r, STATUSCODE_GOOD, "callback response");
 
-	$connected = 1;
-    },
-    $data
-), STATUSCODE_GOOD, "connect async");
+	    $connected = 1;
+	},
+	$data
+    ), STATUSCODE_GOOD, "connect async");
+} else {
+    $client->{config}->setStateCallback(
+	sub {
+	    my ($c, $scs, $ss, $cs) = @_;
+
+	    # callback is called at state changes
+	    return unless $ss == SESSIONSTATE_ACTIVATED;
+
+	    is_deeply([$c->getState()], [$scs, $ss, $cs],
+		"callback client state");
+	    my $d = $c->getConfig()->getClientContext();
+	    is($d->[0], "foo", "callback data in");
+	    push @$d, 'bar';
+	    is($ss, SESSIONSTATE_ACTIVATED, "callback session state");
+	    is($cs, STATUSCODE_GOOD, "callback status code");
+
+	    $connected = 1;
+	}
+    );
+    $client->{config}->setClientContext($data);
+    is($client->{client}->connectAsync(
+	$client->url(),
+    ), STATUSCODE_GOOD, "connect async");
+}
 # wait an initial 100ms for open62541 to start the timer that creates the socket
 sleep .1;
 $client->iterate(\$connected, "connect");
-is($client->{client}->getState(), CLIENTSTATE_SESSION, "client state");
+$client->{config}->setStateCallback(undef);
+$client->{config}->setClientContext(undef);
+if ($async) {
+    is($client->{client}->getState(), CLIENTSTATE_SESSION,
+	"client state");
+} else {
+    is_deeply([$client->{client}->getState()],
+	[SECURECHANNELSTATE_OPEN, SESSIONSTATE_ACTIVATED, STATUSCODE_GOOD],
+	"client state");
+}
 is($data->[1], "bar", "callback data out");
 
 $client->stop();
@@ -81,16 +111,30 @@ $client->start();
 # is only called once.
 $connected = 0;
 no_leaks_ok {
-    $client->{client}->connect_async(
-	$client->url(),
-	sub {
-	    my ($c, $d, $i, $r) = @_;
-	    $connected = 1;
-	},
-	$data
-    );
+    if ($async) {
+	$client->{client}->connect_async(
+	    $client->url(),
+	    sub {
+		my ($c, $d, $i, $r) = @_;
+		$connected = 1;
+	    },
+	    $data
+	);
+    } else {
+	$client->{config}->setStateCallback(
+	    sub {
+		my ($c, $scs, $ss, $cs) = @_;
+		return unless $ss == SESSIONSTATE_ACTIVATED;
+		$connected = 1;
+	    }
+	);
+	$client->{config}->setClientContext($data);
+	$client->{client}->connectAsync($client->url());
+    }
     sleep .1;
     $client->iterate(\$connected);
+    $client->{config}->setStateCallback(undef);
+    $client->{config}->setClientContext(undef);
 } "connect async leak";
 
 $client->stop();
@@ -99,19 +143,36 @@ $client->stop();
 $client = OPCUA::Open62541::Test::Client->new(port => $server->port());
 $client->start();
 
-is($client->{client}->connect_async($client->url(), undef, undef),
-    STATUSCODE_GOOD, "connect async undef callback");
+if ($async) {
+    is($client->{client}->connect_async($client->url(), undef, undef),
+	STATUSCODE_GOOD, "connect async undef callback");
+} else {
+    $client->{config}->setStateCallback(undef);
+    is($client->{client}->connectAsync($client->url()),
+	STATUSCODE_GOOD, "connect async undef callback");
+}
 sleep .1;
 $client->iterate_connect("connect undef callback");
-is($client->{client}->getState(), CLIENTSTATE_SESSION,
-    "connect client state");
+if ($async) {
+    is($client->{client}->getState(), CLIENTSTATE_SESSION,
+	"state undef callback");
+} else {
+    is_deeply([$client->{client}->getState()],
+	[SECURECHANNELSTATE_OPEN, SESSIONSTATE_ACTIVATED, STATUSCODE_GOOD],
+	"state undef callback");
+}
 
 $client->stop();
 
 # the connection itself gets established in run_iterate. so this call should
 # also succeed if no server is running
-no_leaks_ok { $client->{client}->connect_async($client->url(), undef, undef) }
-    "connect async no callback leak";
+no_leaks_ok {
+    if ($async) {
+	$client->{client}->connect_async($client->url(), undef, undef);
+    } else {
+	$client->{client}->connectAsync($client->url());
+    }
+} "connect async no callback leak";
 
 $server->stop();
 
@@ -130,18 +191,47 @@ my $tcp_port = $tcp_server->sockport();
 $client = OPCUA::Open62541::Test::Client->new(port => $tcp_port);
 $client->start();
 
-is($client->{client}->connect_async(
-    $client->url(),
-    sub {
-	my ($c, $d, $i, $r) = @_;
-    },
-    undef,
-), STATUSCODE_GOOD, "connect async bad url");
+if ($async) {
+    is($client->{client}->connect_async(
+	$client->url(),
+	sub {
+	    my ($c, $d, $i, $r) = @_;
+	},
+	undef,
+    ), STATUSCODE_GOOD, "connect async bad url");
+} else {
+    $client->{config}->setStateCallback(
+	sub {
+	    my ($c, $scs, $ss, $cs) = @_;
+	}
+    );
+    is($client->{client}->connectAsync(
+	$client->url(),
+    ), STATUSCODE_GOOD, "connect async bad url");
+}
 undef $tcp_server;
 sleep .1;
 $client->iterate_disconnect("connect bad url");
-is($client->{client}->getState(), CLIENTSTATE_DISCONNECTED,
-    "client bad connection");
+$client->{config}->setStateCallback(undef);
+$client->{config}->setClientContext(undef);
+if ($async) {
+    is($client->{client}->getState(), CLIENTSTATE_DISCONNECTED,
+	"client bad connection");
+} else {
+    # API 1.2 disambiguates fresh from closed.
+    my ($channel, $status);
+    if (defined &SECURECHANNELSTATE_FRESH) {
+	$channel = SECURECHANNELSTATE_FRESH;
+	$status = STATUSCODE_BADDISCONNECT;
+    } else {
+	$channel = SECURECHANNELSTATE_CLOSED;
+	# API 1.1 seem to ignore the error
+	$status = STATUSCODE_GOOD;
+    }
+    is_deeply([$client->{client}->getState()],
+	[$channel, SESSIONSTATE_CLOSED, $status],
+	"client bad connection");
+}
 
 no_leaks_ok {
     $tcp_server = IO::Socket::INET->new(
@@ -150,54 +240,114 @@ no_leaks_ok {
 	Proto		=> "tcp",
 	Listen		=> 1,
     );
-    $client->{client}->connect_async(
-	$client->url(),
-	sub {
-	    my ($c, $d, $i, $r) = @_;
-	},
-	undef,
-    );
+    if ($async) {
+	$client->{client}->connect_async(
+	    $client->url(),
+	    sub {
+		my ($c, $d, $i, $r) = @_;
+	    },
+	    undef,
+	);
+    } else {
+	$client->{config}->setStateCallback(
+	    sub {
+		my ($c, $scs, $ss, $cs) = @_;
+		note "$c, $scs, $ss, $cs";
+	    }
+	);
+	$client->{client}->connectAsync(
+	    $client->url(),
+	);
+    }
     undef $tcp_server;
     sleep .1;
     $client->iterate_disconnect();
+    $client->{config}->setStateCallback(undef);
+    $client->{config}->setClientContext(undef);
 } "connect async bad url leak";
+
+# clean up connection state, dangling connection may affect next test
+$client->iterate_disconnect();
 
 SKIP: {
     skip $skip_freeaddrinfo, 3 if $skip_freeaddrinfo;
 
 # connect to invalid url fails, check that it does not leak
 $data = "foo";
-is($client->{client}->connect_async(
-    "opc.tcp://localhost:",
-    sub {
-	my ($c, $d, $i, $r) = @_;
-	fail "callback called";
-    },
-    \$data,
-), STATUSCODE_BADCONNECTIONCLOSED, "connect async fail");
-is($data, "foo", "data fail");
-no_leaks_ok {
-    $client->{client}->connect_async(
+if ($async) {
+    is($client->{client}->connect_async(
 	"opc.tcp://localhost:",
 	sub {
 	    my ($c, $d, $i, $r) = @_;
+	    fail "callback called";
 	},
 	\$data,
+    ), STATUSCODE_BADCONNECTIONCLOSED, "connect async fail");
+} else {
+    $client->{config}->setStateCallback(
+	sub {
+	    my ($c, $d, $i, $r) = @_;
+	    fail "callback called";
+	}
     );
+    $client->{config}->setClientContext(\$data);
+    is($client->{client}->connectAsync(
+	"opc.tcp://localhost:",
+    ), STATUSCODE_BADCONNECTIONCLOSED, "connect async fail");
+}
+is($data, "foo", "data fail");
+no_leaks_ok {
+    if ($async) {
+	$client->{client}->connect_async(
+	    "opc.tcp://localhost:",
+	    sub {
+		my ($c, $d, $i, $r) = @_;
+	    },
+	    \$data,
+	);
+    } else {
+	$client->{config}->setStateCallback(
+	    sub {
+		my ($c, $d, $i, $r) = @_;
+	    }
+	);
+	$client->{config}->setClientContext(\$data);
+	$client->{client}->connectAsync(
+	    "opc.tcp://localhost:",
+	);
+    }
 } "connect async fail leak";
 
 }  # SKIP
 
-throws_ok { $client->{client}->connect_async($client->url(), "foo", undef) }
-    (qr/Callback 'foo' is not a CODE reference /,
+throws_ok {
+    if ($async) {
+	$client->{client}->connect_async($client->url(), "foo", undef);
+    } else {
+	$client->{config}->setStateCallback("foo");
+    }
+} (qr/Callback 'foo' is not a CODE reference /,
     "callback not reference");
-no_leaks_ok {
-    eval { $client->{client}->connect_async($client->url(), "foo", undef) }
-} "callback not reference leak";
+no_leaks_ok { eval {
+    if ($async) {
+	$client->{client}->connect_async($client->url(), "foo", undef);
+    } else {
+	$client->{config}->setStateCallback("foo");
+    }
+} } "callback not reference leak";
 
-throws_ok { $client->{client}->connect_async($client->url(), [], undef) }
-    (qr/Callback 'ARRAY.*' is not a CODE reference /,
+throws_ok {
+    if ($async) {
+	$client->{client}->connect_async($client->url(), [], undef)
+    } else {
+	$client->{config}->setStateCallback([]);
+    }
+} (qr/Callback 'ARRAY.*' is not a CODE reference /,
     "callback not code reference");
-no_leaks_ok {
-    eval { $client->{client}->connect_async($client->url(), [], undef) }
-} "callback not code reference leak";
+no_leaks_ok { eval {
+    if ($async) {
+	$client->{client}->connect_async($client->url(), [], undef);
+    } else {
+	$client->{config}->setStateCallback([]);
+    }
+} } "callback not code reference leak";

--- a/t/client-statecallback.t
+++ b/t/client-statecallback.t
@@ -55,16 +55,18 @@ my @states;
 sub callback3 {
     my ($c, $channel, $session, $connect) = @_;
     is($c, $client->{client}, "callback client");
+    my $count = @states;
     my $state = shift @states;
-    is($channel, $state->[0], "callback channel");
-    is($session, $state->[1], "callback session");
-    is($connect, $state->[2], "callback connect");
+    is($channel, $state->[0], "callback channel $count");
+    is($session, $state->[1], "callback session $count");
+    is($connect, $state->[2], "callback connect $count");
 }
 # 1.0 API
 sub callback {
     my ($c, $state) = @_;
     is($c, $client->{client}, "callback client");
-    is($state, shift @states, "callback state");
+    my $count = @states;
+    is($state, shift @states, "callback state $count");
 }
 my $callback = @statearray == 3 ? \&callback3 : \&callback;
 lives_ok { $client->{config}->setStateCallback($callback); }


### PR DESCRIPTION
Until now the async tests were skipped in case the 1.1 API provides
new UA_Client_connectAsync() and UA_Client_disconnectAsync().  Make
client connect and disconnect async test work with both variants.
Test that connect after disconnect works with open62541 > 1.0.
Adapt test server singlestep to new API behavior.