### PR TITLE
Server config setCustomHostname() is deprecated.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -92,10 +92,20 @@ check_lib(
     function		=> "UA_ServerConfig_setCustomHostname(NULL, NULL);",
     not_execute		=> 1,
     lib			=> 'open62541',
-    header		=> 'open62541/client.h',
+    header		=> 'open62541/server.h',
     libpath		=> '/usr/local/lib',
     incpath		=> '/usr/local/include',
 ) and push @have, uc('UA_ServerConfig_setCustomHostname');
+check_lib(
+    function		=> "
+	UA_ServerConfig serverConfig;
+	(void)serverConfig.customHostname;",
+    not_execute		=> 1,
+    lib			=> 'open62541',
+    header		=> 'open62541/server.h',
+    libpath		=> '/usr/local/lib',
+    incpath		=> '/usr/local/include',
+) and push @have, uc('UA_ServerConfig_customHostname');
 check_lib(
     function		=> "
 	UA_SessionlessInvokeRequestType requestType;

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -3384,6 +3384,19 @@ UA_ServerConfig_setCustomHostname(config, customHostname)
 
 #endif
 
+#ifdef HAVE_UA_SERVERCONFIG_CUSTOMHOSTNAME
+
+void
+UA_ServerConfig_setCustomHostname(config, customHostname)
+	OPCUA_Open62541_ServerConfig	config
+	OPCUA_Open62541_String		customHostname
+    CODE:
+	UA_String_clear(&config->svc_serverconfig->customHostname);
+	UA_String_copy(customHostname,
+	    &config->svc_serverconfig->customHostname);
+
+#endif
+
 #ifdef HAVE_UA_SERVER_SETADMINSESSIONCONTEXT
 
 void


### PR DESCRIPTION
Since open62541 1.2 UA_ServerConfig_setCustomHostname() has been
deprecated and in 1.3 the function was removed.  Set field
customHostname directly in server config.