### PR TITLE
Fix t/client-read-async.t

### DIFF
--- a/t/client-read-async.t
+++ b/t/client-read-async.t
@@ -151,7 +151,8 @@ for my $r (
 	DataValue_status => 'Good',
 	DataValue_hasValue => 1,
 	DataValue_hasStatus => '',
-	DataValue_hasSourceTimestamp => '',
+	DataValue_hasSourceTimestamp =>
+	    ($r->{attribute} == ATTRIBUTEID_VALUE ? re(qr/^(1|)$/) : ''),
 	DataValue_hasServerTimestamp => '',
 	DataValue_hasSourcePicoseconds => '',
 	DataValue_hasServerPicoseconds => '',


### PR DESCRIPTION
* With newer open62541 Versions, the behaviour for sourceTimestamp
  values changed if reading was unsuccessful (open62541 4c658423).
* We now accept 1 and '' in the test to be compatible with old and new
  behaviour.