### PR TITLE
Implement server config set server urls.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -108,6 +108,16 @@ check_lib(
 ) and push @have, uc('UA_ServerConfig_customHostname');
 check_lib(
     function		=> "
+	UA_ServerConfig serverConfig;
+	(void)serverConfig.serverUrls;",
+    not_execute		=> 1,
+    lib			=> 'open62541',
+    header		=> 'open62541/server.h',
+    libpath		=> '/usr/local/lib',
+    incpath		=> '/usr/local/include',
+) and push @have, uc('UA_ServerConfig_serverUrls');
+check_lib(
+    function		=> "
 	UA_SessionlessInvokeRequestType requestType;
 	(void)requestType.urisVersionSize;",
     not_execute		=> 1,

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -3390,10 +3390,41 @@ void
 UA_ServerConfig_setCustomHostname(config, customHostname)
 	OPCUA_Open62541_ServerConfig	config
 	OPCUA_Open62541_String		customHostname
+    PREINIT:
+	UA_StatusCode		sc;
     CODE:
 	UA_String_clear(&config->svc_serverconfig->customHostname);
-	UA_String_copy(customHostname,
+	sc = UA_String_copy(customHostname,
 	    &config->svc_serverconfig->customHostname);
+	if (sc != UA_STATUSCODE_GOOD)
+		CROAKS(sc, "UA_String_copy");
+
+#endif
+
+#ifdef HAVE_UA_SERVERCONFIG_SERVERURLS
+
+void
+UA_ServerConfig_setServerUrls(config, ...)
+	OPCUA_Open62541_ServerConfig	config
+    PREINIT:
+	int i;
+    CODE:
+	UA_Array_delete(config->svc_serverconfig->serverUrls,
+	    config->svc_serverconfig->serverUrlsSize,
+	    &UA_TYPES[UA_TYPES_STRING]);
+	config->svc_serverconfig->serverUrls = NULL;
+	config->svc_serverconfig->serverUrlsSize = 0;
+	if (items <= 1)
+		XSRETURN_EMPTY;
+	config->svc_serverconfig->serverUrls = UA_Array_new(items - 1,
+	    &UA_TYPES[UA_TYPES_STRING]);
+	if (config->svc_serverconfig->serverUrls == NULL)
+		CROAKE("UA_Array_new");
+	config->svc_serverconfig->serverUrlsSize = items - 1;
+	for (i = 1; i < items; i++) {
+		config->svc_serverconfig->serverUrls[i - 1] =
+		    XS_unpack_UA_String(ST(i));
+	}
 
 #endif
 

--- a/t/server-config-default.t
+++ b/t/server-config-default.t
@@ -25,10 +25,20 @@ throws_ok { OPCUA::Open62541::ServerConfig::setDefault(1) }
 no_leaks_ok { eval { OPCUA::Open62541::ServerConfig::setDefault(1) } }
     "config type leak";
 
-lives_ok { $config->setCustomHostname("foo\0bar") }
-    "custom hostname";
-no_leaks_ok { $config->setCustomHostname("foo\0bar") }
-    "custom hostname leak";
+if ($config->can("setCustomHostname")) {
+    lives_ok { $config->setCustomHostname("foo\0bar") }
+	"custom hostname";
+    no_leaks_ok { $config->setCustomHostname("foo\0bar") }
+	"custom hostname leak";
+}
+if ($config->can("setServerUrls")) {
+    lives_ok {
+	$config->setServerUrls("opc.tcp://foo/", "opc.tcp://bar:4840/");
+    } "custom hostname";
+    no_leaks_ok {
+	$config->setServerUrls("opc.tcp://foo/", "opc.tcp://bar:4840/");
+    } "custom hostname leak";
+}
 
 ok(my $buildinfo = $config->getBuildInfo(), "buildinfo get");
 no_leaks_ok { $config->getBuildInfo() } "buildinfo leak";


### PR DESCRIPTION
Post 1.3 API has removed custom hostname and add server urls instead.
Check if open62541 provides server config setServerUrls().  Test
chooses between setCustomHostname() and setServerUrls().