### PR TITLE
Disable open623541 master branch in github CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@ jobs:
           - {v: 'v1.0.6'}
           - {v: 'v1.1.6'}
           - {v: 'v1.3.3'}
-          - {v: 'master'}
+# the master runner does not terminate currently
+# disable for now until we have time to investigate
+#          - {v: 'master'}
     container:
       image: ubuntu:latest
     steps:


### PR DESCRIPTION
The master runner does not terminate currently.
Disable for now until we have time to investigate.