### PR TITLE
Client subscription create always calls callback.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -50,6 +50,20 @@ check_lib(
 ) and push @have, uc('UA_Client_connectAsync');
 check_lib(
     function		=> "
+	UA_CreateSubscriptionRequest request;
+	UA_Client_StatusChangeNotificationCallback statusChangeCallback;
+	UA_Client_DeleteSubscriptionCallback deleteCallback;
+	UA_ClientAsyncServiceCallback callback;
+	UA_Client_Subscriptions_create_async(NULL, request, NULL,
+	    statusChangeCallback, deleteCallback, callback, NULL, NULL);",
+    not_execute		=> 1,
+    lib			=> 'open62541',
+    header		=> 'open62541/client_subscriptions.h',
+    libpath		=> '/usr/local/lib',
+    incpath		=> '/usr/local/include',
+) and push @have, uc('UA_Client_Subscriptions_create_async');
+check_lib(
+    function		=> "
 	UA_NodeId nodeId;
 	UA_Client_readNodeIdAttribute_async(NULL, nodeId, NULL, NULL, NULL);",
     not_execute		=> 1,


### PR DESCRIPTION
When open62541 1.1 introduced async monitored items, the callback
behavior of UA_Client_Subscriptions_create() changed.  It is no
longer necessary to free the resources at failure, the callback
will do it in most cases.  To prevent leaks, disconnect() must be
called in test.