### PR TITLE
Fix t/server-client-variable.t

### DIFF
--- a/t/server-client-variable.t
+++ b/t/server-client-variable.t
@@ -107,7 +107,8 @@ is($client->{client}->readValueAttribute_async(
 	is($$d, "foo", "readValueAttribute_async data in");
 	$$d = "bar";
 	is($i, $reqid, "readValueAttribute_async reqid");
-	is_deeply($v, $attr{VariableAttributes_value},
+	my $value = $v->{DataValue_value} // $v;
+	is_deeply($value, $attr{VariableAttributes_value},
 	    "readValueAttribute_async value");
 
 	$read = 1;


### PR DESCRIPTION
* Depending on the open62541 Version, readValueAttribute_async returns
  different data types (Variant/DataValue). To compensate for this in
  the test, we just check if we have a DataValue hash and compare it's
  variant component instead of the complete hash.