### PR TITLE
CI: update tags for builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,7 @@ jobs:
         config:
           - {v: 'v1.0.6'}
           - {v: 'v1.1.6'}
-          - {v: 'v1.2.5'}
-          - {v: 'v1.3.1'}
+          - {v: 'v1.3.2'}
           - {v: 'master'}
     container:
       image: ubuntu:latest


### PR DESCRIPTION
* We will not fix the tests / make the module compatible for
  open62541 1.2. So we can remove the 1.2 build from the CI.
* Update 1.3 to 1.3.2