### PR TITLE
Call pack und unpack functions instead of XS wrappers.

### DIFF
--- a/Open62541-packed-type.xsh
+++ b/Open62541-packed-type.xsh
@@ -18,14 +18,12 @@ XS_unpack_UA_AccessLevelExType(SV *in)
 static void
 table_pack_UA_AccessLevelExType(SV *sv, void *p)
 {
-	UA_AccessLevelExType *data = p;
-	XS_pack_UA_AccessLevelExType(sv, *data);
+	pack_UA_AccessLevelExType(sv, p);
 }
 static void
 table_unpack_UA_AccessLevelExType(SV *sv, void *p)
 {
-	UA_AccessLevelExType *data = p;
-	*data = XS_unpack_UA_AccessLevelExType(sv);
+	unpack_UA_AccessLevelExType(p, sv);
 }
 #endif
 
@@ -47,14 +45,12 @@ XS_unpack_UA_AccessLevelType(SV *in)
 static void
 table_pack_UA_AccessLevelType(SV *sv, void *p)
 {
-	UA_AccessLevelType *data = p;
-	XS_pack_UA_AccessLevelType(sv, *data);
+	pack_UA_AccessLevelType(sv, p);
 }
 static void
 table_unpack_UA_AccessLevelType(SV *sv, void *p)
 {
-	UA_AccessLevelType *data = p;
-	*data = XS_unpack_UA_AccessLevelType(sv);
+	unpack_UA_AccessLevelType(p, sv);
 }
 #endif
 
@@ -76,14 +72,12 @@ XS_unpack_UA_AccessRestrictionType(SV *in)
 static void
 table_pack_UA_AccessRestrictionType(SV *sv, void *p)
 {
-	UA_AccessRestrictionType *data = p;
-	XS_pack_UA_AccessRestrictionType(sv, *data);
+	pack_UA_AccessRestrictionType(sv, p);
 }
 static void
 table_unpack_UA_AccessRestrictionType(SV *sv, void *p)
 {
-	UA_AccessRestrictionType *data = p;
-	*data = XS_unpack_UA_AccessRestrictionType(sv);
+	unpack_UA_AccessRestrictionType(p, sv);
 }
 #endif
 
@@ -105,14 +99,12 @@ XS_unpack_UA_ActivateSessionRequest(SV *in)
 static void
 table_pack_UA_ActivateSessionRequest(SV *sv, void *p)
 {
-	UA_ActivateSessionRequest *data = p;
-	XS_pack_UA_ActivateSessionRequest(sv, *data);
+	pack_UA_ActivateSessionRequest(sv, p);
 }
 static void
 table_unpack_UA_ActivateSessionRequest(SV *sv, void *p)
 {
-	UA_ActivateSessionRequest *data = p;
-	*data = XS_unpack_UA_ActivateSessionRequest(sv);
+	unpack_UA_ActivateSessionRequest(p, sv);
 }
 #endif
 
@@ -134,14 +126,12 @@ XS_unpack_UA_ActivateSessionResponse(SV *in)
 static void
 table_pack_UA_ActivateSessionResponse(SV *sv, void *p)
 {
-	UA_ActivateSessionResponse *data = p;
-	XS_pack_UA_ActivateSessionResponse(sv, *data);
+	pack_UA_ActivateSessionResponse(sv, p);
 }
 static void
 table_unpack_UA_ActivateSessionResponse(SV *sv, void *p)
 {
-	UA_ActivateSessionResponse *data = p;
-	*data = XS_unpack_UA_ActivateSessionResponse(sv);
+	unpack_UA_ActivateSessionResponse(p, sv);
 }
 #endif
 
@@ -163,14 +153,12 @@ XS_unpack_UA_AddNodesItem(SV *in)
 static void
 table_pack_UA_AddNodesItem(SV *sv, void *p)
 {
-	UA_AddNodesItem *data = p;
-	XS_pack_UA_AddNodesItem(sv, *data);
+	pack_UA_AddNodesItem(sv, p);
 }
 static void
 table_unpack_UA_AddNodesItem(SV *sv, void *p)
 {
-	UA_AddNodesItem *data = p;
-	*data = XS_unpack_UA_AddNodesItem(sv);
+	unpack_UA_AddNodesItem(p, sv);
 }
 #endif
 
@@ -192,14 +180,12 @@ XS_unpack_UA_AddNodesRequest(SV *in)
 static void
 table_pack_UA_AddNodesRequest(SV *sv, void *p)
 {
-	UA_AddNodesRequest *data = p;
-	XS_pack_UA_AddNodesRequest(sv, *data);
+	pack_UA_AddNodesRequest(sv, p);
 }
 static void
 table_unpack_UA_AddNodesRequest(SV *sv, void *p)
 {
-	UA_AddNodesRequest *data = p;
-	*data = XS_unpack_UA_AddNodesRequest(sv);
+	unpack_UA_AddNodesRequest(p, sv);
 }
 #endif
 
@@ -221,14 +207,12 @@ XS_unpack_UA_AddNodesResponse(SV *in)
 static void
 table_pack_UA_AddNodesResponse(SV *sv, void *p)
 {
-	UA_AddNodesResponse *data = p;
-	XS_pack_UA_AddNodesResponse(sv, *data);
+	pack_UA_AddNodesResponse(sv, p);
 }
 static void
 table_unpack_UA_AddNodesResponse(SV *sv, void *p)
 {
-	UA_AddNodesResponse *data = p;
-	*data = XS_unpack_UA_AddNodesResponse(sv);
+	unpack_UA_AddNodesResponse(p, sv);
 }
 #endif
 
@@ -250,14 +234,12 @@ XS_unpack_UA_AddNodesResult(SV *in)
 static void
 table_pack_UA_AddNodesResult(SV *sv, void *p)
 {
-	UA_AddNodesResult *data = p;
-	XS_pack_UA_AddNodesResult(sv, *data);
+	pack_UA_AddNodesResult(sv, p);
 }
 static void
 table_unpack_UA_AddNodesResult(SV *sv, void *p)
 {
-	UA_AddNodesResult *data = p;
-	*data = XS_unpack_UA_AddNodesResult(sv);
+	unpack_UA_AddNodesResult(p, sv);
 }
 #endif
 
@@ -279,14 +261,12 @@ XS_unpack_UA_AddReferencesItem(SV *in)
 static void
 table_pack_UA_AddReferencesItem(SV *sv, void *p)
 {
-	UA_AddReferencesItem *data = p;
-	XS_pack_UA_AddReferencesItem(sv, *data);
+	pack_UA_AddReferencesItem(sv, p);
 }
 static void
 table_unpack_UA_AddReferencesItem(SV *sv, void *p)
 {
-	UA_AddReferencesItem *data = p;
-	*data = XS_unpack_UA_AddReferencesItem(sv);
+	unpack_UA_AddReferencesItem(p, sv);
 }
 #endif
 
@@ -308,14 +288,12 @@ XS_unpack_UA_AddReferencesRequest(SV *in)
 static void
 table_pack_UA_AddReferencesRequest(SV *sv, void *p)
 {
-	UA_AddReferencesRequest *data = p;
-	XS_pack_UA_AddReferencesRequest(sv, *data);
+	pack_UA_AddReferencesRequest(sv, p);
 }
 static void
 table_unpack_UA_AddReferencesRequest(SV *sv, void *p)
 {
-	UA_AddReferencesRequest *data = p;
-	*data = XS_unpack_UA_AddReferencesRequest(sv);
+	unpack_UA_AddReferencesRequest(p, sv);
 }
 #endif
 
@@ -337,14 +315,12 @@ XS_unpack_UA_AddReferencesResponse(SV *in)
 static void
 table_pack_UA_AddReferencesResponse(SV *sv, void *p)
 {
-	UA_AddReferencesResponse *data = p;
-	XS_pack_UA_AddReferencesResponse(sv, *data);
+	pack_UA_AddReferencesResponse(sv, p);
 }
 static void
 table_unpack_UA_AddReferencesResponse(SV *sv, void *p)
 {
-	UA_AddReferencesResponse *data = p;
-	*data = XS_unpack_UA_AddReferencesResponse(sv);
+	unpack_UA_AddReferencesResponse(p, sv);
 }
 #endif
 
@@ -366,14 +342,12 @@ XS_unpack_UA_AggregateConfiguration(SV *in)
 static void
 table_pack_UA_AggregateConfiguration(SV *sv, void *p)
 {
-	UA_AggregateConfiguration *data = p;
-	XS_pack_UA_AggregateConfiguration(sv, *data);
+	pack_UA_AggregateConfiguration(sv, p);
 }
 static void
 table_unpack_UA_AggregateConfiguration(SV *sv, void *p)
 {
-	UA_AggregateConfiguration *data = p;
-	*data = XS_unpack_UA_AggregateConfiguration(sv);
+	unpack_UA_AggregateConfiguration(p, sv);
 }
 #endif
 
@@ -395,14 +369,12 @@ XS_unpack_UA_AggregateFilter(SV *in)
 static void
 table_pack_UA_AggregateFilter(SV *sv, void *p)
 {
-	UA_AggregateFilter *data = p;
-	XS_pack_UA_AggregateFilter(sv, *data);
+	pack_UA_AggregateFilter(sv, p);
 }
 static void
 table_unpack_UA_AggregateFilter(SV *sv, void *p)
 {
-	UA_AggregateFilter *data = p;
-	*data = XS_unpack_UA_AggregateFilter(sv);
+	unpack_UA_AggregateFilter(p, sv);
 }
 #endif
 
@@ -424,14 +396,12 @@ XS_unpack_UA_AggregateFilterResult(SV *in)
 static void
 table_pack_UA_AggregateFilterResult(SV *sv, void *p)
 {
-	UA_AggregateFilterResult *data = p;
-	XS_pack_UA_AggregateFilterResult(sv, *data);
+	pack_UA_AggregateFilterResult(sv, p);
 }
 static void
 table_unpack_UA_AggregateFilterResult(SV *sv, void *p)
 {
-	UA_AggregateFilterResult *data = p;
-	*data = XS_unpack_UA_AggregateFilterResult(sv);
+	unpack_UA_AggregateFilterResult(p, sv);
 }
 #endif
 
@@ -453,14 +423,12 @@ XS_unpack_UA_Annotation(SV *in)
 static void
 table_pack_UA_Annotation(SV *sv, void *p)
 {
-	UA_Annotation *data = p;
-	XS_pack_UA_Annotation(sv, *data);
+	pack_UA_Annotation(sv, p);
 }
 static void
 table_unpack_UA_Annotation(SV *sv, void *p)
 {
-	UA_Annotation *data = p;
-	*data = XS_unpack_UA_Annotation(sv);
+	unpack_UA_Annotation(p, sv);
 }
 #endif
 
@@ -482,14 +450,12 @@ XS_unpack_UA_AnonymousIdentityToken(SV *in)
 static void
 table_pack_UA_AnonymousIdentityToken(SV *sv, void *p)
 {
-	UA_AnonymousIdentityToken *data = p;
-	XS_pack_UA_AnonymousIdentityToken(sv, *data);
+	pack_UA_AnonymousIdentityToken(sv, p);
 }
 static void
 table_unpack_UA_AnonymousIdentityToken(SV *sv, void *p)
 {
-	UA_AnonymousIdentityToken *data = p;
-	*data = XS_unpack_UA_AnonymousIdentityToken(sv);
+	unpack_UA_AnonymousIdentityToken(p, sv);
 }
 #endif
 
@@ -511,14 +477,12 @@ XS_unpack_UA_ApplicationDescription(SV *in)
 static void
 table_pack_UA_ApplicationDescription(SV *sv, void *p)
 {
-	UA_ApplicationDescription *data = p;
-	XS_pack_UA_ApplicationDescription(sv, *data);
+	pack_UA_ApplicationDescription(sv, p);
 }
 static void
 table_unpack_UA_ApplicationDescription(SV *sv, void *p)
 {
-	UA_ApplicationDescription *data = p;
-	*data = XS_unpack_UA_ApplicationDescription(sv);
+	unpack_UA_ApplicationDescription(p, sv);
 }
 #endif
 
@@ -540,14 +504,12 @@ XS_unpack_UA_ApplicationInstanceCertificate(SV *in)
 static void
 table_pack_UA_ApplicationInstanceCertificate(SV *sv, void *p)
 {
-	UA_ApplicationInstanceCertificate *data = p;
-	XS_pack_UA_ApplicationInstanceCertificate(sv, *data);
+	pack_UA_ApplicationInstanceCertificate(sv, p);
 }
 static void
 table_unpack_UA_ApplicationInstanceCertificate(SV *sv, void *p)
 {
-	UA_ApplicationInstanceCertificate *data = p;
-	*data = XS_unpack_UA_ApplicationInstanceCertificate(sv);
+	unpack_UA_ApplicationInstanceCertificate(p, sv);
 }
 #endif
 
@@ -569,14 +531,12 @@ XS_unpack_UA_ApplicationType(SV *in)
 static void
 table_pack_UA_ApplicationType(SV *sv, void *p)
 {
-	UA_ApplicationType *data = p;
-	XS_pack_UA_ApplicationType(sv, *data);
+	pack_UA_ApplicationType(sv, p);
 }
 static void
 table_unpack_UA_ApplicationType(SV *sv, void *p)
 {
-	UA_ApplicationType *data = p;
-	*data = XS_unpack_UA_ApplicationType(sv);
+	unpack_UA_ApplicationType(p, sv);
 }
 #endif
 
@@ -598,14 +558,12 @@ XS_unpack_UA_Argument(SV *in)
 static void
 table_pack_UA_Argument(SV *sv, void *p)
 {
-	UA_Argument *data = p;
-	XS_pack_UA_Argument(sv, *data);
+	pack_UA_Argument(sv, p);
 }
 static void
 table_unpack_UA_Argument(SV *sv, void *p)
 {
-	UA_Argument *data = p;
-	*data = XS_unpack_UA_Argument(sv);
+	unpack_UA_Argument(p, sv);
 }
 #endif
 
@@ -627,14 +585,12 @@ XS_unpack_UA_AttributeOperand(SV *in)
 static void
 table_pack_UA_AttributeOperand(SV *sv, void *p)
 {
-	UA_AttributeOperand *data = p;
-	XS_pack_UA_AttributeOperand(sv, *data);
+	pack_UA_AttributeOperand(sv, p);
 }
 static void
 table_unpack_UA_AttributeOperand(SV *sv, void *p)
 {
-	UA_AttributeOperand *data = p;
-	*data = XS_unpack_UA_AttributeOperand(sv);
+	unpack_UA_AttributeOperand(p, sv);
 }
 #endif
 
@@ -656,14 +612,12 @@ XS_unpack_UA_AttributeWriteMask(SV *in)
 static void
 table_pack_UA_AttributeWriteMask(SV *sv, void *p)
 {
-	UA_AttributeWriteMask *data = p;
-	XS_pack_UA_AttributeWriteMask(sv, *data);
+	pack_UA_AttributeWriteMask(sv, p);
 }
 static void
 table_unpack_UA_AttributeWriteMask(SV *sv, void *p)
 {
-	UA_AttributeWriteMask *data = p;
-	*data = XS_unpack_UA_AttributeWriteMask(sv);
+	unpack_UA_AttributeWriteMask(p, sv);
 }
 #endif
 
@@ -685,14 +639,12 @@ XS_unpack_UA_AudioDataType(SV *in)
 static void
 table_pack_UA_AudioDataType(SV *sv, void *p)
 {
-	UA_AudioDataType *data = p;
-	XS_pack_UA_AudioDataType(sv, *data);
+	pack_UA_AudioDataType(sv, p);
 }
 static void
 table_unpack_UA_AudioDataType(SV *sv, void *p)
 {
-	UA_AudioDataType *data = p;
-	*data = XS_unpack_UA_AudioDataType(sv);
+	unpack_UA_AudioDataType(p, sv);
 }
 #endif
 
@@ -714,14 +666,12 @@ XS_unpack_UA_AxisInformation(SV *in)
 static void
 table_pack_UA_AxisInformation(SV *sv, void *p)
 {
-	UA_AxisInformation *data = p;
-	XS_pack_UA_AxisInformation(sv, *data);
+	pack_UA_AxisInformation(sv, p);
 }
 static void
 table_unpack_UA_AxisInformation(SV *sv, void *p)
 {
-	UA_AxisInformation *data = p;
-	*data = XS_unpack_UA_AxisInformation(sv);
+	unpack_UA_AxisInformation(p, sv);
 }
 #endif
 
@@ -743,14 +693,12 @@ XS_unpack_UA_AxisScaleEnumeration(SV *in)
 static void
 table_pack_UA_AxisScaleEnumeration(SV *sv, void *p)
 {
-	UA_AxisScaleEnumeration *data = p;
-	XS_pack_UA_AxisScaleEnumeration(sv, *data);
+	pack_UA_AxisScaleEnumeration(sv, p);
 }
 static void
 table_unpack_UA_AxisScaleEnumeration(SV *sv, void *p)
 {
-	UA_AxisScaleEnumeration *data = p;
-	*data = XS_unpack_UA_AxisScaleEnumeration(sv);
+	unpack_UA_AxisScaleEnumeration(p, sv);
 }
 #endif
 
@@ -772,14 +720,12 @@ XS_unpack_UA_BitFieldMaskDataType(SV *in)
 static void
 table_pack_UA_BitFieldMaskDataType(SV *sv, void *p)
 {
-	UA_BitFieldMaskDataType *data = p;
-	XS_pack_UA_BitFieldMaskDataType(sv, *data);
+	pack_UA_BitFieldMaskDataType(sv, p);
 }
 static void
 table_unpack_UA_BitFieldMaskDataType(SV *sv, void *p)
 {
-	UA_BitFieldMaskDataType *data = p;
-	*data = XS_unpack_UA_BitFieldMaskDataType(sv);
+	unpack_UA_BitFieldMaskDataType(p, sv);
 }
 #endif
 
@@ -801,14 +747,12 @@ XS_unpack_UA_Boolean(SV *in)
 static void
 table_pack_UA_Boolean(SV *sv, void *p)
 {
-	UA_Boolean *data = p;
-	XS_pack_UA_Boolean(sv, *data);
+	pack_UA_Boolean(sv, p);
 }
 static void
 table_unpack_UA_Boolean(SV *sv, void *p)
 {
-	UA_Boolean *data = p;
-	*data = XS_unpack_UA_Boolean(sv);
+	unpack_UA_Boolean(p, sv);
 }
 #endif
 
@@ -830,14 +774,12 @@ XS_unpack_UA_BrokerConnectionTransportDataType(SV *in)
 static void
 table_pack_UA_BrokerConnectionTransportDataType(SV *sv, void *p)
 {
-	UA_BrokerConnectionTransportDataType *data = p;
-	XS_pack_UA_BrokerConnectionTransportDataType(sv, *data);
+	pack_UA_BrokerConnectionTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_BrokerConnectionTransportDataType(SV *sv, void *p)
 {
-	UA_BrokerConnectionTransportDataType *data = p;
-	*data = XS_unpack_UA_BrokerConnectionTransportDataType(sv);
+	unpack_UA_BrokerConnectionTransportDataType(p, sv);
 }
 #endif
 
@@ -859,14 +801,12 @@ XS_unpack_UA_BrokerDataSetReaderTransportDataType(SV *in)
 static void
 table_pack_UA_BrokerDataSetReaderTransportDataType(SV *sv, void *p)
 {
-	UA_BrokerDataSetReaderTransportDataType *data = p;
-	XS_pack_UA_BrokerDataSetReaderTransportDataType(sv, *data);
+	pack_UA_BrokerDataSetReaderTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_BrokerDataSetReaderTransportDataType(SV *sv, void *p)
 {
-	UA_BrokerDataSetReaderTransportDataType *data = p;
-	*data = XS_unpack_UA_BrokerDataSetReaderTransportDataType(sv);
+	unpack_UA_BrokerDataSetReaderTransportDataType(p, sv);
 }
 #endif
 
@@ -888,14 +828,12 @@ XS_unpack_UA_BrokerDataSetWriterTransportDataType(SV *in)
 static void
 table_pack_UA_BrokerDataSetWriterTransportDataType(SV *sv, void *p)
 {
-	UA_BrokerDataSetWriterTransportDataType *data = p;
-	XS_pack_UA_BrokerDataSetWriterTransportDataType(sv, *data);
+	pack_UA_BrokerDataSetWriterTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_BrokerDataSetWriterTransportDataType(SV *sv, void *p)
 {
-	UA_BrokerDataSetWriterTransportDataType *data = p;
-	*data = XS_unpack_UA_BrokerDataSetWriterTransportDataType(sv);
+	unpack_UA_BrokerDataSetWriterTransportDataType(p, sv);
 }
 #endif
 
@@ -917,14 +855,12 @@ XS_unpack_UA_BrokerTransportQualityOfService(SV *in)
 static void
 table_pack_UA_BrokerTransportQualityOfService(SV *sv, void *p)
 {
-	UA_BrokerTransportQualityOfService *data = p;
-	XS_pack_UA_BrokerTransportQualityOfService(sv, *data);
+	pack_UA_BrokerTransportQualityOfService(sv, p);
 }
 static void
 table_unpack_UA_BrokerTransportQualityOfService(SV *sv, void *p)
 {
-	UA_BrokerTransportQualityOfService *data = p;
-	*data = XS_unpack_UA_BrokerTransportQualityOfService(sv);
+	unpack_UA_BrokerTransportQualityOfService(p, sv);
 }
 #endif
 
@@ -946,14 +882,12 @@ XS_unpack_UA_BrokerWriterGroupTransportDataType(SV *in)
 static void
 table_pack_UA_BrokerWriterGroupTransportDataType(SV *sv, void *p)
 {
-	UA_BrokerWriterGroupTransportDataType *data = p;
-	XS_pack_UA_BrokerWriterGroupTransportDataType(sv, *data);
+	pack_UA_BrokerWriterGroupTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_BrokerWriterGroupTransportDataType(SV *sv, void *p)
 {
-	UA_BrokerWriterGroupTransportDataType *data = p;
-	*data = XS_unpack_UA_BrokerWriterGroupTransportDataType(sv);
+	unpack_UA_BrokerWriterGroupTransportDataType(p, sv);
 }
 #endif
 
@@ -975,14 +909,12 @@ XS_unpack_UA_BrowseDescription(SV *in)
 static void
 table_pack_UA_BrowseDescription(SV *sv, void *p)
 {
-	UA_BrowseDescription *data = p;
-	XS_pack_UA_BrowseDescription(sv, *data);
+	pack_UA_BrowseDescription(sv, p);
 }
 static void
 table_unpack_UA_BrowseDescription(SV *sv, void *p)
 {
-	UA_BrowseDescription *data = p;
-	*data = XS_unpack_UA_BrowseDescription(sv);
+	unpack_UA_BrowseDescription(p, sv);
 }
 #endif
 
@@ -1004,14 +936,12 @@ XS_unpack_UA_BrowseDirection(SV *in)
 static void
 table_pack_UA_BrowseDirection(SV *sv, void *p)
 {
-	UA_BrowseDirection *data = p;
-	XS_pack_UA_BrowseDirection(sv, *data);
+	pack_UA_BrowseDirection(sv, p);
 }
 static void
 table_unpack_UA_BrowseDirection(SV *sv, void *p)
 {
-	UA_BrowseDirection *data = p;
-	*data = XS_unpack_UA_BrowseDirection(sv);
+	unpack_UA_BrowseDirection(p, sv);
 }
 #endif
 
@@ -1033,14 +963,12 @@ XS_unpack_UA_BrowseNextRequest(SV *in)
 static void
 table_pack_UA_BrowseNextRequest(SV *sv, void *p)
 {
-	UA_BrowseNextRequest *data = p;
-	XS_pack_UA_BrowseNextRequest(sv, *data);
+	pack_UA_BrowseNextRequest(sv, p);
 }
 static void
 table_unpack_UA_BrowseNextRequest(SV *sv, void *p)
 {
-	UA_BrowseNextRequest *data = p;
-	*data = XS_unpack_UA_BrowseNextRequest(sv);
+	unpack_UA_BrowseNextRequest(p, sv);
 }
 #endif
 
@@ -1062,14 +990,12 @@ XS_unpack_UA_BrowseNextResponse(SV *in)
 static void
 table_pack_UA_BrowseNextResponse(SV *sv, void *p)
 {
-	UA_BrowseNextResponse *data = p;
-	XS_pack_UA_BrowseNextResponse(sv, *data);
+	pack_UA_BrowseNextResponse(sv, p);
 }
 static void
 table_unpack_UA_BrowseNextResponse(SV *sv, void *p)
 {
-	UA_BrowseNextResponse *data = p;
-	*data = XS_unpack_UA_BrowseNextResponse(sv);
+	unpack_UA_BrowseNextResponse(p, sv);
 }
 #endif
 
@@ -1091,14 +1017,12 @@ XS_unpack_UA_BrowsePath(SV *in)
 static void
 table_pack_UA_BrowsePath(SV *sv, void *p)
 {
-	UA_BrowsePath *data = p;
-	XS_pack_UA_BrowsePath(sv, *data);
+	pack_UA_BrowsePath(sv, p);
 }
 static void
 table_unpack_UA_BrowsePath(SV *sv, void *p)
 {
-	UA_BrowsePath *data = p;
-	*data = XS_unpack_UA_BrowsePath(sv);
+	unpack_UA_BrowsePath(p, sv);
 }
 #endif
 
@@ -1120,14 +1044,12 @@ XS_unpack_UA_BrowsePathResult(SV *in)
 static void
 table_pack_UA_BrowsePathResult(SV *sv, void *p)
 {
-	UA_BrowsePathResult *data = p;
-	XS_pack_UA_BrowsePathResult(sv, *data);
+	pack_UA_BrowsePathResult(sv, p);
 }
 static void
 table_unpack_UA_BrowsePathResult(SV *sv, void *p)
 {
-	UA_BrowsePathResult *data = p;
-	*data = XS_unpack_UA_BrowsePathResult(sv);
+	unpack_UA_BrowsePathResult(p, sv);
 }
 #endif
 
@@ -1149,14 +1071,12 @@ XS_unpack_UA_BrowsePathTarget(SV *in)
 static void
 table_pack_UA_BrowsePathTarget(SV *sv, void *p)
 {
-	UA_BrowsePathTarget *data = p;
-	XS_pack_UA_BrowsePathTarget(sv, *data);
+	pack_UA_BrowsePathTarget(sv, p);
 }
 static void
 table_unpack_UA_BrowsePathTarget(SV *sv, void *p)
 {
-	UA_BrowsePathTarget *data = p;
-	*data = XS_unpack_UA_BrowsePathTarget(sv);
+	unpack_UA_BrowsePathTarget(p, sv);
 }
 #endif
 
@@ -1178,14 +1098,12 @@ XS_unpack_UA_BrowseRequest(SV *in)
 static void
 table_pack_UA_BrowseRequest(SV *sv, void *p)
 {
-	UA_BrowseRequest *data = p;
-	XS_pack_UA_BrowseRequest(sv, *data);
+	pack_UA_BrowseRequest(sv, p);
 }
 static void
 table_unpack_UA_BrowseRequest(SV *sv, void *p)
 {
-	UA_BrowseRequest *data = p;
-	*data = XS_unpack_UA_BrowseRequest(sv);
+	unpack_UA_BrowseRequest(p, sv);
 }
 #endif
 
@@ -1207,14 +1125,12 @@ XS_unpack_UA_BrowseResponse(SV *in)
 static void
 table_pack_UA_BrowseResponse(SV *sv, void *p)
 {
-	UA_BrowseResponse *data = p;
-	XS_pack_UA_BrowseResponse(sv, *data);
+	pack_UA_BrowseResponse(sv, p);
 }
 static void
 table_unpack_UA_BrowseResponse(SV *sv, void *p)
 {
-	UA_BrowseResponse *data = p;
-	*data = XS_unpack_UA_BrowseResponse(sv);
+	unpack_UA_BrowseResponse(p, sv);
 }
 #endif
 
@@ -1236,14 +1152,12 @@ XS_unpack_UA_BrowseResult(SV *in)
 static void
 table_pack_UA_BrowseResult(SV *sv, void *p)
 {
-	UA_BrowseResult *data = p;
-	XS_pack_UA_BrowseResult(sv, *data);
+	pack_UA_BrowseResult(sv, p);
 }
 static void
 table_unpack_UA_BrowseResult(SV *sv, void *p)
 {
-	UA_BrowseResult *data = p;
-	*data = XS_unpack_UA_BrowseResult(sv);
+	unpack_UA_BrowseResult(p, sv);
 }
 #endif
 
@@ -1265,14 +1179,12 @@ XS_unpack_UA_BrowseResultMask(SV *in)
 static void
 table_pack_UA_BrowseResultMask(SV *sv, void *p)
 {
-	UA_BrowseResultMask *data = p;
-	XS_pack_UA_BrowseResultMask(sv, *data);
+	pack_UA_BrowseResultMask(sv, p);
 }
 static void
 table_unpack_UA_BrowseResultMask(SV *sv, void *p)
 {
-	UA_BrowseResultMask *data = p;
-	*data = XS_unpack_UA_BrowseResultMask(sv);
+	unpack_UA_BrowseResultMask(p, sv);
 }
 #endif
 
@@ -1294,14 +1206,12 @@ XS_unpack_UA_BuildInfo(SV *in)
 static void
 table_pack_UA_BuildInfo(SV *sv, void *p)
 {
-	UA_BuildInfo *data = p;
-	XS_pack_UA_BuildInfo(sv, *data);
+	pack_UA_BuildInfo(sv, p);
 }
 static void
 table_unpack_UA_BuildInfo(SV *sv, void *p)
 {
-	UA_BuildInfo *data = p;
-	*data = XS_unpack_UA_BuildInfo(sv);
+	unpack_UA_BuildInfo(p, sv);
 }
 #endif
 
@@ -1323,14 +1233,12 @@ XS_unpack_UA_Byte(SV *in)
 static void
 table_pack_UA_Byte(SV *sv, void *p)
 {
-	UA_Byte *data = p;
-	XS_pack_UA_Byte(sv, *data);
+	pack_UA_Byte(sv, p);
 }
 static void
 table_unpack_UA_Byte(SV *sv, void *p)
 {
-	UA_Byte *data = p;
-	*data = XS_unpack_UA_Byte(sv);
+	unpack_UA_Byte(p, sv);
 }
 #endif
 
@@ -1352,14 +1260,12 @@ XS_unpack_UA_ByteString(SV *in)
 static void
 table_pack_UA_ByteString(SV *sv, void *p)
 {
-	UA_ByteString *data = p;
-	XS_pack_UA_ByteString(sv, *data);
+	pack_UA_ByteString(sv, p);
 }
 static void
 table_unpack_UA_ByteString(SV *sv, void *p)
 {
-	UA_ByteString *data = p;
-	*data = XS_unpack_UA_ByteString(sv);
+	unpack_UA_ByteString(p, sv);
 }
 #endif
 
@@ -1381,14 +1287,12 @@ XS_unpack_UA_CallMethodRequest(SV *in)
 static void
 table_pack_UA_CallMethodRequest(SV *sv, void *p)
 {
-	UA_CallMethodRequest *data = p;
-	XS_pack_UA_CallMethodRequest(sv, *data);
+	pack_UA_CallMethodRequest(sv, p);
 }
 static void
 table_unpack_UA_CallMethodRequest(SV *sv, void *p)
 {
-	UA_CallMethodRequest *data = p;
-	*data = XS_unpack_UA_CallMethodRequest(sv);
+	unpack_UA_CallMethodRequest(p, sv);
 }
 #endif
 
@@ -1410,14 +1314,12 @@ XS_unpack_UA_CallMethodResult(SV *in)
 static void
 table_pack_UA_CallMethodResult(SV *sv, void *p)
 {
-	UA_CallMethodResult *data = p;
-	XS_pack_UA_CallMethodResult(sv, *data);
+	pack_UA_CallMethodResult(sv, p);
 }
 static void
 table_unpack_UA_CallMethodResult(SV *sv, void *p)
 {
-	UA_CallMethodResult *data = p;
-	*data = XS_unpack_UA_CallMethodResult(sv);
+	unpack_UA_CallMethodResult(p, sv);
 }
 #endif
 
@@ -1439,14 +1341,12 @@ XS_unpack_UA_CallRequest(SV *in)
 static void
 table_pack_UA_CallRequest(SV *sv, void *p)
 {
-	UA_CallRequest *data = p;
-	XS_pack_UA_CallRequest(sv, *data);
+	pack_UA_CallRequest(sv, p);
 }
 static void
 table_unpack_UA_CallRequest(SV *sv, void *p)
 {
-	UA_CallRequest *data = p;
-	*data = XS_unpack_UA_CallRequest(sv);
+	unpack_UA_CallRequest(p, sv);
 }
 #endif
 
@@ -1468,14 +1368,12 @@ XS_unpack_UA_CallResponse(SV *in)
 static void
 table_pack_UA_CallResponse(SV *sv, void *p)
 {
-	UA_CallResponse *data = p;
-	XS_pack_UA_CallResponse(sv, *data);
+	pack_UA_CallResponse(sv, p);
 }
 static void
 table_unpack_UA_CallResponse(SV *sv, void *p)
 {
-	UA_CallResponse *data = p;
-	*data = XS_unpack_UA_CallResponse(sv);
+	unpack_UA_CallResponse(p, sv);
 }
 #endif
 
@@ -1497,14 +1395,12 @@ XS_unpack_UA_CancelRequest(SV *in)
 static void
 table_pack_UA_CancelRequest(SV *sv, void *p)
 {
-	UA_CancelRequest *data = p;
-	XS_pack_UA_CancelRequest(sv, *data);
+	pack_UA_CancelRequest(sv, p);
 }
 static void
 table_unpack_UA_CancelRequest(SV *sv, void *p)
 {
-	UA_CancelRequest *data = p;
-	*data = XS_unpack_UA_CancelRequest(sv);
+	unpack_UA_CancelRequest(p, sv);
 }
 #endif
 
@@ -1526,14 +1422,12 @@ XS_unpack_UA_CancelResponse(SV *in)
 static void
 table_pack_UA_CancelResponse(SV *sv, void *p)
 {
-	UA_CancelResponse *data = p;
-	XS_pack_UA_CancelResponse(sv, *data);
+	pack_UA_CancelResponse(sv, p);
 }
 static void
 table_unpack_UA_CancelResponse(SV *sv, void *p)
 {
-	UA_CancelResponse *data = p;
-	*data = XS_unpack_UA_CancelResponse(sv);
+	unpack_UA_CancelResponse(p, sv);
 }
 #endif
 
@@ -1555,14 +1449,12 @@ XS_unpack_UA_CartesianCoordinates(SV *in)
 static void
 table_pack_UA_CartesianCoordinates(SV *sv, void *p)
 {
-	UA_CartesianCoordinates *data = p;
-	XS_pack_UA_CartesianCoordinates(sv, *data);
+	pack_UA_CartesianCoordinates(sv, p);
 }
 static void
 table_unpack_UA_CartesianCoordinates(SV *sv, void *p)
 {
-	UA_CartesianCoordinates *data = p;
-	*data = XS_unpack_UA_CartesianCoordinates(sv);
+	unpack_UA_CartesianCoordinates(p, sv);
 }
 #endif
 
@@ -1584,14 +1476,12 @@ XS_unpack_UA_ChannelSecurityToken(SV *in)
 static void
 table_pack_UA_ChannelSecurityToken(SV *sv, void *p)
 {
-	UA_ChannelSecurityToken *data = p;
-	XS_pack_UA_ChannelSecurityToken(sv, *data);
+	pack_UA_ChannelSecurityToken(sv, p);
 }
 static void
 table_unpack_UA_ChannelSecurityToken(SV *sv, void *p)
 {
-	UA_ChannelSecurityToken *data = p;
-	*data = XS_unpack_UA_ChannelSecurityToken(sv);
+	unpack_UA_ChannelSecurityToken(p, sv);
 }
 #endif
 
@@ -1613,14 +1503,12 @@ XS_unpack_UA_CloseSecureChannelRequest(SV *in)
 static void
 table_pack_UA_CloseSecureChannelRequest(SV *sv, void *p)
 {
-	UA_CloseSecureChannelRequest *data = p;
-	XS_pack_UA_CloseSecureChannelRequest(sv, *data);
+	pack_UA_CloseSecureChannelRequest(sv, p);
 }
 static void
 table_unpack_UA_CloseSecureChannelRequest(SV *sv, void *p)
 {
-	UA_CloseSecureChannelRequest *data = p;
-	*data = XS_unpack_UA_CloseSecureChannelRequest(sv);
+	unpack_UA_CloseSecureChannelRequest(p, sv);
 }
 #endif
 
@@ -1642,14 +1530,12 @@ XS_unpack_UA_CloseSecureChannelResponse(SV *in)
 static void
 table_pack_UA_CloseSecureChannelResponse(SV *sv, void *p)
 {
-	UA_CloseSecureChannelResponse *data = p;
-	XS_pack_UA_CloseSecureChannelResponse(sv, *data);
+	pack_UA_CloseSecureChannelResponse(sv, p);
 }
 static void
 table_unpack_UA_CloseSecureChannelResponse(SV *sv, void *p)
 {
-	UA_CloseSecureChannelResponse *data = p;
-	*data = XS_unpack_UA_CloseSecureChannelResponse(sv);
+	unpack_UA_CloseSecureChannelResponse(p, sv);
 }
 #endif
 
@@ -1671,14 +1557,12 @@ XS_unpack_UA_CloseSessionRequest(SV *in)
 static void
 table_pack_UA_CloseSessionRequest(SV *sv, void *p)
 {
-	UA_CloseSessionRequest *data = p;
-	XS_pack_UA_CloseSessionRequest(sv, *data);
+	pack_UA_CloseSessionRequest(sv, p);
 }
 static void
 table_unpack_UA_CloseSessionRequest(SV *sv, void *p)
 {
-	UA_CloseSessionRequest *data = p;
-	*data = XS_unpack_UA_CloseSessionRequest(sv);
+	unpack_UA_CloseSessionRequest(p, sv);
 }
 #endif
 
@@ -1700,14 +1584,12 @@ XS_unpack_UA_CloseSessionResponse(SV *in)
 static void
 table_pack_UA_CloseSessionResponse(SV *sv, void *p)
 {
-	UA_CloseSessionResponse *data = p;
-	XS_pack_UA_CloseSessionResponse(sv, *data);
+	pack_UA_CloseSessionResponse(sv, p);
 }
 static void
 table_unpack_UA_CloseSessionResponse(SV *sv, void *p)
 {
-	UA_CloseSessionResponse *data = p;
-	*data = XS_unpack_UA_CloseSessionResponse(sv);
+	unpack_UA_CloseSessionResponse(p, sv);
 }
 #endif
 
@@ -1729,14 +1611,12 @@ XS_unpack_UA_ComplexNumberType(SV *in)
 static void
 table_pack_UA_ComplexNumberType(SV *sv, void *p)
 {
-	UA_ComplexNumberType *data = p;
-	XS_pack_UA_ComplexNumberType(sv, *data);
+	pack_UA_ComplexNumberType(sv, p);
 }
 static void
 table_unpack_UA_ComplexNumberType(SV *sv, void *p)
 {
-	UA_ComplexNumberType *data = p;
-	*data = XS_unpack_UA_ComplexNumberType(sv);
+	unpack_UA_ComplexNumberType(p, sv);
 }
 #endif
 
@@ -1758,14 +1638,12 @@ XS_unpack_UA_ConfigurationVersionDataType(SV *in)
 static void
 table_pack_UA_ConfigurationVersionDataType(SV *sv, void *p)
 {
-	UA_ConfigurationVersionDataType *data = p;
-	XS_pack_UA_ConfigurationVersionDataType(sv, *data);
+	pack_UA_ConfigurationVersionDataType(sv, p);
 }
 static void
 table_unpack_UA_ConfigurationVersionDataType(SV *sv, void *p)
 {
-	UA_ConfigurationVersionDataType *data = p;
-	*data = XS_unpack_UA_ConfigurationVersionDataType(sv);
+	unpack_UA_ConfigurationVersionDataType(p, sv);
 }
 #endif
 
@@ -1787,14 +1665,12 @@ XS_unpack_UA_ConnectionTransportDataType(SV *in)
 static void
 table_pack_UA_ConnectionTransportDataType(SV *sv, void *p)
 {
-	UA_ConnectionTransportDataType *data = p;
-	XS_pack_UA_ConnectionTransportDataType(sv, *data);
+	pack_UA_ConnectionTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_ConnectionTransportDataType(SV *sv, void *p)
 {
-	UA_ConnectionTransportDataType *data = p;
-	*data = XS_unpack_UA_ConnectionTransportDataType(sv);
+	unpack_UA_ConnectionTransportDataType(p, sv);
 }
 #endif
 
@@ -1816,14 +1692,12 @@ XS_unpack_UA_ContentFilter(SV *in)
 static void
 table_pack_UA_ContentFilter(SV *sv, void *p)
 {
-	UA_ContentFilter *data = p;
-	XS_pack_UA_ContentFilter(sv, *data);
+	pack_UA_ContentFilter(sv, p);
 }
 static void
 table_unpack_UA_ContentFilter(SV *sv, void *p)
 {
-	UA_ContentFilter *data = p;
-	*data = XS_unpack_UA_ContentFilter(sv);
+	unpack_UA_ContentFilter(p, sv);
 }
 #endif
 
@@ -1845,14 +1719,12 @@ XS_unpack_UA_ContentFilterElement(SV *in)
 static void
 table_pack_UA_ContentFilterElement(SV *sv, void *p)
 {
-	UA_ContentFilterElement *data = p;
-	XS_pack_UA_ContentFilterElement(sv, *data);
+	pack_UA_ContentFilterElement(sv, p);
 }
 static void
 table_unpack_UA_ContentFilterElement(SV *sv, void *p)
 {
-	UA_ContentFilterElement *data = p;
-	*data = XS_unpack_UA_ContentFilterElement(sv);
+	unpack_UA_ContentFilterElement(p, sv);
 }
 #endif
 
@@ -1874,14 +1746,12 @@ XS_unpack_UA_ContentFilterElementResult(SV *in)
 static void
 table_pack_UA_ContentFilterElementResult(SV *sv, void *p)
 {
-	UA_ContentFilterElementResult *data = p;
-	XS_pack_UA_ContentFilterElementResult(sv, *data);
+	pack_UA_ContentFilterElementResult(sv, p);
 }
 static void
 table_unpack_UA_ContentFilterElementResult(SV *sv, void *p)
 {
-	UA_ContentFilterElementResult *data = p;
-	*data = XS_unpack_UA_ContentFilterElementResult(sv);
+	unpack_UA_ContentFilterElementResult(p, sv);
 }
 #endif
 
@@ -1903,14 +1773,12 @@ XS_unpack_UA_ContentFilterResult(SV *in)
 static void
 table_pack_UA_ContentFilterResult(SV *sv, void *p)
 {
-	UA_ContentFilterResult *data = p;
-	XS_pack_UA_ContentFilterResult(sv, *data);
+	pack_UA_ContentFilterResult(sv, p);
 }
 static void
 table_unpack_UA_ContentFilterResult(SV *sv, void *p)
 {
-	UA_ContentFilterResult *data = p;
-	*data = XS_unpack_UA_ContentFilterResult(sv);
+	unpack_UA_ContentFilterResult(p, sv);
 }
 #endif
 
@@ -1932,14 +1800,12 @@ XS_unpack_UA_ContinuationPoint(SV *in)
 static void
 table_pack_UA_ContinuationPoint(SV *sv, void *p)
 {
-	UA_ContinuationPoint *data = p;
-	XS_pack_UA_ContinuationPoint(sv, *data);
+	pack_UA_ContinuationPoint(sv, p);
 }
 static void
 table_unpack_UA_ContinuationPoint(SV *sv, void *p)
 {
-	UA_ContinuationPoint *data = p;
-	*data = XS_unpack_UA_ContinuationPoint(sv);
+	unpack_UA_ContinuationPoint(p, sv);
 }
 #endif
 
@@ -1961,14 +1827,12 @@ XS_unpack_UA_Counter(SV *in)
 static void
 table_pack_UA_Counter(SV *sv, void *p)
 {
-	UA_Counter *data = p;
-	XS_pack_UA_Counter(sv, *data);
+	pack_UA_Counter(sv, p);
 }
 static void
 table_unpack_UA_Counter(SV *sv, void *p)
 {
-	UA_Counter *data = p;
-	*data = XS_unpack_UA_Counter(sv);
+	unpack_UA_Counter(p, sv);
 }
 #endif
 
@@ -1990,14 +1854,12 @@ XS_unpack_UA_CreateMonitoredItemsRequest(SV *in)
 static void
 table_pack_UA_CreateMonitoredItemsRequest(SV *sv, void *p)
 {
-	UA_CreateMonitoredItemsRequest *data = p;
-	XS_pack_UA_CreateMonitoredItemsRequest(sv, *data);
+	pack_UA_CreateMonitoredItemsRequest(sv, p);
 }
 static void
 table_unpack_UA_CreateMonitoredItemsRequest(SV *sv, void *p)
 {
-	UA_CreateMonitoredItemsRequest *data = p;
-	*data = XS_unpack_UA_CreateMonitoredItemsRequest(sv);
+	unpack_UA_CreateMonitoredItemsRequest(p, sv);
 }
 #endif
 
@@ -2019,14 +1881,12 @@ XS_unpack_UA_CreateMonitoredItemsResponse(SV *in)
 static void
 table_pack_UA_CreateMonitoredItemsResponse(SV *sv, void *p)
 {
-	UA_CreateMonitoredItemsResponse *data = p;
-	XS_pack_UA_CreateMonitoredItemsResponse(sv, *data);
+	pack_UA_CreateMonitoredItemsResponse(sv, p);
 }
 static void
 table_unpack_UA_CreateMonitoredItemsResponse(SV *sv, void *p)
 {
-	UA_CreateMonitoredItemsResponse *data = p;
-	*data = XS_unpack_UA_CreateMonitoredItemsResponse(sv);
+	unpack_UA_CreateMonitoredItemsResponse(p, sv);
 }
 #endif
 
@@ -2048,14 +1908,12 @@ XS_unpack_UA_CreateSessionRequest(SV *in)
 static void
 table_pack_UA_CreateSessionRequest(SV *sv, void *p)
 {
-	UA_CreateSessionRequest *data = p;
-	XS_pack_UA_CreateSessionRequest(sv, *data);
+	pack_UA_CreateSessionRequest(sv, p);
 }
 static void
 table_unpack_UA_CreateSessionRequest(SV *sv, void *p)
 {
-	UA_CreateSessionRequest *data = p;
-	*data = XS_unpack_UA_CreateSessionRequest(sv);
+	unpack_UA_CreateSessionRequest(p, sv);
 }
 #endif
 
@@ -2077,14 +1935,12 @@ XS_unpack_UA_CreateSessionResponse(SV *in)
 static void
 table_pack_UA_CreateSessionResponse(SV *sv, void *p)
 {
-	UA_CreateSessionResponse *data = p;
-	XS_pack_UA_CreateSessionResponse(sv, *data);
+	pack_UA_CreateSessionResponse(sv, p);
 }
 static void
 table_unpack_UA_CreateSessionResponse(SV *sv, void *p)
 {
-	UA_CreateSessionResponse *data = p;
-	*data = XS_unpack_UA_CreateSessionResponse(sv);
+	unpack_UA_CreateSessionResponse(p, sv);
 }
 #endif
 
@@ -2106,14 +1962,12 @@ XS_unpack_UA_CreateSubscriptionRequest(SV *in)
 static void
 table_pack_UA_CreateSubscriptionRequest(SV *sv, void *p)
 {
-	UA_CreateSubscriptionRequest *data = p;
-	XS_pack_UA_CreateSubscriptionRequest(sv, *data);
+	pack_UA_CreateSubscriptionRequest(sv, p);
 }
 static void
 table_unpack_UA_CreateSubscriptionRequest(SV *sv, void *p)
 {
-	UA_CreateSubscriptionRequest *data = p;
-	*data = XS_unpack_UA_CreateSubscriptionRequest(sv);
+	unpack_UA_CreateSubscriptionRequest(p, sv);
 }
 #endif
 
@@ -2135,14 +1989,12 @@ XS_unpack_UA_CreateSubscriptionResponse(SV *in)
 static void
 table_pack_UA_CreateSubscriptionResponse(SV *sv, void *p)
 {
-	UA_CreateSubscriptionResponse *data = p;
-	XS_pack_UA_CreateSubscriptionResponse(sv, *data);
+	pack_UA_CreateSubscriptionResponse(sv, p);
 }
 static void
 table_unpack_UA_CreateSubscriptionResponse(SV *sv, void *p)
 {
-	UA_CreateSubscriptionResponse *data = p;
-	*data = XS_unpack_UA_CreateSubscriptionResponse(sv);
+	unpack_UA_CreateSubscriptionResponse(p, sv);
 }
 #endif
 
@@ -2164,14 +2016,12 @@ XS_unpack_UA_CurrencyUnitType(SV *in)
 static void
 table_pack_UA_CurrencyUnitType(SV *sv, void *p)
 {
-	UA_CurrencyUnitType *data = p;
-	XS_pack_UA_CurrencyUnitType(sv, *data);
+	pack_UA_CurrencyUnitType(sv, p);
 }
 static void
 table_unpack_UA_CurrencyUnitType(SV *sv, void *p)
 {
-	UA_CurrencyUnitType *data = p;
-	*data = XS_unpack_UA_CurrencyUnitType(sv);
+	unpack_UA_CurrencyUnitType(p, sv);
 }
 #endif
 
@@ -2193,14 +2043,12 @@ XS_unpack_UA_DataChangeFilter(SV *in)
 static void
 table_pack_UA_DataChangeFilter(SV *sv, void *p)
 {
-	UA_DataChangeFilter *data = p;
-	XS_pack_UA_DataChangeFilter(sv, *data);
+	pack_UA_DataChangeFilter(sv, p);
 }
 static void
 table_unpack_UA_DataChangeFilter(SV *sv, void *p)
 {
-	UA_DataChangeFilter *data = p;
-	*data = XS_unpack_UA_DataChangeFilter(sv);
+	unpack_UA_DataChangeFilter(p, sv);
 }
 #endif
 
@@ -2222,14 +2070,12 @@ XS_unpack_UA_DataChangeNotification(SV *in)
 static void
 table_pack_UA_DataChangeNotification(SV *sv, void *p)
 {
-	UA_DataChangeNotification *data = p;
-	XS_pack_UA_DataChangeNotification(sv, *data);
+	pack_UA_DataChangeNotification(sv, p);
 }
 static void
 table_unpack_UA_DataChangeNotification(SV *sv, void *p)
 {
-	UA_DataChangeNotification *data = p;
-	*data = XS_unpack_UA_DataChangeNotification(sv);
+	unpack_UA_DataChangeNotification(p, sv);
 }
 #endif
 
@@ -2251,14 +2097,12 @@ XS_unpack_UA_DataChangeTrigger(SV *in)
 static void
 table_pack_UA_DataChangeTrigger(SV *sv, void *p)
 {
-	UA_DataChangeTrigger *data = p;
-	XS_pack_UA_DataChangeTrigger(sv, *data);
+	pack_UA_DataChangeTrigger(sv, p);
 }
 static void
 table_unpack_UA_DataChangeTrigger(SV *sv, void *p)
 {
-	UA_DataChangeTrigger *data = p;
-	*data = XS_unpack_UA_DataChangeTrigger(sv);
+	unpack_UA_DataChangeTrigger(p, sv);
 }
 #endif
 
@@ -2280,14 +2124,12 @@ XS_unpack_UA_DataSetFieldContentMask(SV *in)
 static void
 table_pack_UA_DataSetFieldContentMask(SV *sv, void *p)
 {
-	UA_DataSetFieldContentMask *data = p;
-	XS_pack_UA_DataSetFieldContentMask(sv, *data);
+	pack_UA_DataSetFieldContentMask(sv, p);
 }
 static void
 table_unpack_UA_DataSetFieldContentMask(SV *sv, void *p)
 {
-	UA_DataSetFieldContentMask *data = p;
-	*data = XS_unpack_UA_DataSetFieldContentMask(sv);
+	unpack_UA_DataSetFieldContentMask(p, sv);
 }
 #endif
 
@@ -2309,14 +2151,12 @@ XS_unpack_UA_DataSetFieldFlags(SV *in)
 static void
 table_pack_UA_DataSetFieldFlags(SV *sv, void *p)
 {
-	UA_DataSetFieldFlags *data = p;
-	XS_pack_UA_DataSetFieldFlags(sv, *data);
+	pack_UA_DataSetFieldFlags(sv, p);
 }
 static void
 table_unpack_UA_DataSetFieldFlags(SV *sv, void *p)
 {
-	UA_DataSetFieldFlags *data = p;
-	*data = XS_unpack_UA_DataSetFieldFlags(sv);
+	unpack_UA_DataSetFieldFlags(p, sv);
 }
 #endif
 
@@ -2338,14 +2178,12 @@ XS_unpack_UA_DataSetMetaDataType(SV *in)
 static void
 table_pack_UA_DataSetMetaDataType(SV *sv, void *p)
 {
-	UA_DataSetMetaDataType *data = p;
-	XS_pack_UA_DataSetMetaDataType(sv, *data);
+	pack_UA_DataSetMetaDataType(sv, p);
 }
 static void
 table_unpack_UA_DataSetMetaDataType(SV *sv, void *p)
 {
-	UA_DataSetMetaDataType *data = p;
-	*data = XS_unpack_UA_DataSetMetaDataType(sv);
+	unpack_UA_DataSetMetaDataType(p, sv);
 }
 #endif
 
@@ -2367,14 +2205,12 @@ XS_unpack_UA_DataSetOrderingType(SV *in)
 static void
 table_pack_UA_DataSetOrderingType(SV *sv, void *p)
 {
-	UA_DataSetOrderingType *data = p;
-	XS_pack_UA_DataSetOrderingType(sv, *data);
+	pack_UA_DataSetOrderingType(sv, p);
 }
 static void
 table_unpack_UA_DataSetOrderingType(SV *sv, void *p)
 {
-	UA_DataSetOrderingType *data = p;
-	*data = XS_unpack_UA_DataSetOrderingType(sv);
+	unpack_UA_DataSetOrderingType(p, sv);
 }
 #endif
 
@@ -2396,14 +2232,12 @@ XS_unpack_UA_DataSetReaderDataType(SV *in)
 static void
 table_pack_UA_DataSetReaderDataType(SV *sv, void *p)
 {
-	UA_DataSetReaderDataType *data = p;
-	XS_pack_UA_DataSetReaderDataType(sv, *data);
+	pack_UA_DataSetReaderDataType(sv, p);
 }
 static void
 table_unpack_UA_DataSetReaderDataType(SV *sv, void *p)
 {
-	UA_DataSetReaderDataType *data = p;
-	*data = XS_unpack_UA_DataSetReaderDataType(sv);
+	unpack_UA_DataSetReaderDataType(p, sv);
 }
 #endif
 
@@ -2425,14 +2259,12 @@ XS_unpack_UA_DataSetReaderMessageDataType(SV *in)
 static void
 table_pack_UA_DataSetReaderMessageDataType(SV *sv, void *p)
 {
-	UA_DataSetReaderMessageDataType *data = p;
-	XS_pack_UA_DataSetReaderMessageDataType(sv, *data);
+	pack_UA_DataSetReaderMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_DataSetReaderMessageDataType(SV *sv, void *p)
 {
-	UA_DataSetReaderMessageDataType *data = p;
-	*data = XS_unpack_UA_DataSetReaderMessageDataType(sv);
+	unpack_UA_DataSetReaderMessageDataType(p, sv);
 }
 #endif
 
@@ -2454,14 +2286,12 @@ XS_unpack_UA_DataSetReaderTransportDataType(SV *in)
 static void
 table_pack_UA_DataSetReaderTransportDataType(SV *sv, void *p)
 {
-	UA_DataSetReaderTransportDataType *data = p;
-	XS_pack_UA_DataSetReaderTransportDataType(sv, *data);
+	pack_UA_DataSetReaderTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_DataSetReaderTransportDataType(SV *sv, void *p)
 {
-	UA_DataSetReaderTransportDataType *data = p;
-	*data = XS_unpack_UA_DataSetReaderTransportDataType(sv);
+	unpack_UA_DataSetReaderTransportDataType(p, sv);
 }
 #endif
 
@@ -2483,14 +2313,12 @@ XS_unpack_UA_DataSetWriterDataType(SV *in)
 static void
 table_pack_UA_DataSetWriterDataType(SV *sv, void *p)
 {
-	UA_DataSetWriterDataType *data = p;
-	XS_pack_UA_DataSetWriterDataType(sv, *data);
+	pack_UA_DataSetWriterDataType(sv, p);
 }
 static void
 table_unpack_UA_DataSetWriterDataType(SV *sv, void *p)
 {
-	UA_DataSetWriterDataType *data = p;
-	*data = XS_unpack_UA_DataSetWriterDataType(sv);
+	unpack_UA_DataSetWriterDataType(p, sv);
 }
 #endif
 
@@ -2512,14 +2340,12 @@ XS_unpack_UA_DataSetWriterMessageDataType(SV *in)
 static void
 table_pack_UA_DataSetWriterMessageDataType(SV *sv, void *p)
 {
-	UA_DataSetWriterMessageDataType *data = p;
-	XS_pack_UA_DataSetWriterMessageDataType(sv, *data);
+	pack_UA_DataSetWriterMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_DataSetWriterMessageDataType(SV *sv, void *p)
 {
-	UA_DataSetWriterMessageDataType *data = p;
-	*data = XS_unpack_UA_DataSetWriterMessageDataType(sv);
+	unpack_UA_DataSetWriterMessageDataType(p, sv);
 }
 #endif
 
@@ -2541,14 +2367,12 @@ XS_unpack_UA_DataSetWriterTransportDataType(SV *in)
 static void
 table_pack_UA_DataSetWriterTransportDataType(SV *sv, void *p)
 {
-	UA_DataSetWriterTransportDataType *data = p;
-	XS_pack_UA_DataSetWriterTransportDataType(sv, *data);
+	pack_UA_DataSetWriterTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_DataSetWriterTransportDataType(SV *sv, void *p)
 {
-	UA_DataSetWriterTransportDataType *data = p;
-	*data = XS_unpack_UA_DataSetWriterTransportDataType(sv);
+	unpack_UA_DataSetWriterTransportDataType(p, sv);
 }
 #endif
 
@@ -2570,14 +2394,12 @@ XS_unpack_UA_DataTypeAttributes(SV *in)
 static void
 table_pack_UA_DataTypeAttributes(SV *sv, void *p)
 {
-	UA_DataTypeAttributes *data = p;
-	XS_pack_UA_DataTypeAttributes(sv, *data);
+	pack_UA_DataTypeAttributes(sv, p);
 }
 static void
 table_unpack_UA_DataTypeAttributes(SV *sv, void *p)
 {
-	UA_DataTypeAttributes *data = p;
-	*data = XS_unpack_UA_DataTypeAttributes(sv);
+	unpack_UA_DataTypeAttributes(p, sv);
 }
 #endif
 
@@ -2599,14 +2421,12 @@ XS_unpack_UA_DataTypeDescription(SV *in)
 static void
 table_pack_UA_DataTypeDescription(SV *sv, void *p)
 {
-	UA_DataTypeDescription *data = p;
-	XS_pack_UA_DataTypeDescription(sv, *data);
+	pack_UA_DataTypeDescription(sv, p);
 }
 static void
 table_unpack_UA_DataTypeDescription(SV *sv, void *p)
 {
-	UA_DataTypeDescription *data = p;
-	*data = XS_unpack_UA_DataTypeDescription(sv);
+	unpack_UA_DataTypeDescription(p, sv);
 }
 #endif
 
@@ -2628,14 +2448,12 @@ XS_unpack_UA_DataTypeSchemaHeader(SV *in)
 static void
 table_pack_UA_DataTypeSchemaHeader(SV *sv, void *p)
 {
-	UA_DataTypeSchemaHeader *data = p;
-	XS_pack_UA_DataTypeSchemaHeader(sv, *data);
+	pack_UA_DataTypeSchemaHeader(sv, p);
 }
 static void
 table_unpack_UA_DataTypeSchemaHeader(SV *sv, void *p)
 {
-	UA_DataTypeSchemaHeader *data = p;
-	*data = XS_unpack_UA_DataTypeSchemaHeader(sv);
+	unpack_UA_DataTypeSchemaHeader(p, sv);
 }
 #endif
 
@@ -2657,14 +2475,12 @@ XS_unpack_UA_DataValue(SV *in)
 static void
 table_pack_UA_DataValue(SV *sv, void *p)
 {
-	UA_DataValue *data = p;
-	XS_pack_UA_DataValue(sv, *data);
+	pack_UA_DataValue(sv, p);
 }
 static void
 table_unpack_UA_DataValue(SV *sv, void *p)
 {
-	UA_DataValue *data = p;
-	*data = XS_unpack_UA_DataValue(sv);
+	unpack_UA_DataValue(p, sv);
 }
 #endif
 
@@ -2686,14 +2502,12 @@ XS_unpack_UA_DatagramConnectionTransportDataType(SV *in)
 static void
 table_pack_UA_DatagramConnectionTransportDataType(SV *sv, void *p)
 {
-	UA_DatagramConnectionTransportDataType *data = p;
-	XS_pack_UA_DatagramConnectionTransportDataType(sv, *data);
+	pack_UA_DatagramConnectionTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_DatagramConnectionTransportDataType(SV *sv, void *p)
 {
-	UA_DatagramConnectionTransportDataType *data = p;
-	*data = XS_unpack_UA_DatagramConnectionTransportDataType(sv);
+	unpack_UA_DatagramConnectionTransportDataType(p, sv);
 }
 #endif
 
@@ -2715,14 +2529,12 @@ XS_unpack_UA_DatagramWriterGroupTransportDataType(SV *in)
 static void
 table_pack_UA_DatagramWriterGroupTransportDataType(SV *sv, void *p)
 {
-	UA_DatagramWriterGroupTransportDataType *data = p;
-	XS_pack_UA_DatagramWriterGroupTransportDataType(sv, *data);
+	pack_UA_DatagramWriterGroupTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_DatagramWriterGroupTransportDataType(SV *sv, void *p)
 {
-	UA_DatagramWriterGroupTransportDataType *data = p;
-	*data = XS_unpack_UA_DatagramWriterGroupTransportDataType(sv);
+	unpack_UA_DatagramWriterGroupTransportDataType(p, sv);
 }
 #endif
 
@@ -2744,14 +2556,12 @@ XS_unpack_UA_Date(SV *in)
 static void
 table_pack_UA_Date(SV *sv, void *p)
 {
-	UA_Date *data = p;
-	XS_pack_UA_Date(sv, *data);
+	pack_UA_Date(sv, p);
 }
 static void
 table_unpack_UA_Date(SV *sv, void *p)
 {
-	UA_Date *data = p;
-	*data = XS_unpack_UA_Date(sv);
+	unpack_UA_Date(p, sv);
 }
 #endif
 
@@ -2773,14 +2583,12 @@ XS_unpack_UA_DateString(SV *in)
 static void
 table_pack_UA_DateString(SV *sv, void *p)
 {
-	UA_DateString *data = p;
-	XS_pack_UA_DateString(sv, *data);
+	pack_UA_DateString(sv, p);
 }
 static void
 table_unpack_UA_DateString(SV *sv, void *p)
 {
-	UA_DateString *data = p;
-	*data = XS_unpack_UA_DateString(sv);
+	unpack_UA_DateString(p, sv);
 }
 #endif
 
@@ -2802,14 +2610,12 @@ XS_unpack_UA_DateTime(SV *in)
 static void
 table_pack_UA_DateTime(SV *sv, void *p)
 {
-	UA_DateTime *data = p;
-	XS_pack_UA_DateTime(sv, *data);
+	pack_UA_DateTime(sv, p);
 }
 static void
 table_unpack_UA_DateTime(SV *sv, void *p)
 {
-	UA_DateTime *data = p;
-	*data = XS_unpack_UA_DateTime(sv);
+	unpack_UA_DateTime(p, sv);
 }
 #endif
 
@@ -2831,14 +2637,12 @@ XS_unpack_UA_DeadbandType(SV *in)
 static void
 table_pack_UA_DeadbandType(SV *sv, void *p)
 {
-	UA_DeadbandType *data = p;
-	XS_pack_UA_DeadbandType(sv, *data);
+	pack_UA_DeadbandType(sv, p);
 }
 static void
 table_unpack_UA_DeadbandType(SV *sv, void *p)
 {
-	UA_DeadbandType *data = p;
-	*data = XS_unpack_UA_DeadbandType(sv);
+	unpack_UA_DeadbandType(p, sv);
 }
 #endif
 
@@ -2860,14 +2664,12 @@ XS_unpack_UA_DecimalDataType(SV *in)
 static void
 table_pack_UA_DecimalDataType(SV *sv, void *p)
 {
-	UA_DecimalDataType *data = p;
-	XS_pack_UA_DecimalDataType(sv, *data);
+	pack_UA_DecimalDataType(sv, p);
 }
 static void
 table_unpack_UA_DecimalDataType(SV *sv, void *p)
 {
-	UA_DecimalDataType *data = p;
-	*data = XS_unpack_UA_DecimalDataType(sv);
+	unpack_UA_DecimalDataType(p, sv);
 }
 #endif
 
@@ -2889,14 +2691,12 @@ XS_unpack_UA_DecimalString(SV *in)
 static void
 table_pack_UA_DecimalString(SV *sv, void *p)
 {
-	UA_DecimalString *data = p;
-	XS_pack_UA_DecimalString(sv, *data);
+	pack_UA_DecimalString(sv, p);
 }
 static void
 table_unpack_UA_DecimalString(SV *sv, void *p)
 {
-	UA_DecimalString *data = p;
-	*data = XS_unpack_UA_DecimalString(sv);
+	unpack_UA_DecimalString(p, sv);
 }
 #endif
 
@@ -2918,14 +2718,12 @@ XS_unpack_UA_DeleteAtTimeDetails(SV *in)
 static void
 table_pack_UA_DeleteAtTimeDetails(SV *sv, void *p)
 {
-	UA_DeleteAtTimeDetails *data = p;
-	XS_pack_UA_DeleteAtTimeDetails(sv, *data);
+	pack_UA_DeleteAtTimeDetails(sv, p);
 }
 static void
 table_unpack_UA_DeleteAtTimeDetails(SV *sv, void *p)
 {
-	UA_DeleteAtTimeDetails *data = p;
-	*data = XS_unpack_UA_DeleteAtTimeDetails(sv);
+	unpack_UA_DeleteAtTimeDetails(p, sv);
 }
 #endif
 
@@ -2947,14 +2745,12 @@ XS_unpack_UA_DeleteEventDetails(SV *in)
 static void
 table_pack_UA_DeleteEventDetails(SV *sv, void *p)
 {
-	UA_DeleteEventDetails *data = p;
-	XS_pack_UA_DeleteEventDetails(sv, *data);
+	pack_UA_DeleteEventDetails(sv, p);
 }
 static void
 table_unpack_UA_DeleteEventDetails(SV *sv, void *p)
 {
-	UA_DeleteEventDetails *data = p;
-	*data = XS_unpack_UA_DeleteEventDetails(sv);
+	unpack_UA_DeleteEventDetails(p, sv);
 }
 #endif
 
@@ -2976,14 +2772,12 @@ XS_unpack_UA_DeleteMonitoredItemsRequest(SV *in)
 static void
 table_pack_UA_DeleteMonitoredItemsRequest(SV *sv, void *p)
 {
-	UA_DeleteMonitoredItemsRequest *data = p;
-	XS_pack_UA_DeleteMonitoredItemsRequest(sv, *data);
+	pack_UA_DeleteMonitoredItemsRequest(sv, p);
 }
 static void
 table_unpack_UA_DeleteMonitoredItemsRequest(SV *sv, void *p)
 {
-	UA_DeleteMonitoredItemsRequest *data = p;
-	*data = XS_unpack_UA_DeleteMonitoredItemsRequest(sv);
+	unpack_UA_DeleteMonitoredItemsRequest(p, sv);
 }
 #endif
 
@@ -3005,14 +2799,12 @@ XS_unpack_UA_DeleteMonitoredItemsResponse(SV *in)
 static void
 table_pack_UA_DeleteMonitoredItemsResponse(SV *sv, void *p)
 {
-	UA_DeleteMonitoredItemsResponse *data = p;
-	XS_pack_UA_DeleteMonitoredItemsResponse(sv, *data);
+	pack_UA_DeleteMonitoredItemsResponse(sv, p);
 }
 static void
 table_unpack_UA_DeleteMonitoredItemsResponse(SV *sv, void *p)
 {
-	UA_DeleteMonitoredItemsResponse *data = p;
-	*data = XS_unpack_UA_DeleteMonitoredItemsResponse(sv);
+	unpack_UA_DeleteMonitoredItemsResponse(p, sv);
 }
 #endif
 
@@ -3034,14 +2826,12 @@ XS_unpack_UA_DeleteNodesItem(SV *in)
 static void
 table_pack_UA_DeleteNodesItem(SV *sv, void *p)
 {
-	UA_DeleteNodesItem *data = p;
-	XS_pack_UA_DeleteNodesItem(sv, *data);
+	pack_UA_DeleteNodesItem(sv, p);
 }
 static void
 table_unpack_UA_DeleteNodesItem(SV *sv, void *p)
 {
-	UA_DeleteNodesItem *data = p;
-	*data = XS_unpack_UA_DeleteNodesItem(sv);
+	unpack_UA_DeleteNodesItem(p, sv);
 }
 #endif
 
@@ -3063,14 +2853,12 @@ XS_unpack_UA_DeleteNodesRequest(SV *in)
 static void
 table_pack_UA_DeleteNodesRequest(SV *sv, void *p)
 {
-	UA_DeleteNodesRequest *data = p;
-	XS_pack_UA_DeleteNodesRequest(sv, *data);
+	pack_UA_DeleteNodesRequest(sv, p);
 }
 static void
 table_unpack_UA_DeleteNodesRequest(SV *sv, void *p)
 {
-	UA_DeleteNodesRequest *data = p;
-	*data = XS_unpack_UA_DeleteNodesRequest(sv);
+	unpack_UA_DeleteNodesRequest(p, sv);
 }
 #endif
 
@@ -3092,14 +2880,12 @@ XS_unpack_UA_DeleteNodesResponse(SV *in)
 static void
 table_pack_UA_DeleteNodesResponse(SV *sv, void *p)
 {
-	UA_DeleteNodesResponse *data = p;
-	XS_pack_UA_DeleteNodesResponse(sv, *data);
+	pack_UA_DeleteNodesResponse(sv, p);
 }
 static void
 table_unpack_UA_DeleteNodesResponse(SV *sv, void *p)
 {
-	UA_DeleteNodesResponse *data = p;
-	*data = XS_unpack_UA_DeleteNodesResponse(sv);
+	unpack_UA_DeleteNodesResponse(p, sv);
 }
 #endif
 
@@ -3121,14 +2907,12 @@ XS_unpack_UA_DeleteRawModifiedDetails(SV *in)
 static void
 table_pack_UA_DeleteRawModifiedDetails(SV *sv, void *p)
 {
-	UA_DeleteRawModifiedDetails *data = p;
-	XS_pack_UA_DeleteRawModifiedDetails(sv, *data);
+	pack_UA_DeleteRawModifiedDetails(sv, p);
 }
 static void
 table_unpack_UA_DeleteRawModifiedDetails(SV *sv, void *p)
 {
-	UA_DeleteRawModifiedDetails *data = p;
-	*data = XS_unpack_UA_DeleteRawModifiedDetails(sv);
+	unpack_UA_DeleteRawModifiedDetails(p, sv);
 }
 #endif
 
@@ -3150,14 +2934,12 @@ XS_unpack_UA_DeleteReferencesItem(SV *in)
 static void
 table_pack_UA_DeleteReferencesItem(SV *sv, void *p)
 {
-	UA_DeleteReferencesItem *data = p;
-	XS_pack_UA_DeleteReferencesItem(sv, *data);
+	pack_UA_DeleteReferencesItem(sv, p);
 }
 static void
 table_unpack_UA_DeleteReferencesItem(SV *sv, void *p)
 {
-	UA_DeleteReferencesItem *data = p;
-	*data = XS_unpack_UA_DeleteReferencesItem(sv);
+	unpack_UA_DeleteReferencesItem(p, sv);
 }
 #endif
 
@@ -3179,14 +2961,12 @@ XS_unpack_UA_DeleteReferencesRequest(SV *in)
 static void
 table_pack_UA_DeleteReferencesRequest(SV *sv, void *p)
 {
-	UA_DeleteReferencesRequest *data = p;
-	XS_pack_UA_DeleteReferencesRequest(sv, *data);
+	pack_UA_DeleteReferencesRequest(sv, p);
 }
 static void
 table_unpack_UA_DeleteReferencesRequest(SV *sv, void *p)
 {
-	UA_DeleteReferencesRequest *data = p;
-	*data = XS_unpack_UA_DeleteReferencesRequest(sv);
+	unpack_UA_DeleteReferencesRequest(p, sv);
 }
 #endif
 
@@ -3208,14 +2988,12 @@ XS_unpack_UA_DeleteReferencesResponse(SV *in)
 static void
 table_pack_UA_DeleteReferencesResponse(SV *sv, void *p)
 {
-	UA_DeleteReferencesResponse *data = p;
-	XS_pack_UA_DeleteReferencesResponse(sv, *data);
+	pack_UA_DeleteReferencesResponse(sv, p);
 }
 static void
 table_unpack_UA_DeleteReferencesResponse(SV *sv, void *p)
 {
-	UA_DeleteReferencesResponse *data = p;
-	*data = XS_unpack_UA_DeleteReferencesResponse(sv);
+	unpack_UA_DeleteReferencesResponse(p, sv);
 }
 #endif
 
@@ -3237,14 +3015,12 @@ XS_unpack_UA_DeleteSubscriptionsRequest(SV *in)
 static void
 table_pack_UA_DeleteSubscriptionsRequest(SV *sv, void *p)
 {
-	UA_DeleteSubscriptionsRequest *data = p;
-	XS_pack_UA_DeleteSubscriptionsRequest(sv, *data);
+	pack_UA_DeleteSubscriptionsRequest(sv, p);
 }
 static void
 table_unpack_UA_DeleteSubscriptionsRequest(SV *sv, void *p)
 {
-	UA_DeleteSubscriptionsRequest *data = p;
-	*data = XS_unpack_UA_DeleteSubscriptionsRequest(sv);
+	unpack_UA_DeleteSubscriptionsRequest(p, sv);
 }
 #endif
 
@@ -3266,14 +3042,12 @@ XS_unpack_UA_DeleteSubscriptionsResponse(SV *in)
 static void
 table_pack_UA_DeleteSubscriptionsResponse(SV *sv, void *p)
 {
-	UA_DeleteSubscriptionsResponse *data = p;
-	XS_pack_UA_DeleteSubscriptionsResponse(sv, *data);
+	pack_UA_DeleteSubscriptionsResponse(sv, p);
 }
 static void
 table_unpack_UA_DeleteSubscriptionsResponse(SV *sv, void *p)
 {
-	UA_DeleteSubscriptionsResponse *data = p;
-	*data = XS_unpack_UA_DeleteSubscriptionsResponse(sv);
+	unpack_UA_DeleteSubscriptionsResponse(p, sv);
 }
 #endif
 
@@ -3295,14 +3069,12 @@ XS_unpack_UA_DiagnosticInfo(SV *in)
 static void
 table_pack_UA_DiagnosticInfo(SV *sv, void *p)
 {
-	UA_DiagnosticInfo *data = p;
-	XS_pack_UA_DiagnosticInfo(sv, *data);
+	pack_UA_DiagnosticInfo(sv, p);
 }
 static void
 table_unpack_UA_DiagnosticInfo(SV *sv, void *p)
 {
-	UA_DiagnosticInfo *data = p;
-	*data = XS_unpack_UA_DiagnosticInfo(sv);
+	unpack_UA_DiagnosticInfo(p, sv);
 }
 #endif
 
@@ -3324,14 +3096,12 @@ XS_unpack_UA_DiagnosticsLevel(SV *in)
 static void
 table_pack_UA_DiagnosticsLevel(SV *sv, void *p)
 {
-	UA_DiagnosticsLevel *data = p;
-	XS_pack_UA_DiagnosticsLevel(sv, *data);
+	pack_UA_DiagnosticsLevel(sv, p);
 }
 static void
 table_unpack_UA_DiagnosticsLevel(SV *sv, void *p)
 {
-	UA_DiagnosticsLevel *data = p;
-	*data = XS_unpack_UA_DiagnosticsLevel(sv);
+	unpack_UA_DiagnosticsLevel(p, sv);
 }
 #endif
 
@@ -3353,14 +3123,12 @@ XS_unpack_UA_DiscoveryConfiguration(SV *in)
 static void
 table_pack_UA_DiscoveryConfiguration(SV *sv, void *p)
 {
-	UA_DiscoveryConfiguration *data = p;
-	XS_pack_UA_DiscoveryConfiguration(sv, *data);
+	pack_UA_DiscoveryConfiguration(sv, p);
 }
 static void
 table_unpack_UA_DiscoveryConfiguration(SV *sv, void *p)
 {
-	UA_DiscoveryConfiguration *data = p;
-	*data = XS_unpack_UA_DiscoveryConfiguration(sv);
+	unpack_UA_DiscoveryConfiguration(p, sv);
 }
 #endif
 
@@ -3382,14 +3150,12 @@ XS_unpack_UA_Double(SV *in)
 static void
 table_pack_UA_Double(SV *sv, void *p)
 {
-	UA_Double *data = p;
-	XS_pack_UA_Double(sv, *data);
+	pack_UA_Double(sv, p);
 }
 static void
 table_unpack_UA_Double(SV *sv, void *p)
 {
-	UA_Double *data = p;
-	*data = XS_unpack_UA_Double(sv);
+	unpack_UA_Double(p, sv);
 }
 #endif
 
@@ -3411,14 +3177,12 @@ XS_unpack_UA_DoubleComplexNumberType(SV *in)
 static void
 table_pack_UA_DoubleComplexNumberType(SV *sv, void *p)
 {
-	UA_DoubleComplexNumberType *data = p;
-	XS_pack_UA_DoubleComplexNumberType(sv, *data);
+	pack_UA_DoubleComplexNumberType(sv, p);
 }
 static void
 table_unpack_UA_DoubleComplexNumberType(SV *sv, void *p)
 {
-	UA_DoubleComplexNumberType *data = p;
-	*data = XS_unpack_UA_DoubleComplexNumberType(sv);
+	unpack_UA_DoubleComplexNumberType(p, sv);
 }
 #endif
 
@@ -3440,14 +3204,12 @@ XS_unpack_UA_Duration(SV *in)
 static void
 table_pack_UA_Duration(SV *sv, void *p)
 {
-	UA_Duration *data = p;
-	XS_pack_UA_Duration(sv, *data);
+	pack_UA_Duration(sv, p);
 }
 static void
 table_unpack_UA_Duration(SV *sv, void *p)
 {
-	UA_Duration *data = p;
-	*data = XS_unpack_UA_Duration(sv);
+	unpack_UA_Duration(p, sv);
 }
 #endif
 
@@ -3469,14 +3231,12 @@ XS_unpack_UA_DurationString(SV *in)
 static void
 table_pack_UA_DurationString(SV *sv, void *p)
 {
-	UA_DurationString *data = p;
-	XS_pack_UA_DurationString(sv, *data);
+	pack_UA_DurationString(sv, p);
 }
 static void
 table_unpack_UA_DurationString(SV *sv, void *p)
 {
-	UA_DurationString *data = p;
-	*data = XS_unpack_UA_DurationString(sv);
+	unpack_UA_DurationString(p, sv);
 }
 #endif
 
@@ -3498,14 +3258,12 @@ XS_unpack_UA_EUInformation(SV *in)
 static void
 table_pack_UA_EUInformation(SV *sv, void *p)
 {
-	UA_EUInformation *data = p;
-	XS_pack_UA_EUInformation(sv, *data);
+	pack_UA_EUInformation(sv, p);
 }
 static void
 table_unpack_UA_EUInformation(SV *sv, void *p)
 {
-	UA_EUInformation *data = p;
-	*data = XS_unpack_UA_EUInformation(sv);
+	unpack_UA_EUInformation(p, sv);
 }
 #endif
 
@@ -3527,14 +3285,12 @@ XS_unpack_UA_ElementOperand(SV *in)
 static void
 table_pack_UA_ElementOperand(SV *sv, void *p)
 {
-	UA_ElementOperand *data = p;
-	XS_pack_UA_ElementOperand(sv, *data);
+	pack_UA_ElementOperand(sv, p);
 }
 static void
 table_unpack_UA_ElementOperand(SV *sv, void *p)
 {
-	UA_ElementOperand *data = p;
-	*data = XS_unpack_UA_ElementOperand(sv);
+	unpack_UA_ElementOperand(p, sv);
 }
 #endif
 
@@ -3556,14 +3312,12 @@ XS_unpack_UA_EndpointConfiguration(SV *in)
 static void
 table_pack_UA_EndpointConfiguration(SV *sv, void *p)
 {
-	UA_EndpointConfiguration *data = p;
-	XS_pack_UA_EndpointConfiguration(sv, *data);
+	pack_UA_EndpointConfiguration(sv, p);
 }
 static void
 table_unpack_UA_EndpointConfiguration(SV *sv, void *p)
 {
-	UA_EndpointConfiguration *data = p;
-	*data = XS_unpack_UA_EndpointConfiguration(sv);
+	unpack_UA_EndpointConfiguration(p, sv);
 }
 #endif
 
@@ -3585,14 +3339,12 @@ XS_unpack_UA_EndpointDescription(SV *in)
 static void
 table_pack_UA_EndpointDescription(SV *sv, void *p)
 {
-	UA_EndpointDescription *data = p;
-	XS_pack_UA_EndpointDescription(sv, *data);
+	pack_UA_EndpointDescription(sv, p);
 }
 static void
 table_unpack_UA_EndpointDescription(SV *sv, void *p)
 {
-	UA_EndpointDescription *data = p;
-	*data = XS_unpack_UA_EndpointDescription(sv);
+	unpack_UA_EndpointDescription(p, sv);
 }
 #endif
 
@@ -3614,14 +3366,12 @@ XS_unpack_UA_EndpointType(SV *in)
 static void
 table_pack_UA_EndpointType(SV *sv, void *p)
 {
-	UA_EndpointType *data = p;
-	XS_pack_UA_EndpointType(sv, *data);
+	pack_UA_EndpointType(sv, p);
 }
 static void
 table_unpack_UA_EndpointType(SV *sv, void *p)
 {
-	UA_EndpointType *data = p;
-	*data = XS_unpack_UA_EndpointType(sv);
+	unpack_UA_EndpointType(p, sv);
 }
 #endif
 
@@ -3643,14 +3393,12 @@ XS_unpack_UA_EndpointUrlListDataType(SV *in)
 static void
 table_pack_UA_EndpointUrlListDataType(SV *sv, void *p)
 {
-	UA_EndpointUrlListDataType *data = p;
-	XS_pack_UA_EndpointUrlListDataType(sv, *data);
+	pack_UA_EndpointUrlListDataType(sv, p);
 }
 static void
 table_unpack_UA_EndpointUrlListDataType(SV *sv, void *p)
 {
-	UA_EndpointUrlListDataType *data = p;
-	*data = XS_unpack_UA_EndpointUrlListDataType(sv);
+	unpack_UA_EndpointUrlListDataType(p, sv);
 }
 #endif
 
@@ -3672,14 +3420,12 @@ XS_unpack_UA_EnumDefinition(SV *in)
 static void
 table_pack_UA_EnumDefinition(SV *sv, void *p)
 {
-	UA_EnumDefinition *data = p;
-	XS_pack_UA_EnumDefinition(sv, *data);
+	pack_UA_EnumDefinition(sv, p);
 }
 static void
 table_unpack_UA_EnumDefinition(SV *sv, void *p)
 {
-	UA_EnumDefinition *data = p;
-	*data = XS_unpack_UA_EnumDefinition(sv);
+	unpack_UA_EnumDefinition(p, sv);
 }
 #endif
 
@@ -3701,14 +3447,12 @@ XS_unpack_UA_EnumDescription(SV *in)
 static void
 table_pack_UA_EnumDescription(SV *sv, void *p)
 {
-	UA_EnumDescription *data = p;
-	XS_pack_UA_EnumDescription(sv, *data);
+	pack_UA_EnumDescription(sv, p);
 }
 static void
 table_unpack_UA_EnumDescription(SV *sv, void *p)
 {
-	UA_EnumDescription *data = p;
-	*data = XS_unpack_UA_EnumDescription(sv);
+	unpack_UA_EnumDescription(p, sv);
 }
 #endif
 
@@ -3730,14 +3474,12 @@ XS_unpack_UA_EnumField(SV *in)
 static void
 table_pack_UA_EnumField(SV *sv, void *p)
 {
-	UA_EnumField *data = p;
-	XS_pack_UA_EnumField(sv, *data);
+	pack_UA_EnumField(sv, p);
 }
 static void
 table_unpack_UA_EnumField(SV *sv, void *p)
 {
-	UA_EnumField *data = p;
-	*data = XS_unpack_UA_EnumField(sv);
+	unpack_UA_EnumField(p, sv);
 }
 #endif
 
@@ -3759,14 +3501,12 @@ XS_unpack_UA_EnumValueType(SV *in)
 static void
 table_pack_UA_EnumValueType(SV *sv, void *p)
 {
-	UA_EnumValueType *data = p;
-	XS_pack_UA_EnumValueType(sv, *data);
+	pack_UA_EnumValueType(sv, p);
 }
 static void
 table_unpack_UA_EnumValueType(SV *sv, void *p)
 {
-	UA_EnumValueType *data = p;
-	*data = XS_unpack_UA_EnumValueType(sv);
+	unpack_UA_EnumValueType(p, sv);
 }
 #endif
 
@@ -3788,14 +3528,12 @@ XS_unpack_UA_EventFieldList(SV *in)
 static void
 table_pack_UA_EventFieldList(SV *sv, void *p)
 {
-	UA_EventFieldList *data = p;
-	XS_pack_UA_EventFieldList(sv, *data);
+	pack_UA_EventFieldList(sv, p);
 }
 static void
 table_unpack_UA_EventFieldList(SV *sv, void *p)
 {
-	UA_EventFieldList *data = p;
-	*data = XS_unpack_UA_EventFieldList(sv);
+	unpack_UA_EventFieldList(p, sv);
 }
 #endif
 
@@ -3817,14 +3555,12 @@ XS_unpack_UA_EventFilter(SV *in)
 static void
 table_pack_UA_EventFilter(SV *sv, void *p)
 {
-	UA_EventFilter *data = p;
-	XS_pack_UA_EventFilter(sv, *data);
+	pack_UA_EventFilter(sv, p);
 }
 static void
 table_unpack_UA_EventFilter(SV *sv, void *p)
 {
-	UA_EventFilter *data = p;
-	*data = XS_unpack_UA_EventFilter(sv);
+	unpack_UA_EventFilter(p, sv);
 }
 #endif
 
@@ -3846,14 +3582,12 @@ XS_unpack_UA_EventFilterResult(SV *in)
 static void
 table_pack_UA_EventFilterResult(SV *sv, void *p)
 {
-	UA_EventFilterResult *data = p;
-	XS_pack_UA_EventFilterResult(sv, *data);
+	pack_UA_EventFilterResult(sv, p);
 }
 static void
 table_unpack_UA_EventFilterResult(SV *sv, void *p)
 {
-	UA_EventFilterResult *data = p;
-	*data = XS_unpack_UA_EventFilterResult(sv);
+	unpack_UA_EventFilterResult(p, sv);
 }
 #endif
 
@@ -3875,14 +3609,12 @@ XS_unpack_UA_EventNotificationList(SV *in)
 static void
 table_pack_UA_EventNotificationList(SV *sv, void *p)
 {
-	UA_EventNotificationList *data = p;
-	XS_pack_UA_EventNotificationList(sv, *data);
+	pack_UA_EventNotificationList(sv, p);
 }
 static void
 table_unpack_UA_EventNotificationList(SV *sv, void *p)
 {
-	UA_EventNotificationList *data = p;
-	*data = XS_unpack_UA_EventNotificationList(sv);
+	unpack_UA_EventNotificationList(p, sv);
 }
 #endif
 
@@ -3904,14 +3636,12 @@ XS_unpack_UA_EventNotifierType(SV *in)
 static void
 table_pack_UA_EventNotifierType(SV *sv, void *p)
 {
-	UA_EventNotifierType *data = p;
-	XS_pack_UA_EventNotifierType(sv, *data);
+	pack_UA_EventNotifierType(sv, p);
 }
 static void
 table_unpack_UA_EventNotifierType(SV *sv, void *p)
 {
-	UA_EventNotifierType *data = p;
-	*data = XS_unpack_UA_EventNotifierType(sv);
+	unpack_UA_EventNotifierType(p, sv);
 }
 #endif
 
@@ -3933,14 +3663,12 @@ XS_unpack_UA_ExceptionDeviationFormat(SV *in)
 static void
 table_pack_UA_ExceptionDeviationFormat(SV *sv, void *p)
 {
-	UA_ExceptionDeviationFormat *data = p;
-	XS_pack_UA_ExceptionDeviationFormat(sv, *data);
+	pack_UA_ExceptionDeviationFormat(sv, p);
 }
 static void
 table_unpack_UA_ExceptionDeviationFormat(SV *sv, void *p)
 {
-	UA_ExceptionDeviationFormat *data = p;
-	*data = XS_unpack_UA_ExceptionDeviationFormat(sv);
+	unpack_UA_ExceptionDeviationFormat(p, sv);
 }
 #endif
 
@@ -3962,14 +3690,12 @@ XS_unpack_UA_ExpandedNodeId(SV *in)
 static void
 table_pack_UA_ExpandedNodeId(SV *sv, void *p)
 {
-	UA_ExpandedNodeId *data = p;
-	XS_pack_UA_ExpandedNodeId(sv, *data);
+	pack_UA_ExpandedNodeId(sv, p);
 }
 static void
 table_unpack_UA_ExpandedNodeId(SV *sv, void *p)
 {
-	UA_ExpandedNodeId *data = p;
-	*data = XS_unpack_UA_ExpandedNodeId(sv);
+	unpack_UA_ExpandedNodeId(p, sv);
 }
 #endif
 
@@ -3991,14 +3717,12 @@ XS_unpack_UA_ExtensionObject(SV *in)
 static void
 table_pack_UA_ExtensionObject(SV *sv, void *p)
 {
-	UA_ExtensionObject *data = p;
-	XS_pack_UA_ExtensionObject(sv, *data);
+	pack_UA_ExtensionObject(sv, p);
 }
 static void
 table_unpack_UA_ExtensionObject(SV *sv, void *p)
 {
-	UA_ExtensionObject *data = p;
-	*data = XS_unpack_UA_ExtensionObject(sv);
+	unpack_UA_ExtensionObject(p, sv);
 }
 #endif
 
@@ -4020,14 +3744,12 @@ XS_unpack_UA_FieldMetaData(SV *in)
 static void
 table_pack_UA_FieldMetaData(SV *sv, void *p)
 {
-	UA_FieldMetaData *data = p;
-	XS_pack_UA_FieldMetaData(sv, *data);
+	pack_UA_FieldMetaData(sv, p);
 }
 static void
 table_unpack_UA_FieldMetaData(SV *sv, void *p)
 {
-	UA_FieldMetaData *data = p;
-	*data = XS_unpack_UA_FieldMetaData(sv);
+	unpack_UA_FieldMetaData(p, sv);
 }
 #endif
 
@@ -4049,14 +3771,12 @@ XS_unpack_UA_FieldTargetDataType(SV *in)
 static void
 table_pack_UA_FieldTargetDataType(SV *sv, void *p)
 {
-	UA_FieldTargetDataType *data = p;
-	XS_pack_UA_FieldTargetDataType(sv, *data);
+	pack_UA_FieldTargetDataType(sv, p);
 }
 static void
 table_unpack_UA_FieldTargetDataType(SV *sv, void *p)
 {
-	UA_FieldTargetDataType *data = p;
-	*data = XS_unpack_UA_FieldTargetDataType(sv);
+	unpack_UA_FieldTargetDataType(p, sv);
 }
 #endif
 
@@ -4078,14 +3798,12 @@ XS_unpack_UA_FilterOperand(SV *in)
 static void
 table_pack_UA_FilterOperand(SV *sv, void *p)
 {
-	UA_FilterOperand *data = p;
-	XS_pack_UA_FilterOperand(sv, *data);
+	pack_UA_FilterOperand(sv, p);
 }
 static void
 table_unpack_UA_FilterOperand(SV *sv, void *p)
 {
-	UA_FilterOperand *data = p;
-	*data = XS_unpack_UA_FilterOperand(sv);
+	unpack_UA_FilterOperand(p, sv);
 }
 #endif
 
@@ -4107,14 +3825,12 @@ XS_unpack_UA_FilterOperator(SV *in)
 static void
 table_pack_UA_FilterOperator(SV *sv, void *p)
 {
-	UA_FilterOperator *data = p;
-	XS_pack_UA_FilterOperator(sv, *data);
+	pack_UA_FilterOperator(sv, p);
 }
 static void
 table_unpack_UA_FilterOperator(SV *sv, void *p)
 {
-	UA_FilterOperator *data = p;
-	*data = XS_unpack_UA_FilterOperator(sv);
+	unpack_UA_FilterOperator(p, sv);
 }
 #endif
 
@@ -4136,14 +3852,12 @@ XS_unpack_UA_FindServersOnNetworkRequest(SV *in)
 static void
 table_pack_UA_FindServersOnNetworkRequest(SV *sv, void *p)
 {
-	UA_FindServersOnNetworkRequest *data = p;
-	XS_pack_UA_FindServersOnNetworkRequest(sv, *data);
+	pack_UA_FindServersOnNetworkRequest(sv, p);
 }
 static void
 table_unpack_UA_FindServersOnNetworkRequest(SV *sv, void *p)
 {
-	UA_FindServersOnNetworkRequest *data = p;
-	*data = XS_unpack_UA_FindServersOnNetworkRequest(sv);
+	unpack_UA_FindServersOnNetworkRequest(p, sv);
 }
 #endif
 
@@ -4165,14 +3879,12 @@ XS_unpack_UA_FindServersOnNetworkResponse(SV *in)
 static void
 table_pack_UA_FindServersOnNetworkResponse(SV *sv, void *p)
 {
-	UA_FindServersOnNetworkResponse *data = p;
-	XS_pack_UA_FindServersOnNetworkResponse(sv, *data);
+	pack_UA_FindServersOnNetworkResponse(sv, p);
 }
 static void
 table_unpack_UA_FindServersOnNetworkResponse(SV *sv, void *p)
 {
-	UA_FindServersOnNetworkResponse *data = p;
-	*data = XS_unpack_UA_FindServersOnNetworkResponse(sv);
+	unpack_UA_FindServersOnNetworkResponse(p, sv);
 }
 #endif
 
@@ -4194,14 +3906,12 @@ XS_unpack_UA_FindServersRequest(SV *in)
 static void
 table_pack_UA_FindServersRequest(SV *sv, void *p)
 {
-	UA_FindServersRequest *data = p;
-	XS_pack_UA_FindServersRequest(sv, *data);
+	pack_UA_FindServersRequest(sv, p);
 }
 static void
 table_unpack_UA_FindServersRequest(SV *sv, void *p)
 {
-	UA_FindServersRequest *data = p;
-	*data = XS_unpack_UA_FindServersRequest(sv);
+	unpack_UA_FindServersRequest(p, sv);
 }
 #endif
 
@@ -4223,14 +3933,12 @@ XS_unpack_UA_FindServersResponse(SV *in)
 static void
 table_pack_UA_FindServersResponse(SV *sv, void *p)
 {
-	UA_FindServersResponse *data = p;
-	XS_pack_UA_FindServersResponse(sv, *data);
+	pack_UA_FindServersResponse(sv, p);
 }
 static void
 table_unpack_UA_FindServersResponse(SV *sv, void *p)
 {
-	UA_FindServersResponse *data = p;
-	*data = XS_unpack_UA_FindServersResponse(sv);
+	unpack_UA_FindServersResponse(p, sv);
 }
 #endif
 
@@ -4252,14 +3960,12 @@ XS_unpack_UA_Float(SV *in)
 static void
 table_pack_UA_Float(SV *sv, void *p)
 {
-	UA_Float *data = p;
-	XS_pack_UA_Float(sv, *data);
+	pack_UA_Float(sv, p);
 }
 static void
 table_unpack_UA_Float(SV *sv, void *p)
 {
-	UA_Float *data = p;
-	*data = XS_unpack_UA_Float(sv);
+	unpack_UA_Float(p, sv);
 }
 #endif
 
@@ -4281,14 +3987,12 @@ XS_unpack_UA_Frame(SV *in)
 static void
 table_pack_UA_Frame(SV *sv, void *p)
 {
-	UA_Frame *data = p;
-	XS_pack_UA_Frame(sv, *data);
+	pack_UA_Frame(sv, p);
 }
 static void
 table_unpack_UA_Frame(SV *sv, void *p)
 {
-	UA_Frame *data = p;
-	*data = XS_unpack_UA_Frame(sv);
+	unpack_UA_Frame(p, sv);
 }
 #endif
 
@@ -4310,14 +4014,12 @@ XS_unpack_UA_GenericAttributeValue(SV *in)
 static void
 table_pack_UA_GenericAttributeValue(SV *sv, void *p)
 {
-	UA_GenericAttributeValue *data = p;
-	XS_pack_UA_GenericAttributeValue(sv, *data);
+	pack_UA_GenericAttributeValue(sv, p);
 }
 static void
 table_unpack_UA_GenericAttributeValue(SV *sv, void *p)
 {
-	UA_GenericAttributeValue *data = p;
-	*data = XS_unpack_UA_GenericAttributeValue(sv);
+	unpack_UA_GenericAttributeValue(p, sv);
 }
 #endif
 
@@ -4339,14 +4041,12 @@ XS_unpack_UA_GenericAttributes(SV *in)
 static void
 table_pack_UA_GenericAttributes(SV *sv, void *p)
 {
-	UA_GenericAttributes *data = p;
-	XS_pack_UA_GenericAttributes(sv, *data);
+	pack_UA_GenericAttributes(sv, p);
 }
 static void
 table_unpack_UA_GenericAttributes(SV *sv, void *p)
 {
-	UA_GenericAttributes *data = p;
-	*data = XS_unpack_UA_GenericAttributes(sv);
+	unpack_UA_GenericAttributes(p, sv);
 }
 #endif
 
@@ -4368,14 +4068,12 @@ XS_unpack_UA_GetEndpointsRequest(SV *in)
 static void
 table_pack_UA_GetEndpointsRequest(SV *sv, void *p)
 {
-	UA_GetEndpointsRequest *data = p;
-	XS_pack_UA_GetEndpointsRequest(sv, *data);
+	pack_UA_GetEndpointsRequest(sv, p);
 }
 static void
 table_unpack_UA_GetEndpointsRequest(SV *sv, void *p)
 {
-	UA_GetEndpointsRequest *data = p;
-	*data = XS_unpack_UA_GetEndpointsRequest(sv);
+	unpack_UA_GetEndpointsRequest(p, sv);
 }
 #endif
 
@@ -4397,14 +4095,12 @@ XS_unpack_UA_GetEndpointsResponse(SV *in)
 static void
 table_pack_UA_GetEndpointsResponse(SV *sv, void *p)
 {
-	UA_GetEndpointsResponse *data = p;
-	XS_pack_UA_GetEndpointsResponse(sv, *data);
+	pack_UA_GetEndpointsResponse(sv, p);
 }
 static void
 table_unpack_UA_GetEndpointsResponse(SV *sv, void *p)
 {
-	UA_GetEndpointsResponse *data = p;
-	*data = XS_unpack_UA_GetEndpointsResponse(sv);
+	unpack_UA_GetEndpointsResponse(p, sv);
 }
 #endif
 
@@ -4426,14 +4122,12 @@ XS_unpack_UA_Guid(SV *in)
 static void
 table_pack_UA_Guid(SV *sv, void *p)
 {
-	UA_Guid *data = p;
-	XS_pack_UA_Guid(sv, *data);
+	pack_UA_Guid(sv, p);
 }
 static void
 table_unpack_UA_Guid(SV *sv, void *p)
 {
-	UA_Guid *data = p;
-	*data = XS_unpack_UA_Guid(sv);
+	unpack_UA_Guid(p, sv);
 }
 #endif
 
@@ -4455,14 +4149,12 @@ XS_unpack_UA_HistoryData(SV *in)
 static void
 table_pack_UA_HistoryData(SV *sv, void *p)
 {
-	UA_HistoryData *data = p;
-	XS_pack_UA_HistoryData(sv, *data);
+	pack_UA_HistoryData(sv, p);
 }
 static void
 table_unpack_UA_HistoryData(SV *sv, void *p)
 {
-	UA_HistoryData *data = p;
-	*data = XS_unpack_UA_HistoryData(sv);
+	unpack_UA_HistoryData(p, sv);
 }
 #endif
 
@@ -4484,14 +4176,12 @@ XS_unpack_UA_HistoryEvent(SV *in)
 static void
 table_pack_UA_HistoryEvent(SV *sv, void *p)
 {
-	UA_HistoryEvent *data = p;
-	XS_pack_UA_HistoryEvent(sv, *data);
+	pack_UA_HistoryEvent(sv, p);
 }
 static void
 table_unpack_UA_HistoryEvent(SV *sv, void *p)
 {
-	UA_HistoryEvent *data = p;
-	*data = XS_unpack_UA_HistoryEvent(sv);
+	unpack_UA_HistoryEvent(p, sv);
 }
 #endif
 
@@ -4513,14 +4203,12 @@ XS_unpack_UA_HistoryEventFieldList(SV *in)
 static void
 table_pack_UA_HistoryEventFieldList(SV *sv, void *p)
 {
-	UA_HistoryEventFieldList *data = p;
-	XS_pack_UA_HistoryEventFieldList(sv, *data);
+	pack_UA_HistoryEventFieldList(sv, p);
 }
 static void
 table_unpack_UA_HistoryEventFieldList(SV *sv, void *p)
 {
-	UA_HistoryEventFieldList *data = p;
-	*data = XS_unpack_UA_HistoryEventFieldList(sv);
+	unpack_UA_HistoryEventFieldList(p, sv);
 }
 #endif
 
@@ -4542,14 +4230,12 @@ XS_unpack_UA_HistoryModifiedData(SV *in)
 static void
 table_pack_UA_HistoryModifiedData(SV *sv, void *p)
 {
-	UA_HistoryModifiedData *data = p;
-	XS_pack_UA_HistoryModifiedData(sv, *data);
+	pack_UA_HistoryModifiedData(sv, p);
 }
 static void
 table_unpack_UA_HistoryModifiedData(SV *sv, void *p)
 {
-	UA_HistoryModifiedData *data = p;
-	*data = XS_unpack_UA_HistoryModifiedData(sv);
+	unpack_UA_HistoryModifiedData(p, sv);
 }
 #endif
 
@@ -4571,14 +4257,12 @@ XS_unpack_UA_HistoryReadDetails(SV *in)
 static void
 table_pack_UA_HistoryReadDetails(SV *sv, void *p)
 {
-	UA_HistoryReadDetails *data = p;
-	XS_pack_UA_HistoryReadDetails(sv, *data);
+	pack_UA_HistoryReadDetails(sv, p);
 }
 static void
 table_unpack_UA_HistoryReadDetails(SV *sv, void *p)
 {
-	UA_HistoryReadDetails *data = p;
-	*data = XS_unpack_UA_HistoryReadDetails(sv);
+	unpack_UA_HistoryReadDetails(p, sv);
 }
 #endif
 
@@ -4600,14 +4284,12 @@ XS_unpack_UA_HistoryReadRequest(SV *in)
 static void
 table_pack_UA_HistoryReadRequest(SV *sv, void *p)
 {
-	UA_HistoryReadRequest *data = p;
-	XS_pack_UA_HistoryReadRequest(sv, *data);
+	pack_UA_HistoryReadRequest(sv, p);
 }
 static void
 table_unpack_UA_HistoryReadRequest(SV *sv, void *p)
 {
-	UA_HistoryReadRequest *data = p;
-	*data = XS_unpack_UA_HistoryReadRequest(sv);
+	unpack_UA_HistoryReadRequest(p, sv);
 }
 #endif
 
@@ -4629,14 +4311,12 @@ XS_unpack_UA_HistoryReadResponse(SV *in)
 static void
 table_pack_UA_HistoryReadResponse(SV *sv, void *p)
 {
-	UA_HistoryReadResponse *data = p;
-	XS_pack_UA_HistoryReadResponse(sv, *data);
+	pack_UA_HistoryReadResponse(sv, p);
 }
 static void
 table_unpack_UA_HistoryReadResponse(SV *sv, void *p)
 {
-	UA_HistoryReadResponse *data = p;
-	*data = XS_unpack_UA_HistoryReadResponse(sv);
+	unpack_UA_HistoryReadResponse(p, sv);
 }
 #endif
 
@@ -4658,14 +4338,12 @@ XS_unpack_UA_HistoryReadResult(SV *in)
 static void
 table_pack_UA_HistoryReadResult(SV *sv, void *p)
 {
-	UA_HistoryReadResult *data = p;
-	XS_pack_UA_HistoryReadResult(sv, *data);
+	pack_UA_HistoryReadResult(sv, p);
 }
 static void
 table_unpack_UA_HistoryReadResult(SV *sv, void *p)
 {
-	UA_HistoryReadResult *data = p;
-	*data = XS_unpack_UA_HistoryReadResult(sv);
+	unpack_UA_HistoryReadResult(p, sv);
 }
 #endif
 
@@ -4687,14 +4365,12 @@ XS_unpack_UA_HistoryReadValueId(SV *in)
 static void
 table_pack_UA_HistoryReadValueId(SV *sv, void *p)
 {
-	UA_HistoryReadValueId *data = p;
-	XS_pack_UA_HistoryReadValueId(sv, *data);
+	pack_UA_HistoryReadValueId(sv, p);
 }
 static void
 table_unpack_UA_HistoryReadValueId(SV *sv, void *p)
 {
-	UA_HistoryReadValueId *data = p;
-	*data = XS_unpack_UA_HistoryReadValueId(sv);
+	unpack_UA_HistoryReadValueId(p, sv);
 }
 #endif
 
@@ -4716,14 +4392,12 @@ XS_unpack_UA_HistoryUpdateDetails(SV *in)
 static void
 table_pack_UA_HistoryUpdateDetails(SV *sv, void *p)
 {
-	UA_HistoryUpdateDetails *data = p;
-	XS_pack_UA_HistoryUpdateDetails(sv, *data);
+	pack_UA_HistoryUpdateDetails(sv, p);
 }
 static void
 table_unpack_UA_HistoryUpdateDetails(SV *sv, void *p)
 {
-	UA_HistoryUpdateDetails *data = p;
-	*data = XS_unpack_UA_HistoryUpdateDetails(sv);
+	unpack_UA_HistoryUpdateDetails(p, sv);
 }
 #endif
 
@@ -4745,14 +4419,12 @@ XS_unpack_UA_HistoryUpdateRequest(SV *in)
 static void
 table_pack_UA_HistoryUpdateRequest(SV *sv, void *p)
 {
-	UA_HistoryUpdateRequest *data = p;
-	XS_pack_UA_HistoryUpdateRequest(sv, *data);
+	pack_UA_HistoryUpdateRequest(sv, p);
 }
 static void
 table_unpack_UA_HistoryUpdateRequest(SV *sv, void *p)
 {
-	UA_HistoryUpdateRequest *data = p;
-	*data = XS_unpack_UA_HistoryUpdateRequest(sv);
+	unpack_UA_HistoryUpdateRequest(p, sv);
 }
 #endif
 
@@ -4774,14 +4446,12 @@ XS_unpack_UA_HistoryUpdateResponse(SV *in)
 static void
 table_pack_UA_HistoryUpdateResponse(SV *sv, void *p)
 {
-	UA_HistoryUpdateResponse *data = p;
-	XS_pack_UA_HistoryUpdateResponse(sv, *data);
+	pack_UA_HistoryUpdateResponse(sv, p);
 }
 static void
 table_unpack_UA_HistoryUpdateResponse(SV *sv, void *p)
 {
-	UA_HistoryUpdateResponse *data = p;
-	*data = XS_unpack_UA_HistoryUpdateResponse(sv);
+	unpack_UA_HistoryUpdateResponse(p, sv);
 }
 #endif
 
@@ -4803,14 +4473,12 @@ XS_unpack_UA_HistoryUpdateResult(SV *in)
 static void
 table_pack_UA_HistoryUpdateResult(SV *sv, void *p)
 {
-	UA_HistoryUpdateResult *data = p;
-	XS_pack_UA_HistoryUpdateResult(sv, *data);
+	pack_UA_HistoryUpdateResult(sv, p);
 }
 static void
 table_unpack_UA_HistoryUpdateResult(SV *sv, void *p)
 {
-	UA_HistoryUpdateResult *data = p;
-	*data = XS_unpack_UA_HistoryUpdateResult(sv);
+	unpack_UA_HistoryUpdateResult(p, sv);
 }
 #endif
 
@@ -4832,14 +4500,12 @@ XS_unpack_UA_HistoryUpdateType(SV *in)
 static void
 table_pack_UA_HistoryUpdateType(SV *sv, void *p)
 {
-	UA_HistoryUpdateType *data = p;
-	XS_pack_UA_HistoryUpdateType(sv, *data);
+	pack_UA_HistoryUpdateType(sv, p);
 }
 static void
 table_unpack_UA_HistoryUpdateType(SV *sv, void *p)
 {
-	UA_HistoryUpdateType *data = p;
-	*data = XS_unpack_UA_HistoryUpdateType(sv);
+	unpack_UA_HistoryUpdateType(p, sv);
 }
 #endif
 
@@ -4861,14 +4527,12 @@ XS_unpack_UA_IdType(SV *in)
 static void
 table_pack_UA_IdType(SV *sv, void *p)
 {
-	UA_IdType *data = p;
-	XS_pack_UA_IdType(sv, *data);
+	pack_UA_IdType(sv, p);
 }
 static void
 table_unpack_UA_IdType(SV *sv, void *p)
 {
-	UA_IdType *data = p;
-	*data = XS_unpack_UA_IdType(sv);
+	unpack_UA_IdType(p, sv);
 }
 #endif
 
@@ -4890,14 +4554,12 @@ XS_unpack_UA_IdentityCriteriaType(SV *in)
 static void
 table_pack_UA_IdentityCriteriaType(SV *sv, void *p)
 {
-	UA_IdentityCriteriaType *data = p;
-	XS_pack_UA_IdentityCriteriaType(sv, *data);
+	pack_UA_IdentityCriteriaType(sv, p);
 }
 static void
 table_unpack_UA_IdentityCriteriaType(SV *sv, void *p)
 {
-	UA_IdentityCriteriaType *data = p;
-	*data = XS_unpack_UA_IdentityCriteriaType(sv);
+	unpack_UA_IdentityCriteriaType(p, sv);
 }
 #endif
 
@@ -4919,14 +4581,12 @@ XS_unpack_UA_IdentityMappingRuleType(SV *in)
 static void
 table_pack_UA_IdentityMappingRuleType(SV *sv, void *p)
 {
-	UA_IdentityMappingRuleType *data = p;
-	XS_pack_UA_IdentityMappingRuleType(sv, *data);
+	pack_UA_IdentityMappingRuleType(sv, p);
 }
 static void
 table_unpack_UA_IdentityMappingRuleType(SV *sv, void *p)
 {
-	UA_IdentityMappingRuleType *data = p;
-	*data = XS_unpack_UA_IdentityMappingRuleType(sv);
+	unpack_UA_IdentityMappingRuleType(p, sv);
 }
 #endif
 
@@ -4948,14 +4608,12 @@ XS_unpack_UA_ImageBMP(SV *in)
 static void
 table_pack_UA_ImageBMP(SV *sv, void *p)
 {
-	UA_ImageBMP *data = p;
-	XS_pack_UA_ImageBMP(sv, *data);
+	pack_UA_ImageBMP(sv, p);
 }
 static void
 table_unpack_UA_ImageBMP(SV *sv, void *p)
 {
-	UA_ImageBMP *data = p;
-	*data = XS_unpack_UA_ImageBMP(sv);
+	unpack_UA_ImageBMP(p, sv);
 }
 #endif
 
@@ -4977,14 +4635,12 @@ XS_unpack_UA_ImageGIF(SV *in)
 static void
 table_pack_UA_ImageGIF(SV *sv, void *p)
 {
-	UA_ImageGIF *data = p;
-	XS_pack_UA_ImageGIF(sv, *data);
+	pack_UA_ImageGIF(sv, p);
 }
 static void
 table_unpack_UA_ImageGIF(SV *sv, void *p)
 {
-	UA_ImageGIF *data = p;
-	*data = XS_unpack_UA_ImageGIF(sv);
+	unpack_UA_ImageGIF(p, sv);
 }
 #endif
 
@@ -5006,14 +4662,12 @@ XS_unpack_UA_ImageJPG(SV *in)
 static void
 table_pack_UA_ImageJPG(SV *sv, void *p)
 {
-	UA_ImageJPG *data = p;
-	XS_pack_UA_ImageJPG(sv, *data);
+	pack_UA_ImageJPG(sv, p);
 }
 static void
 table_unpack_UA_ImageJPG(SV *sv, void *p)
 {
-	UA_ImageJPG *data = p;
-	*data = XS_unpack_UA_ImageJPG(sv);
+	unpack_UA_ImageJPG(p, sv);
 }
 #endif
 
@@ -5035,14 +4689,12 @@ XS_unpack_UA_ImagePNG(SV *in)
 static void
 table_pack_UA_ImagePNG(SV *sv, void *p)
 {
-	UA_ImagePNG *data = p;
-	XS_pack_UA_ImagePNG(sv, *data);
+	pack_UA_ImagePNG(sv, p);
 }
 static void
 table_unpack_UA_ImagePNG(SV *sv, void *p)
 {
-	UA_ImagePNG *data = p;
-	*data = XS_unpack_UA_ImagePNG(sv);
+	unpack_UA_ImagePNG(p, sv);
 }
 #endif
 
@@ -5064,14 +4716,12 @@ XS_unpack_UA_Index(SV *in)
 static void
 table_pack_UA_Index(SV *sv, void *p)
 {
-	UA_Index *data = p;
-	XS_pack_UA_Index(sv, *data);
+	pack_UA_Index(sv, p);
 }
 static void
 table_unpack_UA_Index(SV *sv, void *p)
 {
-	UA_Index *data = p;
-	*data = XS_unpack_UA_Index(sv);
+	unpack_UA_Index(p, sv);
 }
 #endif
 
@@ -5093,14 +4743,12 @@ XS_unpack_UA_Int16(SV *in)
 static void
 table_pack_UA_Int16(SV *sv, void *p)
 {
-	UA_Int16 *data = p;
-	XS_pack_UA_Int16(sv, *data);
+	pack_UA_Int16(sv, p);
 }
 static void
 table_unpack_UA_Int16(SV *sv, void *p)
 {
-	UA_Int16 *data = p;
-	*data = XS_unpack_UA_Int16(sv);
+	unpack_UA_Int16(p, sv);
 }
 #endif
 
@@ -5122,14 +4770,12 @@ XS_unpack_UA_Int32(SV *in)
 static void
 table_pack_UA_Int32(SV *sv, void *p)
 {
-	UA_Int32 *data = p;
-	XS_pack_UA_Int32(sv, *data);
+	pack_UA_Int32(sv, p);
 }
 static void
 table_unpack_UA_Int32(SV *sv, void *p)
 {
-	UA_Int32 *data = p;
-	*data = XS_unpack_UA_Int32(sv);
+	unpack_UA_Int32(p, sv);
 }
 #endif
 
@@ -5151,14 +4797,12 @@ XS_unpack_UA_Int64(SV *in)
 static void
 table_pack_UA_Int64(SV *sv, void *p)
 {
-	UA_Int64 *data = p;
-	XS_pack_UA_Int64(sv, *data);
+	pack_UA_Int64(sv, p);
 }
 static void
 table_unpack_UA_Int64(SV *sv, void *p)
 {
-	UA_Int64 *data = p;
-	*data = XS_unpack_UA_Int64(sv);
+	unpack_UA_Int64(p, sv);
 }
 #endif
 
@@ -5180,14 +4824,12 @@ XS_unpack_UA_IntegerId(SV *in)
 static void
 table_pack_UA_IntegerId(SV *sv, void *p)
 {
-	UA_IntegerId *data = p;
-	XS_pack_UA_IntegerId(sv, *data);
+	pack_UA_IntegerId(sv, p);
 }
 static void
 table_unpack_UA_IntegerId(SV *sv, void *p)
 {
-	UA_IntegerId *data = p;
-	*data = XS_unpack_UA_IntegerId(sv);
+	unpack_UA_IntegerId(p, sv);
 }
 #endif
 
@@ -5209,14 +4851,12 @@ XS_unpack_UA_IssuedIdentityToken(SV *in)
 static void
 table_pack_UA_IssuedIdentityToken(SV *sv, void *p)
 {
-	UA_IssuedIdentityToken *data = p;
-	XS_pack_UA_IssuedIdentityToken(sv, *data);
+	pack_UA_IssuedIdentityToken(sv, p);
 }
 static void
 table_unpack_UA_IssuedIdentityToken(SV *sv, void *p)
 {
-	UA_IssuedIdentityToken *data = p;
-	*data = XS_unpack_UA_IssuedIdentityToken(sv);
+	unpack_UA_IssuedIdentityToken(p, sv);
 }
 #endif
 
@@ -5238,14 +4878,12 @@ XS_unpack_UA_JsonDataSetMessageContentMask(SV *in)
 static void
 table_pack_UA_JsonDataSetMessageContentMask(SV *sv, void *p)
 {
-	UA_JsonDataSetMessageContentMask *data = p;
-	XS_pack_UA_JsonDataSetMessageContentMask(sv, *data);
+	pack_UA_JsonDataSetMessageContentMask(sv, p);
 }
 static void
 table_unpack_UA_JsonDataSetMessageContentMask(SV *sv, void *p)
 {
-	UA_JsonDataSetMessageContentMask *data = p;
-	*data = XS_unpack_UA_JsonDataSetMessageContentMask(sv);
+	unpack_UA_JsonDataSetMessageContentMask(p, sv);
 }
 #endif
 
@@ -5267,14 +4905,12 @@ XS_unpack_UA_JsonDataSetReaderMessageDataType(SV *in)
 static void
 table_pack_UA_JsonDataSetReaderMessageDataType(SV *sv, void *p)
 {
-	UA_JsonDataSetReaderMessageDataType *data = p;
-	XS_pack_UA_JsonDataSetReaderMessageDataType(sv, *data);
+	pack_UA_JsonDataSetReaderMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_JsonDataSetReaderMessageDataType(SV *sv, void *p)
 {
-	UA_JsonDataSetReaderMessageDataType *data = p;
-	*data = XS_unpack_UA_JsonDataSetReaderMessageDataType(sv);
+	unpack_UA_JsonDataSetReaderMessageDataType(p, sv);
 }
 #endif
 
@@ -5296,14 +4932,12 @@ XS_unpack_UA_JsonDataSetWriterMessageDataType(SV *in)
 static void
 table_pack_UA_JsonDataSetWriterMessageDataType(SV *sv, void *p)
 {
-	UA_JsonDataSetWriterMessageDataType *data = p;
-	XS_pack_UA_JsonDataSetWriterMessageDataType(sv, *data);
+	pack_UA_JsonDataSetWriterMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_JsonDataSetWriterMessageDataType(SV *sv, void *p)
 {
-	UA_JsonDataSetWriterMessageDataType *data = p;
-	*data = XS_unpack_UA_JsonDataSetWriterMessageDataType(sv);
+	unpack_UA_JsonDataSetWriterMessageDataType(p, sv);
 }
 #endif
 
@@ -5325,14 +4959,12 @@ XS_unpack_UA_JsonNetworkMessageContentMask(SV *in)
 static void
 table_pack_UA_JsonNetworkMessageContentMask(SV *sv, void *p)
 {
-	UA_JsonNetworkMessageContentMask *data = p;
-	XS_pack_UA_JsonNetworkMessageContentMask(sv, *data);
+	pack_UA_JsonNetworkMessageContentMask(sv, p);
 }
 static void
 table_unpack_UA_JsonNetworkMessageContentMask(SV *sv, void *p)
 {
-	UA_JsonNetworkMessageContentMask *data = p;
-	*data = XS_unpack_UA_JsonNetworkMessageContentMask(sv);
+	unpack_UA_JsonNetworkMessageContentMask(p, sv);
 }
 #endif
 
@@ -5354,14 +4986,12 @@ XS_unpack_UA_JsonWriterGroupMessageDataType(SV *in)
 static void
 table_pack_UA_JsonWriterGroupMessageDataType(SV *sv, void *p)
 {
-	UA_JsonWriterGroupMessageDataType *data = p;
-	XS_pack_UA_JsonWriterGroupMessageDataType(sv, *data);
+	pack_UA_JsonWriterGroupMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_JsonWriterGroupMessageDataType(SV *sv, void *p)
 {
-	UA_JsonWriterGroupMessageDataType *data = p;
-	*data = XS_unpack_UA_JsonWriterGroupMessageDataType(sv);
+	unpack_UA_JsonWriterGroupMessageDataType(p, sv);
 }
 #endif
 
@@ -5383,14 +5013,12 @@ XS_unpack_UA_KeyValuePair(SV *in)
 static void
 table_pack_UA_KeyValuePair(SV *sv, void *p)
 {
-	UA_KeyValuePair *data = p;
-	XS_pack_UA_KeyValuePair(sv, *data);
+	pack_UA_KeyValuePair(sv, p);
 }
 static void
 table_unpack_UA_KeyValuePair(SV *sv, void *p)
 {
-	UA_KeyValuePair *data = p;
-	*data = XS_unpack_UA_KeyValuePair(sv);
+	unpack_UA_KeyValuePair(p, sv);
 }
 #endif
 
@@ -5412,14 +5040,12 @@ XS_unpack_UA_LiteralOperand(SV *in)
 static void
 table_pack_UA_LiteralOperand(SV *sv, void *p)
 {
-	UA_LiteralOperand *data = p;
-	XS_pack_UA_LiteralOperand(sv, *data);
+	pack_UA_LiteralOperand(sv, p);
 }
 static void
 table_unpack_UA_LiteralOperand(SV *sv, void *p)
 {
-	UA_LiteralOperand *data = p;
-	*data = XS_unpack_UA_LiteralOperand(sv);
+	unpack_UA_LiteralOperand(p, sv);
 }
 #endif
 
@@ -5441,14 +5067,12 @@ XS_unpack_UA_LocaleId(SV *in)
 static void
 table_pack_UA_LocaleId(SV *sv, void *p)
 {
-	UA_LocaleId *data = p;
-	XS_pack_UA_LocaleId(sv, *data);
+	pack_UA_LocaleId(sv, p);
 }
 static void
 table_unpack_UA_LocaleId(SV *sv, void *p)
 {
-	UA_LocaleId *data = p;
-	*data = XS_unpack_UA_LocaleId(sv);
+	unpack_UA_LocaleId(p, sv);
 }
 #endif
 
@@ -5470,14 +5094,12 @@ XS_unpack_UA_LocalizedText(SV *in)
 static void
 table_pack_UA_LocalizedText(SV *sv, void *p)
 {
-	UA_LocalizedText *data = p;
-	XS_pack_UA_LocalizedText(sv, *data);
+	pack_UA_LocalizedText(sv, p);
 }
 static void
 table_unpack_UA_LocalizedText(SV *sv, void *p)
 {
-	UA_LocalizedText *data = p;
-	*data = XS_unpack_UA_LocalizedText(sv);
+	unpack_UA_LocalizedText(p, sv);
 }
 #endif
 
@@ -5499,14 +5121,12 @@ XS_unpack_UA_MdnsDiscoveryConfiguration(SV *in)
 static void
 table_pack_UA_MdnsDiscoveryConfiguration(SV *sv, void *p)
 {
-	UA_MdnsDiscoveryConfiguration *data = p;
-	XS_pack_UA_MdnsDiscoveryConfiguration(sv, *data);
+	pack_UA_MdnsDiscoveryConfiguration(sv, p);
 }
 static void
 table_unpack_UA_MdnsDiscoveryConfiguration(SV *sv, void *p)
 {
-	UA_MdnsDiscoveryConfiguration *data = p;
-	*data = XS_unpack_UA_MdnsDiscoveryConfiguration(sv);
+	unpack_UA_MdnsDiscoveryConfiguration(p, sv);
 }
 #endif
 
@@ -5528,14 +5148,12 @@ XS_unpack_UA_MessageSecurityMode(SV *in)
 static void
 table_pack_UA_MessageSecurityMode(SV *sv, void *p)
 {
-	UA_MessageSecurityMode *data = p;
-	XS_pack_UA_MessageSecurityMode(sv, *data);
+	pack_UA_MessageSecurityMode(sv, p);
 }
 static void
 table_unpack_UA_MessageSecurityMode(SV *sv, void *p)
 {
-	UA_MessageSecurityMode *data = p;
-	*data = XS_unpack_UA_MessageSecurityMode(sv);
+	unpack_UA_MessageSecurityMode(p, sv);
 }
 #endif
 
@@ -5557,14 +5175,12 @@ XS_unpack_UA_MethodAttributes(SV *in)
 static void
 table_pack_UA_MethodAttributes(SV *sv, void *p)
 {
-	UA_MethodAttributes *data = p;
-	XS_pack_UA_MethodAttributes(sv, *data);
+	pack_UA_MethodAttributes(sv, p);
 }
 static void
 table_unpack_UA_MethodAttributes(SV *sv, void *p)
 {
-	UA_MethodAttributes *data = p;
-	*data = XS_unpack_UA_MethodAttributes(sv);
+	unpack_UA_MethodAttributes(p, sv);
 }
 #endif
 
@@ -5586,14 +5202,12 @@ XS_unpack_UA_ModelChangeStructureDataType(SV *in)
 static void
 table_pack_UA_ModelChangeStructureDataType(SV *sv, void *p)
 {
-	UA_ModelChangeStructureDataType *data = p;
-	XS_pack_UA_ModelChangeStructureDataType(sv, *data);
+	pack_UA_ModelChangeStructureDataType(sv, p);
 }
 static void
 table_unpack_UA_ModelChangeStructureDataType(SV *sv, void *p)
 {
-	UA_ModelChangeStructureDataType *data = p;
-	*data = XS_unpack_UA_ModelChangeStructureDataType(sv);
+	unpack_UA_ModelChangeStructureDataType(p, sv);
 }
 #endif
 
@@ -5615,14 +5229,12 @@ XS_unpack_UA_ModelChangeStructureVerbMask(SV *in)
 static void
 table_pack_UA_ModelChangeStructureVerbMask(SV *sv, void *p)
 {
-	UA_ModelChangeStructureVerbMask *data = p;
-	XS_pack_UA_ModelChangeStructureVerbMask(sv, *data);
+	pack_UA_ModelChangeStructureVerbMask(sv, p);
 }
 static void
 table_unpack_UA_ModelChangeStructureVerbMask(SV *sv, void *p)
 {
-	UA_ModelChangeStructureVerbMask *data = p;
-	*data = XS_unpack_UA_ModelChangeStructureVerbMask(sv);
+	unpack_UA_ModelChangeStructureVerbMask(p, sv);
 }
 #endif
 
@@ -5644,14 +5256,12 @@ XS_unpack_UA_ModificationInfo(SV *in)
 static void
 table_pack_UA_ModificationInfo(SV *sv, void *p)
 {
-	UA_ModificationInfo *data = p;
-	XS_pack_UA_ModificationInfo(sv, *data);
+	pack_UA_ModificationInfo(sv, p);
 }
 static void
 table_unpack_UA_ModificationInfo(SV *sv, void *p)
 {
-	UA_ModificationInfo *data = p;
-	*data = XS_unpack_UA_ModificationInfo(sv);
+	unpack_UA_ModificationInfo(p, sv);
 }
 #endif
 
@@ -5673,14 +5283,12 @@ XS_unpack_UA_ModifyMonitoredItemsRequest(SV *in)
 static void
 table_pack_UA_ModifyMonitoredItemsRequest(SV *sv, void *p)
 {
-	UA_ModifyMonitoredItemsRequest *data = p;
-	XS_pack_UA_ModifyMonitoredItemsRequest(sv, *data);
+	pack_UA_ModifyMonitoredItemsRequest(sv, p);
 }
 static void
 table_unpack_UA_ModifyMonitoredItemsRequest(SV *sv, void *p)
 {
-	UA_ModifyMonitoredItemsRequest *data = p;
-	*data = XS_unpack_UA_ModifyMonitoredItemsRequest(sv);
+	unpack_UA_ModifyMonitoredItemsRequest(p, sv);
 }
 #endif
 
@@ -5702,14 +5310,12 @@ XS_unpack_UA_ModifyMonitoredItemsResponse(SV *in)
 static void
 table_pack_UA_ModifyMonitoredItemsResponse(SV *sv, void *p)
 {
-	UA_ModifyMonitoredItemsResponse *data = p;
-	XS_pack_UA_ModifyMonitoredItemsResponse(sv, *data);
+	pack_UA_ModifyMonitoredItemsResponse(sv, p);
 }
 static void
 table_unpack_UA_ModifyMonitoredItemsResponse(SV *sv, void *p)
 {
-	UA_ModifyMonitoredItemsResponse *data = p;
-	*data = XS_unpack_UA_ModifyMonitoredItemsResponse(sv);
+	unpack_UA_ModifyMonitoredItemsResponse(p, sv);
 }
 #endif
 
@@ -5731,14 +5337,12 @@ XS_unpack_UA_ModifySubscriptionRequest(SV *in)
 static void
 table_pack_UA_ModifySubscriptionRequest(SV *sv, void *p)
 {
-	UA_ModifySubscriptionRequest *data = p;
-	XS_pack_UA_ModifySubscriptionRequest(sv, *data);
+	pack_UA_ModifySubscriptionRequest(sv, p);
 }
 static void
 table_unpack_UA_ModifySubscriptionRequest(SV *sv, void *p)
 {
-	UA_ModifySubscriptionRequest *data = p;
-	*data = XS_unpack_UA_ModifySubscriptionRequest(sv);
+	unpack_UA_ModifySubscriptionRequest(p, sv);
 }
 #endif
 
@@ -5760,14 +5364,12 @@ XS_unpack_UA_ModifySubscriptionResponse(SV *in)
 static void
 table_pack_UA_ModifySubscriptionResponse(SV *sv, void *p)
 {
-	UA_ModifySubscriptionResponse *data = p;
-	XS_pack_UA_ModifySubscriptionResponse(sv, *data);
+	pack_UA_ModifySubscriptionResponse(sv, p);
 }
 static void
 table_unpack_UA_ModifySubscriptionResponse(SV *sv, void *p)
 {
-	UA_ModifySubscriptionResponse *data = p;
-	*data = XS_unpack_UA_ModifySubscriptionResponse(sv);
+	unpack_UA_ModifySubscriptionResponse(p, sv);
 }
 #endif
 
@@ -5789,14 +5391,12 @@ XS_unpack_UA_MonitoredItemCreateRequest(SV *in)
 static void
 table_pack_UA_MonitoredItemCreateRequest(SV *sv, void *p)
 {
-	UA_MonitoredItemCreateRequest *data = p;
-	XS_pack_UA_MonitoredItemCreateRequest(sv, *data);
+	pack_UA_MonitoredItemCreateRequest(sv, p);
 }
 static void
 table_unpack_UA_MonitoredItemCreateRequest(SV *sv, void *p)
 {
-	UA_MonitoredItemCreateRequest *data = p;
-	*data = XS_unpack_UA_MonitoredItemCreateRequest(sv);
+	unpack_UA_MonitoredItemCreateRequest(p, sv);
 }
 #endif
 
@@ -5818,14 +5418,12 @@ XS_unpack_UA_MonitoredItemCreateResult(SV *in)
 static void
 table_pack_UA_MonitoredItemCreateResult(SV *sv, void *p)
 {
-	UA_MonitoredItemCreateResult *data = p;
-	XS_pack_UA_MonitoredItemCreateResult(sv, *data);
+	pack_UA_MonitoredItemCreateResult(sv, p);
 }
 static void
 table_unpack_UA_MonitoredItemCreateResult(SV *sv, void *p)
 {
-	UA_MonitoredItemCreateResult *data = p;
-	*data = XS_unpack_UA_MonitoredItemCreateResult(sv);
+	unpack_UA_MonitoredItemCreateResult(p, sv);
 }
 #endif
 
@@ -5847,14 +5445,12 @@ XS_unpack_UA_MonitoredItemModifyRequest(SV *in)
 static void
 table_pack_UA_MonitoredItemModifyRequest(SV *sv, void *p)
 {
-	UA_MonitoredItemModifyRequest *data = p;
-	XS_pack_UA_MonitoredItemModifyRequest(sv, *data);
+	pack_UA_MonitoredItemModifyRequest(sv, p);
 }
 static void
 table_unpack_UA_MonitoredItemModifyRequest(SV *sv, void *p)
 {
-	UA_MonitoredItemModifyRequest *data = p;
-	*data = XS_unpack_UA_MonitoredItemModifyRequest(sv);
+	unpack_UA_MonitoredItemModifyRequest(p, sv);
 }
 #endif
 
@@ -5876,14 +5472,12 @@ XS_unpack_UA_MonitoredItemModifyResult(SV *in)
 static void
 table_pack_UA_MonitoredItemModifyResult(SV *sv, void *p)
 {
-	UA_MonitoredItemModifyResult *data = p;
-	XS_pack_UA_MonitoredItemModifyResult(sv, *data);
+	pack_UA_MonitoredItemModifyResult(sv, p);
 }
 static void
 table_unpack_UA_MonitoredItemModifyResult(SV *sv, void *p)
 {
-	UA_MonitoredItemModifyResult *data = p;
-	*data = XS_unpack_UA_MonitoredItemModifyResult(sv);
+	unpack_UA_MonitoredItemModifyResult(p, sv);
 }
 #endif
 
@@ -5905,14 +5499,12 @@ XS_unpack_UA_MonitoredItemNotification(SV *in)
 static void
 table_pack_UA_MonitoredItemNotification(SV *sv, void *p)
 {
-	UA_MonitoredItemNotification *data = p;
-	XS_pack_UA_MonitoredItemNotification(sv, *data);
+	pack_UA_MonitoredItemNotification(sv, p);
 }
 static void
 table_unpack_UA_MonitoredItemNotification(SV *sv, void *p)
 {
-	UA_MonitoredItemNotification *data = p;
-	*data = XS_unpack_UA_MonitoredItemNotification(sv);
+	unpack_UA_MonitoredItemNotification(p, sv);
 }
 #endif
 
@@ -5934,14 +5526,12 @@ XS_unpack_UA_MonitoringFilter(SV *in)
 static void
 table_pack_UA_MonitoringFilter(SV *sv, void *p)
 {
-	UA_MonitoringFilter *data = p;
-	XS_pack_UA_MonitoringFilter(sv, *data);
+	pack_UA_MonitoringFilter(sv, p);
 }
 static void
 table_unpack_UA_MonitoringFilter(SV *sv, void *p)
 {
-	UA_MonitoringFilter *data = p;
-	*data = XS_unpack_UA_MonitoringFilter(sv);
+	unpack_UA_MonitoringFilter(p, sv);
 }
 #endif
 
@@ -5963,14 +5553,12 @@ XS_unpack_UA_MonitoringFilterResult(SV *in)
 static void
 table_pack_UA_MonitoringFilterResult(SV *sv, void *p)
 {
-	UA_MonitoringFilterResult *data = p;
-	XS_pack_UA_MonitoringFilterResult(sv, *data);
+	pack_UA_MonitoringFilterResult(sv, p);
 }
 static void
 table_unpack_UA_MonitoringFilterResult(SV *sv, void *p)
 {
-	UA_MonitoringFilterResult *data = p;
-	*data = XS_unpack_UA_MonitoringFilterResult(sv);
+	unpack_UA_MonitoringFilterResult(p, sv);
 }
 #endif
 
@@ -5992,14 +5580,12 @@ XS_unpack_UA_MonitoringMode(SV *in)
 static void
 table_pack_UA_MonitoringMode(SV *sv, void *p)
 {
-	UA_MonitoringMode *data = p;
-	XS_pack_UA_MonitoringMode(sv, *data);
+	pack_UA_MonitoringMode(sv, p);
 }
 static void
 table_unpack_UA_MonitoringMode(SV *sv, void *p)
 {
-	UA_MonitoringMode *data = p;
-	*data = XS_unpack_UA_MonitoringMode(sv);
+	unpack_UA_MonitoringMode(p, sv);
 }
 #endif
 
@@ -6021,14 +5607,12 @@ XS_unpack_UA_MonitoringParameters(SV *in)
 static void
 table_pack_UA_MonitoringParameters(SV *sv, void *p)
 {
-	UA_MonitoringParameters *data = p;
-	XS_pack_UA_MonitoringParameters(sv, *data);
+	pack_UA_MonitoringParameters(sv, p);
 }
 static void
 table_unpack_UA_MonitoringParameters(SV *sv, void *p)
 {
-	UA_MonitoringParameters *data = p;
-	*data = XS_unpack_UA_MonitoringParameters(sv);
+	unpack_UA_MonitoringParameters(p, sv);
 }
 #endif
 
@@ -6050,14 +5634,12 @@ XS_unpack_UA_NamingRuleType(SV *in)
 static void
 table_pack_UA_NamingRuleType(SV *sv, void *p)
 {
-	UA_NamingRuleType *data = p;
-	XS_pack_UA_NamingRuleType(sv, *data);
+	pack_UA_NamingRuleType(sv, p);
 }
 static void
 table_unpack_UA_NamingRuleType(SV *sv, void *p)
 {
-	UA_NamingRuleType *data = p;
-	*data = XS_unpack_UA_NamingRuleType(sv);
+	unpack_UA_NamingRuleType(p, sv);
 }
 #endif
 
@@ -6079,14 +5661,12 @@ XS_unpack_UA_NetworkAddressDataType(SV *in)
 static void
 table_pack_UA_NetworkAddressDataType(SV *sv, void *p)
 {
-	UA_NetworkAddressDataType *data = p;
-	XS_pack_UA_NetworkAddressDataType(sv, *data);
+	pack_UA_NetworkAddressDataType(sv, p);
 }
 static void
 table_unpack_UA_NetworkAddressDataType(SV *sv, void *p)
 {
-	UA_NetworkAddressDataType *data = p;
-	*data = XS_unpack_UA_NetworkAddressDataType(sv);
+	unpack_UA_NetworkAddressDataType(p, sv);
 }
 #endif
 
@@ -6108,14 +5688,12 @@ XS_unpack_UA_NetworkAddressUrlDataType(SV *in)
 static void
 table_pack_UA_NetworkAddressUrlDataType(SV *sv, void *p)
 {
-	UA_NetworkAddressUrlDataType *data = p;
-	XS_pack_UA_NetworkAddressUrlDataType(sv, *data);
+	pack_UA_NetworkAddressUrlDataType(sv, p);
 }
 static void
 table_unpack_UA_NetworkAddressUrlDataType(SV *sv, void *p)
 {
-	UA_NetworkAddressUrlDataType *data = p;
-	*data = XS_unpack_UA_NetworkAddressUrlDataType(sv);
+	unpack_UA_NetworkAddressUrlDataType(p, sv);
 }
 #endif
 
@@ -6137,14 +5715,12 @@ XS_unpack_UA_NetworkGroupDataType(SV *in)
 static void
 table_pack_UA_NetworkGroupDataType(SV *sv, void *p)
 {
-	UA_NetworkGroupDataType *data = p;
-	XS_pack_UA_NetworkGroupDataType(sv, *data);
+	pack_UA_NetworkGroupDataType(sv, p);
 }
 static void
 table_unpack_UA_NetworkGroupDataType(SV *sv, void *p)
 {
-	UA_NetworkGroupDataType *data = p;
-	*data = XS_unpack_UA_NetworkGroupDataType(sv);
+	unpack_UA_NetworkGroupDataType(p, sv);
 }
 #endif
 
@@ -6166,14 +5742,12 @@ XS_unpack_UA_NodeAttributes(SV *in)
 static void
 table_pack_UA_NodeAttributes(SV *sv, void *p)
 {
-	UA_NodeAttributes *data = p;
-	XS_pack_UA_NodeAttributes(sv, *data);
+	pack_UA_NodeAttributes(sv, p);
 }
 static void
 table_unpack_UA_NodeAttributes(SV *sv, void *p)
 {
-	UA_NodeAttributes *data = p;
-	*data = XS_unpack_UA_NodeAttributes(sv);
+	unpack_UA_NodeAttributes(p, sv);
 }
 #endif
 
@@ -6195,14 +5769,12 @@ XS_unpack_UA_NodeAttributesMask(SV *in)
 static void
 table_pack_UA_NodeAttributesMask(SV *sv, void *p)
 {
-	UA_NodeAttributesMask *data = p;
-	XS_pack_UA_NodeAttributesMask(sv, *data);
+	pack_UA_NodeAttributesMask(sv, p);
 }
 static void
 table_unpack_UA_NodeAttributesMask(SV *sv, void *p)
 {
-	UA_NodeAttributesMask *data = p;
-	*data = XS_unpack_UA_NodeAttributesMask(sv);
+	unpack_UA_NodeAttributesMask(p, sv);
 }
 #endif
 
@@ -6224,14 +5796,12 @@ XS_unpack_UA_NodeClass(SV *in)
 static void
 table_pack_UA_NodeClass(SV *sv, void *p)
 {
-	UA_NodeClass *data = p;
-	XS_pack_UA_NodeClass(sv, *data);
+	pack_UA_NodeClass(sv, p);
 }
 static void
 table_unpack_UA_NodeClass(SV *sv, void *p)
 {
-	UA_NodeClass *data = p;
-	*data = XS_unpack_UA_NodeClass(sv);
+	unpack_UA_NodeClass(p, sv);
 }
 #endif
 
@@ -6253,14 +5823,12 @@ XS_unpack_UA_NodeId(SV *in)
 static void
 table_pack_UA_NodeId(SV *sv, void *p)
 {
-	UA_NodeId *data = p;
-	XS_pack_UA_NodeId(sv, *data);
+	pack_UA_NodeId(sv, p);
 }
 static void
 table_unpack_UA_NodeId(SV *sv, void *p)
 {
-	UA_NodeId *data = p;
-	*data = XS_unpack_UA_NodeId(sv);
+	unpack_UA_NodeId(p, sv);
 }
 #endif
 
@@ -6282,14 +5850,12 @@ XS_unpack_UA_NodeReference(SV *in)
 static void
 table_pack_UA_NodeReference(SV *sv, void *p)
 {
-	UA_NodeReference *data = p;
-	XS_pack_UA_NodeReference(sv, *data);
+	pack_UA_NodeReference(sv, p);
 }
 static void
 table_unpack_UA_NodeReference(SV *sv, void *p)
 {
-	UA_NodeReference *data = p;
-	*data = XS_unpack_UA_NodeReference(sv);
+	unpack_UA_NodeReference(p, sv);
 }
 #endif
 
@@ -6311,14 +5877,12 @@ XS_unpack_UA_NodeTypeDescription(SV *in)
 static void
 table_pack_UA_NodeTypeDescription(SV *sv, void *p)
 {
-	UA_NodeTypeDescription *data = p;
-	XS_pack_UA_NodeTypeDescription(sv, *data);
+	pack_UA_NodeTypeDescription(sv, p);
 }
 static void
 table_unpack_UA_NodeTypeDescription(SV *sv, void *p)
 {
-	UA_NodeTypeDescription *data = p;
-	*data = XS_unpack_UA_NodeTypeDescription(sv);
+	unpack_UA_NodeTypeDescription(p, sv);
 }
 #endif
 
@@ -6340,14 +5904,12 @@ XS_unpack_UA_NormalizedString(SV *in)
 static void
 table_pack_UA_NormalizedString(SV *sv, void *p)
 {
-	UA_NormalizedString *data = p;
-	XS_pack_UA_NormalizedString(sv, *data);
+	pack_UA_NormalizedString(sv, p);
 }
 static void
 table_unpack_UA_NormalizedString(SV *sv, void *p)
 {
-	UA_NormalizedString *data = p;
-	*data = XS_unpack_UA_NormalizedString(sv);
+	unpack_UA_NormalizedString(p, sv);
 }
 #endif
 
@@ -6369,14 +5931,12 @@ XS_unpack_UA_NotificationData(SV *in)
 static void
 table_pack_UA_NotificationData(SV *sv, void *p)
 {
-	UA_NotificationData *data = p;
-	XS_pack_UA_NotificationData(sv, *data);
+	pack_UA_NotificationData(sv, p);
 }
 static void
 table_unpack_UA_NotificationData(SV *sv, void *p)
 {
-	UA_NotificationData *data = p;
-	*data = XS_unpack_UA_NotificationData(sv);
+	unpack_UA_NotificationData(p, sv);
 }
 #endif
 
@@ -6398,14 +5958,12 @@ XS_unpack_UA_NotificationMessage(SV *in)
 static void
 table_pack_UA_NotificationMessage(SV *sv, void *p)
 {
-	UA_NotificationMessage *data = p;
-	XS_pack_UA_NotificationMessage(sv, *data);
+	pack_UA_NotificationMessage(sv, p);
 }
 static void
 table_unpack_UA_NotificationMessage(SV *sv, void *p)
 {
-	UA_NotificationMessage *data = p;
-	*data = XS_unpack_UA_NotificationMessage(sv);
+	unpack_UA_NotificationMessage(p, sv);
 }
 #endif
 
@@ -6427,14 +5985,12 @@ XS_unpack_UA_ObjectAttributes(SV *in)
 static void
 table_pack_UA_ObjectAttributes(SV *sv, void *p)
 {
-	UA_ObjectAttributes *data = p;
-	XS_pack_UA_ObjectAttributes(sv, *data);
+	pack_UA_ObjectAttributes(sv, p);
 }
 static void
 table_unpack_UA_ObjectAttributes(SV *sv, void *p)
 {
-	UA_ObjectAttributes *data = p;
-	*data = XS_unpack_UA_ObjectAttributes(sv);
+	unpack_UA_ObjectAttributes(p, sv);
 }
 #endif
 
@@ -6456,14 +6012,12 @@ XS_unpack_UA_ObjectTypeAttributes(SV *in)
 static void
 table_pack_UA_ObjectTypeAttributes(SV *sv, void *p)
 {
-	UA_ObjectTypeAttributes *data = p;
-	XS_pack_UA_ObjectTypeAttributes(sv, *data);
+	pack_UA_ObjectTypeAttributes(sv, p);
 }
 static void
 table_unpack_UA_ObjectTypeAttributes(SV *sv, void *p)
 {
-	UA_ObjectTypeAttributes *data = p;
-	*data = XS_unpack_UA_ObjectTypeAttributes(sv);
+	unpack_UA_ObjectTypeAttributes(p, sv);
 }
 #endif
 
@@ -6485,14 +6039,12 @@ XS_unpack_UA_OpenFileMode(SV *in)
 static void
 table_pack_UA_OpenFileMode(SV *sv, void *p)
 {
-	UA_OpenFileMode *data = p;
-	XS_pack_UA_OpenFileMode(sv, *data);
+	pack_UA_OpenFileMode(sv, p);
 }
 static void
 table_unpack_UA_OpenFileMode(SV *sv, void *p)
 {
-	UA_OpenFileMode *data = p;
-	*data = XS_unpack_UA_OpenFileMode(sv);
+	unpack_UA_OpenFileMode(p, sv);
 }
 #endif
 
@@ -6514,14 +6066,12 @@ XS_unpack_UA_OpenSecureChannelRequest(SV *in)
 static void
 table_pack_UA_OpenSecureChannelRequest(SV *sv, void *p)
 {
-	UA_OpenSecureChannelRequest *data = p;
-	XS_pack_UA_OpenSecureChannelRequest(sv, *data);
+	pack_UA_OpenSecureChannelRequest(sv, p);
 }
 static void
 table_unpack_UA_OpenSecureChannelRequest(SV *sv, void *p)
 {
-	UA_OpenSecureChannelRequest *data = p;
-	*data = XS_unpack_UA_OpenSecureChannelRequest(sv);
+	unpack_UA_OpenSecureChannelRequest(p, sv);
 }
 #endif
 
@@ -6543,14 +6093,12 @@ XS_unpack_UA_OpenSecureChannelResponse(SV *in)
 static void
 table_pack_UA_OpenSecureChannelResponse(SV *sv, void *p)
 {
-	UA_OpenSecureChannelResponse *data = p;
-	XS_pack_UA_OpenSecureChannelResponse(sv, *data);
+	pack_UA_OpenSecureChannelResponse(sv, p);
 }
 static void
 table_unpack_UA_OpenSecureChannelResponse(SV *sv, void *p)
 {
-	UA_OpenSecureChannelResponse *data = p;
-	*data = XS_unpack_UA_OpenSecureChannelResponse(sv);
+	unpack_UA_OpenSecureChannelResponse(p, sv);
 }
 #endif
 
@@ -6572,14 +6120,12 @@ XS_unpack_UA_OptionSet(SV *in)
 static void
 table_pack_UA_OptionSet(SV *sv, void *p)
 {
-	UA_OptionSet *data = p;
-	XS_pack_UA_OptionSet(sv, *data);
+	pack_UA_OptionSet(sv, p);
 }
 static void
 table_unpack_UA_OptionSet(SV *sv, void *p)
 {
-	UA_OptionSet *data = p;
-	*data = XS_unpack_UA_OptionSet(sv);
+	unpack_UA_OptionSet(p, sv);
 }
 #endif
 
@@ -6601,14 +6147,12 @@ XS_unpack_UA_Orientation(SV *in)
 static void
 table_pack_UA_Orientation(SV *sv, void *p)
 {
-	UA_Orientation *data = p;
-	XS_pack_UA_Orientation(sv, *data);
+	pack_UA_Orientation(sv, p);
 }
 static void
 table_unpack_UA_Orientation(SV *sv, void *p)
 {
-	UA_Orientation *data = p;
-	*data = XS_unpack_UA_Orientation(sv);
+	unpack_UA_Orientation(p, sv);
 }
 #endif
 
@@ -6630,14 +6174,12 @@ XS_unpack_UA_OverrideValueHandling(SV *in)
 static void
 table_pack_UA_OverrideValueHandling(SV *sv, void *p)
 {
-	UA_OverrideValueHandling *data = p;
-	XS_pack_UA_OverrideValueHandling(sv, *data);
+	pack_UA_OverrideValueHandling(sv, p);
 }
 static void
 table_unpack_UA_OverrideValueHandling(SV *sv, void *p)
 {
-	UA_OverrideValueHandling *data = p;
-	*data = XS_unpack_UA_OverrideValueHandling(sv);
+	unpack_UA_OverrideValueHandling(p, sv);
 }
 #endif
 
@@ -6659,14 +6201,12 @@ XS_unpack_UA_ParsingResult(SV *in)
 static void
 table_pack_UA_ParsingResult(SV *sv, void *p)
 {
-	UA_ParsingResult *data = p;
-	XS_pack_UA_ParsingResult(sv, *data);
+	pack_UA_ParsingResult(sv, p);
 }
 static void
 table_unpack_UA_ParsingResult(SV *sv, void *p)
 {
-	UA_ParsingResult *data = p;
-	*data = XS_unpack_UA_ParsingResult(sv);
+	unpack_UA_ParsingResult(p, sv);
 }
 #endif
 
@@ -6688,14 +6228,12 @@ XS_unpack_UA_PerformUpdateType(SV *in)
 static void
 table_pack_UA_PerformUpdateType(SV *sv, void *p)
 {
-	UA_PerformUpdateType *data = p;
-	XS_pack_UA_PerformUpdateType(sv, *data);
+	pack_UA_PerformUpdateType(sv, p);
 }
 static void
 table_unpack_UA_PerformUpdateType(SV *sv, void *p)
 {
-	UA_PerformUpdateType *data = p;
-	*data = XS_unpack_UA_PerformUpdateType(sv);
+	unpack_UA_PerformUpdateType(p, sv);
 }
 #endif
 
@@ -6717,14 +6255,12 @@ XS_unpack_UA_PermissionType(SV *in)
 static void
 table_pack_UA_PermissionType(SV *sv, void *p)
 {
-	UA_PermissionType *data = p;
-	XS_pack_UA_PermissionType(sv, *data);
+	pack_UA_PermissionType(sv, p);
 }
 static void
 table_unpack_UA_PermissionType(SV *sv, void *p)
 {
-	UA_PermissionType *data = p;
-	*data = XS_unpack_UA_PermissionType(sv);
+	unpack_UA_PermissionType(p, sv);
 }
 #endif
 
@@ -6746,14 +6282,12 @@ XS_unpack_UA_ProgramDiagnostic2DataType(SV *in)
 static void
 table_pack_UA_ProgramDiagnostic2DataType(SV *sv, void *p)
 {
-	UA_ProgramDiagnostic2DataType *data = p;
-	XS_pack_UA_ProgramDiagnostic2DataType(sv, *data);
+	pack_UA_ProgramDiagnostic2DataType(sv, p);
 }
 static void
 table_unpack_UA_ProgramDiagnostic2DataType(SV *sv, void *p)
 {
-	UA_ProgramDiagnostic2DataType *data = p;
-	*data = XS_unpack_UA_ProgramDiagnostic2DataType(sv);
+	unpack_UA_ProgramDiagnostic2DataType(p, sv);
 }
 #endif
 
@@ -6775,14 +6309,12 @@ XS_unpack_UA_ProgramDiagnosticDataType(SV *in)
 static void
 table_pack_UA_ProgramDiagnosticDataType(SV *sv, void *p)
 {
-	UA_ProgramDiagnosticDataType *data = p;
-	XS_pack_UA_ProgramDiagnosticDataType(sv, *data);
+	pack_UA_ProgramDiagnosticDataType(sv, p);
 }
 static void
 table_unpack_UA_ProgramDiagnosticDataType(SV *sv, void *p)
 {
-	UA_ProgramDiagnosticDataType *data = p;
-	*data = XS_unpack_UA_ProgramDiagnosticDataType(sv);
+	unpack_UA_ProgramDiagnosticDataType(p, sv);
 }
 #endif
 
@@ -6804,14 +6336,12 @@ XS_unpack_UA_PubSubConfigurationDataType(SV *in)
 static void
 table_pack_UA_PubSubConfigurationDataType(SV *sv, void *p)
 {
-	UA_PubSubConfigurationDataType *data = p;
-	XS_pack_UA_PubSubConfigurationDataType(sv, *data);
+	pack_UA_PubSubConfigurationDataType(sv, p);
 }
 static void
 table_unpack_UA_PubSubConfigurationDataType(SV *sv, void *p)
 {
-	UA_PubSubConfigurationDataType *data = p;
-	*data = XS_unpack_UA_PubSubConfigurationDataType(sv);
+	unpack_UA_PubSubConfigurationDataType(p, sv);
 }
 #endif
 
@@ -6833,14 +6363,12 @@ XS_unpack_UA_PubSubConnectionDataType(SV *in)
 static void
 table_pack_UA_PubSubConnectionDataType(SV *sv, void *p)
 {
-	UA_PubSubConnectionDataType *data = p;
-	XS_pack_UA_PubSubConnectionDataType(sv, *data);
+	pack_UA_PubSubConnectionDataType(sv, p);
 }
 static void
 table_unpack_UA_PubSubConnectionDataType(SV *sv, void *p)
 {
-	UA_PubSubConnectionDataType *data = p;
-	*data = XS_unpack_UA_PubSubConnectionDataType(sv);
+	unpack_UA_PubSubConnectionDataType(p, sv);
 }
 #endif
 
@@ -6862,14 +6390,12 @@ XS_unpack_UA_PubSubDiagnosticsCounterClassification(SV *in)
 static void
 table_pack_UA_PubSubDiagnosticsCounterClassification(SV *sv, void *p)
 {
-	UA_PubSubDiagnosticsCounterClassification *data = p;
-	XS_pack_UA_PubSubDiagnosticsCounterClassification(sv, *data);
+	pack_UA_PubSubDiagnosticsCounterClassification(sv, p);
 }
 static void
 table_unpack_UA_PubSubDiagnosticsCounterClassification(SV *sv, void *p)
 {
-	UA_PubSubDiagnosticsCounterClassification *data = p;
-	*data = XS_unpack_UA_PubSubDiagnosticsCounterClassification(sv);
+	unpack_UA_PubSubDiagnosticsCounterClassification(p, sv);
 }
 #endif
 
@@ -6891,14 +6417,12 @@ XS_unpack_UA_PubSubGroupDataType(SV *in)
 static void
 table_pack_UA_PubSubGroupDataType(SV *sv, void *p)
 {
-	UA_PubSubGroupDataType *data = p;
-	XS_pack_UA_PubSubGroupDataType(sv, *data);
+	pack_UA_PubSubGroupDataType(sv, p);
 }
 static void
 table_unpack_UA_PubSubGroupDataType(SV *sv, void *p)
 {
-	UA_PubSubGroupDataType *data = p;
-	*data = XS_unpack_UA_PubSubGroupDataType(sv);
+	unpack_UA_PubSubGroupDataType(p, sv);
 }
 #endif
 
@@ -6920,14 +6444,12 @@ XS_unpack_UA_PubSubState(SV *in)
 static void
 table_pack_UA_PubSubState(SV *sv, void *p)
 {
-	UA_PubSubState *data = p;
-	XS_pack_UA_PubSubState(sv, *data);
+	pack_UA_PubSubState(sv, p);
 }
 static void
 table_unpack_UA_PubSubState(SV *sv, void *p)
 {
-	UA_PubSubState *data = p;
-	*data = XS_unpack_UA_PubSubState(sv);
+	unpack_UA_PubSubState(p, sv);
 }
 #endif
 
@@ -6949,14 +6471,12 @@ XS_unpack_UA_PublishRequest(SV *in)
 static void
 table_pack_UA_PublishRequest(SV *sv, void *p)
 {
-	UA_PublishRequest *data = p;
-	XS_pack_UA_PublishRequest(sv, *data);
+	pack_UA_PublishRequest(sv, p);
 }
 static void
 table_unpack_UA_PublishRequest(SV *sv, void *p)
 {
-	UA_PublishRequest *data = p;
-	*data = XS_unpack_UA_PublishRequest(sv);
+	unpack_UA_PublishRequest(p, sv);
 }
 #endif
 
@@ -6978,14 +6498,12 @@ XS_unpack_UA_PublishResponse(SV *in)
 static void
 table_pack_UA_PublishResponse(SV *sv, void *p)
 {
-	UA_PublishResponse *data = p;
-	XS_pack_UA_PublishResponse(sv, *data);
+	pack_UA_PublishResponse(sv, p);
 }
 static void
 table_unpack_UA_PublishResponse(SV *sv, void *p)
 {
-	UA_PublishResponse *data = p;
-	*data = XS_unpack_UA_PublishResponse(sv);
+	unpack_UA_PublishResponse(p, sv);
 }
 #endif
 
@@ -7007,14 +6525,12 @@ XS_unpack_UA_PublishedDataItemsDataType(SV *in)
 static void
 table_pack_UA_PublishedDataItemsDataType(SV *sv, void *p)
 {
-	UA_PublishedDataItemsDataType *data = p;
-	XS_pack_UA_PublishedDataItemsDataType(sv, *data);
+	pack_UA_PublishedDataItemsDataType(sv, p);
 }
 static void
 table_unpack_UA_PublishedDataItemsDataType(SV *sv, void *p)
 {
-	UA_PublishedDataItemsDataType *data = p;
-	*data = XS_unpack_UA_PublishedDataItemsDataType(sv);
+	unpack_UA_PublishedDataItemsDataType(p, sv);
 }
 #endif
 
@@ -7036,14 +6552,12 @@ XS_unpack_UA_PublishedDataSetDataType(SV *in)
 static void
 table_pack_UA_PublishedDataSetDataType(SV *sv, void *p)
 {
-	UA_PublishedDataSetDataType *data = p;
-	XS_pack_UA_PublishedDataSetDataType(sv, *data);
+	pack_UA_PublishedDataSetDataType(sv, p);
 }
 static void
 table_unpack_UA_PublishedDataSetDataType(SV *sv, void *p)
 {
-	UA_PublishedDataSetDataType *data = p;
-	*data = XS_unpack_UA_PublishedDataSetDataType(sv);
+	unpack_UA_PublishedDataSetDataType(p, sv);
 }
 #endif
 
@@ -7065,14 +6579,12 @@ XS_unpack_UA_PublishedDataSetSourceDataType(SV *in)
 static void
 table_pack_UA_PublishedDataSetSourceDataType(SV *sv, void *p)
 {
-	UA_PublishedDataSetSourceDataType *data = p;
-	XS_pack_UA_PublishedDataSetSourceDataType(sv, *data);
+	pack_UA_PublishedDataSetSourceDataType(sv, p);
 }
 static void
 table_unpack_UA_PublishedDataSetSourceDataType(SV *sv, void *p)
 {
-	UA_PublishedDataSetSourceDataType *data = p;
-	*data = XS_unpack_UA_PublishedDataSetSourceDataType(sv);
+	unpack_UA_PublishedDataSetSourceDataType(p, sv);
 }
 #endif
 
@@ -7094,14 +6606,12 @@ XS_unpack_UA_PublishedEventsDataType(SV *in)
 static void
 table_pack_UA_PublishedEventsDataType(SV *sv, void *p)
 {
-	UA_PublishedEventsDataType *data = p;
-	XS_pack_UA_PublishedEventsDataType(sv, *data);
+	pack_UA_PublishedEventsDataType(sv, p);
 }
 static void
 table_unpack_UA_PublishedEventsDataType(SV *sv, void *p)
 {
-	UA_PublishedEventsDataType *data = p;
-	*data = XS_unpack_UA_PublishedEventsDataType(sv);
+	unpack_UA_PublishedEventsDataType(p, sv);
 }
 #endif
 
@@ -7123,14 +6633,12 @@ XS_unpack_UA_PublishedVariableDataType(SV *in)
 static void
 table_pack_UA_PublishedVariableDataType(SV *sv, void *p)
 {
-	UA_PublishedVariableDataType *data = p;
-	XS_pack_UA_PublishedVariableDataType(sv, *data);
+	pack_UA_PublishedVariableDataType(sv, p);
 }
 static void
 table_unpack_UA_PublishedVariableDataType(SV *sv, void *p)
 {
-	UA_PublishedVariableDataType *data = p;
-	*data = XS_unpack_UA_PublishedVariableDataType(sv);
+	unpack_UA_PublishedVariableDataType(p, sv);
 }
 #endif
 
@@ -7152,14 +6660,12 @@ XS_unpack_UA_QualifiedName(SV *in)
 static void
 table_pack_UA_QualifiedName(SV *sv, void *p)
 {
-	UA_QualifiedName *data = p;
-	XS_pack_UA_QualifiedName(sv, *data);
+	pack_UA_QualifiedName(sv, p);
 }
 static void
 table_unpack_UA_QualifiedName(SV *sv, void *p)
 {
-	UA_QualifiedName *data = p;
-	*data = XS_unpack_UA_QualifiedName(sv);
+	unpack_UA_QualifiedName(p, sv);
 }
 #endif
 
@@ -7181,14 +6687,12 @@ XS_unpack_UA_QueryDataDescription(SV *in)
 static void
 table_pack_UA_QueryDataDescription(SV *sv, void *p)
 {
-	UA_QueryDataDescription *data = p;
-	XS_pack_UA_QueryDataDescription(sv, *data);
+	pack_UA_QueryDataDescription(sv, p);
 }
 static void
 table_unpack_UA_QueryDataDescription(SV *sv, void *p)
 {
-	UA_QueryDataDescription *data = p;
-	*data = XS_unpack_UA_QueryDataDescription(sv);
+	unpack_UA_QueryDataDescription(p, sv);
 }
 #endif
 
@@ -7210,14 +6714,12 @@ XS_unpack_UA_QueryDataSet(SV *in)
 static void
 table_pack_UA_QueryDataSet(SV *sv, void *p)
 {
-	UA_QueryDataSet *data = p;
-	XS_pack_UA_QueryDataSet(sv, *data);
+	pack_UA_QueryDataSet(sv, p);
 }
 static void
 table_unpack_UA_QueryDataSet(SV *sv, void *p)
 {
-	UA_QueryDataSet *data = p;
-	*data = XS_unpack_UA_QueryDataSet(sv);
+	unpack_UA_QueryDataSet(p, sv);
 }
 #endif
 
@@ -7239,14 +6741,12 @@ XS_unpack_UA_QueryFirstRequest(SV *in)
 static void
 table_pack_UA_QueryFirstRequest(SV *sv, void *p)
 {
-	UA_QueryFirstRequest *data = p;
-	XS_pack_UA_QueryFirstRequest(sv, *data);
+	pack_UA_QueryFirstRequest(sv, p);
 }
 static void
 table_unpack_UA_QueryFirstRequest(SV *sv, void *p)
 {
-	UA_QueryFirstRequest *data = p;
-	*data = XS_unpack_UA_QueryFirstRequest(sv);
+	unpack_UA_QueryFirstRequest(p, sv);
 }
 #endif
 
@@ -7268,14 +6768,12 @@ XS_unpack_UA_QueryFirstResponse(SV *in)
 static void
 table_pack_UA_QueryFirstResponse(SV *sv, void *p)
 {
-	UA_QueryFirstResponse *data = p;
-	XS_pack_UA_QueryFirstResponse(sv, *data);
+	pack_UA_QueryFirstResponse(sv, p);
 }
 static void
 table_unpack_UA_QueryFirstResponse(SV *sv, void *p)
 {
-	UA_QueryFirstResponse *data = p;
-	*data = XS_unpack_UA_QueryFirstResponse(sv);
+	unpack_UA_QueryFirstResponse(p, sv);
 }
 #endif
 
@@ -7297,14 +6795,12 @@ XS_unpack_UA_QueryNextRequest(SV *in)
 static void
 table_pack_UA_QueryNextRequest(SV *sv, void *p)
 {
-	UA_QueryNextRequest *data = p;
-	XS_pack_UA_QueryNextRequest(sv, *data);
+	pack_UA_QueryNextRequest(sv, p);
 }
 static void
 table_unpack_UA_QueryNextRequest(SV *sv, void *p)
 {
-	UA_QueryNextRequest *data = p;
-	*data = XS_unpack_UA_QueryNextRequest(sv);
+	unpack_UA_QueryNextRequest(p, sv);
 }
 #endif
 
@@ -7326,14 +6822,12 @@ XS_unpack_UA_QueryNextResponse(SV *in)
 static void
 table_pack_UA_QueryNextResponse(SV *sv, void *p)
 {
-	UA_QueryNextResponse *data = p;
-	XS_pack_UA_QueryNextResponse(sv, *data);
+	pack_UA_QueryNextResponse(sv, p);
 }
 static void
 table_unpack_UA_QueryNextResponse(SV *sv, void *p)
 {
-	UA_QueryNextResponse *data = p;
-	*data = XS_unpack_UA_QueryNextResponse(sv);
+	unpack_UA_QueryNextResponse(p, sv);
 }
 #endif
 
@@ -7355,14 +6849,12 @@ XS_unpack_UA_Range(SV *in)
 static void
 table_pack_UA_Range(SV *sv, void *p)
 {
-	UA_Range *data = p;
-	XS_pack_UA_Range(sv, *data);
+	pack_UA_Range(sv, p);
 }
 static void
 table_unpack_UA_Range(SV *sv, void *p)
 {
-	UA_Range *data = p;
-	*data = XS_unpack_UA_Range(sv);
+	unpack_UA_Range(p, sv);
 }
 #endif
 
@@ -7384,14 +6876,12 @@ XS_unpack_UA_RationalNumber(SV *in)
 static void
 table_pack_UA_RationalNumber(SV *sv, void *p)
 {
-	UA_RationalNumber *data = p;
-	XS_pack_UA_RationalNumber(sv, *data);
+	pack_UA_RationalNumber(sv, p);
 }
 static void
 table_unpack_UA_RationalNumber(SV *sv, void *p)
 {
-	UA_RationalNumber *data = p;
-	*data = XS_unpack_UA_RationalNumber(sv);
+	unpack_UA_RationalNumber(p, sv);
 }
 #endif
 
@@ -7413,14 +6903,12 @@ XS_unpack_UA_ReadAnnotationDataDetails(SV *in)
 static void
 table_pack_UA_ReadAnnotationDataDetails(SV *sv, void *p)
 {
-	UA_ReadAnnotationDataDetails *data = p;
-	XS_pack_UA_ReadAnnotationDataDetails(sv, *data);
+	pack_UA_ReadAnnotationDataDetails(sv, p);
 }
 static void
 table_unpack_UA_ReadAnnotationDataDetails(SV *sv, void *p)
 {
-	UA_ReadAnnotationDataDetails *data = p;
-	*data = XS_unpack_UA_ReadAnnotationDataDetails(sv);
+	unpack_UA_ReadAnnotationDataDetails(p, sv);
 }
 #endif
 
@@ -7442,14 +6930,12 @@ XS_unpack_UA_ReadAtTimeDetails(SV *in)
 static void
 table_pack_UA_ReadAtTimeDetails(SV *sv, void *p)
 {
-	UA_ReadAtTimeDetails *data = p;
-	XS_pack_UA_ReadAtTimeDetails(sv, *data);
+	pack_UA_ReadAtTimeDetails(sv, p);
 }
 static void
 table_unpack_UA_ReadAtTimeDetails(SV *sv, void *p)
 {
-	UA_ReadAtTimeDetails *data = p;
-	*data = XS_unpack_UA_ReadAtTimeDetails(sv);
+	unpack_UA_ReadAtTimeDetails(p, sv);
 }
 #endif
 
@@ -7471,14 +6957,12 @@ XS_unpack_UA_ReadEventDetails(SV *in)
 static void
 table_pack_UA_ReadEventDetails(SV *sv, void *p)
 {
-	UA_ReadEventDetails *data = p;
-	XS_pack_UA_ReadEventDetails(sv, *data);
+	pack_UA_ReadEventDetails(sv, p);
 }
 static void
 table_unpack_UA_ReadEventDetails(SV *sv, void *p)
 {
-	UA_ReadEventDetails *data = p;
-	*data = XS_unpack_UA_ReadEventDetails(sv);
+	unpack_UA_ReadEventDetails(p, sv);
 }
 #endif
 
@@ -7500,14 +6984,12 @@ XS_unpack_UA_ReadProcessedDetails(SV *in)
 static void
 table_pack_UA_ReadProcessedDetails(SV *sv, void *p)
 {
-	UA_ReadProcessedDetails *data = p;
-	XS_pack_UA_ReadProcessedDetails(sv, *data);
+	pack_UA_ReadProcessedDetails(sv, p);
 }
 static void
 table_unpack_UA_ReadProcessedDetails(SV *sv, void *p)
 {
-	UA_ReadProcessedDetails *data = p;
-	*data = XS_unpack_UA_ReadProcessedDetails(sv);
+	unpack_UA_ReadProcessedDetails(p, sv);
 }
 #endif
 
@@ -7529,14 +7011,12 @@ XS_unpack_UA_ReadRawModifiedDetails(SV *in)
 static void
 table_pack_UA_ReadRawModifiedDetails(SV *sv, void *p)
 {
-	UA_ReadRawModifiedDetails *data = p;
-	XS_pack_UA_ReadRawModifiedDetails(sv, *data);
+	pack_UA_ReadRawModifiedDetails(sv, p);
 }
 static void
 table_unpack_UA_ReadRawModifiedDetails(SV *sv, void *p)
 {
-	UA_ReadRawModifiedDetails *data = p;
-	*data = XS_unpack_UA_ReadRawModifiedDetails(sv);
+	unpack_UA_ReadRawModifiedDetails(p, sv);
 }
 #endif
 
@@ -7558,14 +7038,12 @@ XS_unpack_UA_ReadRequest(SV *in)
 static void
 table_pack_UA_ReadRequest(SV *sv, void *p)
 {
-	UA_ReadRequest *data = p;
-	XS_pack_UA_ReadRequest(sv, *data);
+	pack_UA_ReadRequest(sv, p);
 }
 static void
 table_unpack_UA_ReadRequest(SV *sv, void *p)
 {
-	UA_ReadRequest *data = p;
-	*data = XS_unpack_UA_ReadRequest(sv);
+	unpack_UA_ReadRequest(p, sv);
 }
 #endif
 
@@ -7587,14 +7065,12 @@ XS_unpack_UA_ReadResponse(SV *in)
 static void
 table_pack_UA_ReadResponse(SV *sv, void *p)
 {
-	UA_ReadResponse *data = p;
-	XS_pack_UA_ReadResponse(sv, *data);
+	pack_UA_ReadResponse(sv, p);
 }
 static void
 table_unpack_UA_ReadResponse(SV *sv, void *p)
 {
-	UA_ReadResponse *data = p;
-	*data = XS_unpack_UA_ReadResponse(sv);
+	unpack_UA_ReadResponse(p, sv);
 }
 #endif
 
@@ -7616,14 +7092,12 @@ XS_unpack_UA_ReadValueId(SV *in)
 static void
 table_pack_UA_ReadValueId(SV *sv, void *p)
 {
-	UA_ReadValueId *data = p;
-	XS_pack_UA_ReadValueId(sv, *data);
+	pack_UA_ReadValueId(sv, p);
 }
 static void
 table_unpack_UA_ReadValueId(SV *sv, void *p)
 {
-	UA_ReadValueId *data = p;
-	*data = XS_unpack_UA_ReadValueId(sv);
+	unpack_UA_ReadValueId(p, sv);
 }
 #endif
 
@@ -7645,14 +7119,12 @@ XS_unpack_UA_ReaderGroupDataType(SV *in)
 static void
 table_pack_UA_ReaderGroupDataType(SV *sv, void *p)
 {
-	UA_ReaderGroupDataType *data = p;
-	XS_pack_UA_ReaderGroupDataType(sv, *data);
+	pack_UA_ReaderGroupDataType(sv, p);
 }
 static void
 table_unpack_UA_ReaderGroupDataType(SV *sv, void *p)
 {
-	UA_ReaderGroupDataType *data = p;
-	*data = XS_unpack_UA_ReaderGroupDataType(sv);
+	unpack_UA_ReaderGroupDataType(p, sv);
 }
 #endif
 
@@ -7674,14 +7146,12 @@ XS_unpack_UA_ReaderGroupMessageDataType(SV *in)
 static void
 table_pack_UA_ReaderGroupMessageDataType(SV *sv, void *p)
 {
-	UA_ReaderGroupMessageDataType *data = p;
-	XS_pack_UA_ReaderGroupMessageDataType(sv, *data);
+	pack_UA_ReaderGroupMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_ReaderGroupMessageDataType(SV *sv, void *p)
 {
-	UA_ReaderGroupMessageDataType *data = p;
-	*data = XS_unpack_UA_ReaderGroupMessageDataType(sv);
+	unpack_UA_ReaderGroupMessageDataType(p, sv);
 }
 #endif
 
@@ -7703,14 +7173,12 @@ XS_unpack_UA_ReaderGroupTransportDataType(SV *in)
 static void
 table_pack_UA_ReaderGroupTransportDataType(SV *sv, void *p)
 {
-	UA_ReaderGroupTransportDataType *data = p;
-	XS_pack_UA_ReaderGroupTransportDataType(sv, *data);
+	pack_UA_ReaderGroupTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_ReaderGroupTransportDataType(SV *sv, void *p)
 {
-	UA_ReaderGroupTransportDataType *data = p;
-	*data = XS_unpack_UA_ReaderGroupTransportDataType(sv);
+	unpack_UA_ReaderGroupTransportDataType(p, sv);
 }
 #endif
 
@@ -7732,14 +7200,12 @@ XS_unpack_UA_RedundancySupport(SV *in)
 static void
 table_pack_UA_RedundancySupport(SV *sv, void *p)
 {
-	UA_RedundancySupport *data = p;
-	XS_pack_UA_RedundancySupport(sv, *data);
+	pack_UA_RedundancySupport(sv, p);
 }
 static void
 table_unpack_UA_RedundancySupport(SV *sv, void *p)
 {
-	UA_RedundancySupport *data = p;
-	*data = XS_unpack_UA_RedundancySupport(sv);
+	unpack_UA_RedundancySupport(p, sv);
 }
 #endif
 
@@ -7761,14 +7227,12 @@ XS_unpack_UA_RedundantServerDataType(SV *in)
 static void
 table_pack_UA_RedundantServerDataType(SV *sv, void *p)
 {
-	UA_RedundantServerDataType *data = p;
-	XS_pack_UA_RedundantServerDataType(sv, *data);
+	pack_UA_RedundantServerDataType(sv, p);
 }
 static void
 table_unpack_UA_RedundantServerDataType(SV *sv, void *p)
 {
-	UA_RedundantServerDataType *data = p;
-	*data = XS_unpack_UA_RedundantServerDataType(sv);
+	unpack_UA_RedundantServerDataType(p, sv);
 }
 #endif
 
@@ -7790,14 +7254,12 @@ XS_unpack_UA_ReferenceDescription(SV *in)
 static void
 table_pack_UA_ReferenceDescription(SV *sv, void *p)
 {
-	UA_ReferenceDescription *data = p;
-	XS_pack_UA_ReferenceDescription(sv, *data);
+	pack_UA_ReferenceDescription(sv, p);
 }
 static void
 table_unpack_UA_ReferenceDescription(SV *sv, void *p)
 {
-	UA_ReferenceDescription *data = p;
-	*data = XS_unpack_UA_ReferenceDescription(sv);
+	unpack_UA_ReferenceDescription(p, sv);
 }
 #endif
 
@@ -7819,14 +7281,12 @@ XS_unpack_UA_ReferenceNode(SV *in)
 static void
 table_pack_UA_ReferenceNode(SV *sv, void *p)
 {
-	UA_ReferenceNode *data = p;
-	XS_pack_UA_ReferenceNode(sv, *data);
+	pack_UA_ReferenceNode(sv, p);
 }
 static void
 table_unpack_UA_ReferenceNode(SV *sv, void *p)
 {
-	UA_ReferenceNode *data = p;
-	*data = XS_unpack_UA_ReferenceNode(sv);
+	unpack_UA_ReferenceNode(p, sv);
 }
 #endif
 
@@ -7848,14 +7308,12 @@ XS_unpack_UA_ReferenceTypeAttributes(SV *in)
 static void
 table_pack_UA_ReferenceTypeAttributes(SV *sv, void *p)
 {
-	UA_ReferenceTypeAttributes *data = p;
-	XS_pack_UA_ReferenceTypeAttributes(sv, *data);
+	pack_UA_ReferenceTypeAttributes(sv, p);
 }
 static void
 table_unpack_UA_ReferenceTypeAttributes(SV *sv, void *p)
 {
-	UA_ReferenceTypeAttributes *data = p;
-	*data = XS_unpack_UA_ReferenceTypeAttributes(sv);
+	unpack_UA_ReferenceTypeAttributes(p, sv);
 }
 #endif
 
@@ -7877,14 +7335,12 @@ XS_unpack_UA_RegisterNodesRequest(SV *in)
 static void
 table_pack_UA_RegisterNodesRequest(SV *sv, void *p)
 {
-	UA_RegisterNodesRequest *data = p;
-	XS_pack_UA_RegisterNodesRequest(sv, *data);
+	pack_UA_RegisterNodesRequest(sv, p);
 }
 static void
 table_unpack_UA_RegisterNodesRequest(SV *sv, void *p)
 {
-	UA_RegisterNodesRequest *data = p;
-	*data = XS_unpack_UA_RegisterNodesRequest(sv);
+	unpack_UA_RegisterNodesRequest(p, sv);
 }
 #endif
 
@@ -7906,14 +7362,12 @@ XS_unpack_UA_RegisterNodesResponse(SV *in)
 static void
 table_pack_UA_RegisterNodesResponse(SV *sv, void *p)
 {
-	UA_RegisterNodesResponse *data = p;
-	XS_pack_UA_RegisterNodesResponse(sv, *data);
+	pack_UA_RegisterNodesResponse(sv, p);
 }
 static void
 table_unpack_UA_RegisterNodesResponse(SV *sv, void *p)
 {
-	UA_RegisterNodesResponse *data = p;
-	*data = XS_unpack_UA_RegisterNodesResponse(sv);
+	unpack_UA_RegisterNodesResponse(p, sv);
 }
 #endif
 
@@ -7935,14 +7389,12 @@ XS_unpack_UA_RegisterServer2Request(SV *in)
 static void
 table_pack_UA_RegisterServer2Request(SV *sv, void *p)
 {
-	UA_RegisterServer2Request *data = p;
-	XS_pack_UA_RegisterServer2Request(sv, *data);
+	pack_UA_RegisterServer2Request(sv, p);
 }
 static void
 table_unpack_UA_RegisterServer2Request(SV *sv, void *p)
 {
-	UA_RegisterServer2Request *data = p;
-	*data = XS_unpack_UA_RegisterServer2Request(sv);
+	unpack_UA_RegisterServer2Request(p, sv);
 }
 #endif
 
@@ -7964,14 +7416,12 @@ XS_unpack_UA_RegisterServer2Response(SV *in)
 static void
 table_pack_UA_RegisterServer2Response(SV *sv, void *p)
 {
-	UA_RegisterServer2Response *data = p;
-	XS_pack_UA_RegisterServer2Response(sv, *data);
+	pack_UA_RegisterServer2Response(sv, p);
 }
 static void
 table_unpack_UA_RegisterServer2Response(SV *sv, void *p)
 {
-	UA_RegisterServer2Response *data = p;
-	*data = XS_unpack_UA_RegisterServer2Response(sv);
+	unpack_UA_RegisterServer2Response(p, sv);
 }
 #endif
 
@@ -7993,14 +7443,12 @@ XS_unpack_UA_RegisterServerRequest(SV *in)
 static void
 table_pack_UA_RegisterServerRequest(SV *sv, void *p)
 {
-	UA_RegisterServerRequest *data = p;
-	XS_pack_UA_RegisterServerRequest(sv, *data);
+	pack_UA_RegisterServerRequest(sv, p);
 }
 static void
 table_unpack_UA_RegisterServerRequest(SV *sv, void *p)
 {
-	UA_RegisterServerRequest *data = p;
-	*data = XS_unpack_UA_RegisterServerRequest(sv);
+	unpack_UA_RegisterServerRequest(p, sv);
 }
 #endif
 
@@ -8022,14 +7470,12 @@ XS_unpack_UA_RegisterServerResponse(SV *in)
 static void
 table_pack_UA_RegisterServerResponse(SV *sv, void *p)
 {
-	UA_RegisterServerResponse *data = p;
-	XS_pack_UA_RegisterServerResponse(sv, *data);
+	pack_UA_RegisterServerResponse(sv, p);
 }
 static void
 table_unpack_UA_RegisterServerResponse(SV *sv, void *p)
 {
-	UA_RegisterServerResponse *data = p;
-	*data = XS_unpack_UA_RegisterServerResponse(sv);
+	unpack_UA_RegisterServerResponse(p, sv);
 }
 #endif
 
@@ -8051,14 +7497,12 @@ XS_unpack_UA_RegisteredServer(SV *in)
 static void
 table_pack_UA_RegisteredServer(SV *sv, void *p)
 {
-	UA_RegisteredServer *data = p;
-	XS_pack_UA_RegisteredServer(sv, *data);
+	pack_UA_RegisteredServer(sv, p);
 }
 static void
 table_unpack_UA_RegisteredServer(SV *sv, void *p)
 {
-	UA_RegisteredServer *data = p;
-	*data = XS_unpack_UA_RegisteredServer(sv);
+	unpack_UA_RegisteredServer(p, sv);
 }
 #endif
 
@@ -8080,14 +7524,12 @@ XS_unpack_UA_RelativePath(SV *in)
 static void
 table_pack_UA_RelativePath(SV *sv, void *p)
 {
-	UA_RelativePath *data = p;
-	XS_pack_UA_RelativePath(sv, *data);
+	pack_UA_RelativePath(sv, p);
 }
 static void
 table_unpack_UA_RelativePath(SV *sv, void *p)
 {
-	UA_RelativePath *data = p;
-	*data = XS_unpack_UA_RelativePath(sv);
+	unpack_UA_RelativePath(p, sv);
 }
 #endif
 
@@ -8109,14 +7551,12 @@ XS_unpack_UA_RelativePathElement(SV *in)
 static void
 table_pack_UA_RelativePathElement(SV *sv, void *p)
 {
-	UA_RelativePathElement *data = p;
-	XS_pack_UA_RelativePathElement(sv, *data);
+	pack_UA_RelativePathElement(sv, p);
 }
 static void
 table_unpack_UA_RelativePathElement(SV *sv, void *p)
 {
-	UA_RelativePathElement *data = p;
-	*data = XS_unpack_UA_RelativePathElement(sv);
+	unpack_UA_RelativePathElement(p, sv);
 }
 #endif
 
@@ -8138,14 +7578,12 @@ XS_unpack_UA_RepublishRequest(SV *in)
 static void
 table_pack_UA_RepublishRequest(SV *sv, void *p)
 {
-	UA_RepublishRequest *data = p;
-	XS_pack_UA_RepublishRequest(sv, *data);
+	pack_UA_RepublishRequest(sv, p);
 }
 static void
 table_unpack_UA_RepublishRequest(SV *sv, void *p)
 {
-	UA_RepublishRequest *data = p;
-	*data = XS_unpack_UA_RepublishRequest(sv);
+	unpack_UA_RepublishRequest(p, sv);
 }
 #endif
 
@@ -8167,14 +7605,12 @@ XS_unpack_UA_RepublishResponse(SV *in)
 static void
 table_pack_UA_RepublishResponse(SV *sv, void *p)
 {
-	UA_RepublishResponse *data = p;
-	XS_pack_UA_RepublishResponse(sv, *data);
+	pack_UA_RepublishResponse(sv, p);
 }
 static void
 table_unpack_UA_RepublishResponse(SV *sv, void *p)
 {
-	UA_RepublishResponse *data = p;
-	*data = XS_unpack_UA_RepublishResponse(sv);
+	unpack_UA_RepublishResponse(p, sv);
 }
 #endif
 
@@ -8196,14 +7632,12 @@ XS_unpack_UA_RequestHeader(SV *in)
 static void
 table_pack_UA_RequestHeader(SV *sv, void *p)
 {
-	UA_RequestHeader *data = p;
-	XS_pack_UA_RequestHeader(sv, *data);
+	pack_UA_RequestHeader(sv, p);
 }
 static void
 table_unpack_UA_RequestHeader(SV *sv, void *p)
 {
-	UA_RequestHeader *data = p;
-	*data = XS_unpack_UA_RequestHeader(sv);
+	unpack_UA_RequestHeader(p, sv);
 }
 #endif
 
@@ -8225,14 +7659,12 @@ XS_unpack_UA_ResponseHeader(SV *in)
 static void
 table_pack_UA_ResponseHeader(SV *sv, void *p)
 {
-	UA_ResponseHeader *data = p;
-	XS_pack_UA_ResponseHeader(sv, *data);
+	pack_UA_ResponseHeader(sv, p);
 }
 static void
 table_unpack_UA_ResponseHeader(SV *sv, void *p)
 {
-	UA_ResponseHeader *data = p;
-	*data = XS_unpack_UA_ResponseHeader(sv);
+	unpack_UA_ResponseHeader(p, sv);
 }
 #endif
 
@@ -8254,14 +7686,12 @@ XS_unpack_UA_RolePermissionType(SV *in)
 static void
 table_pack_UA_RolePermissionType(SV *sv, void *p)
 {
-	UA_RolePermissionType *data = p;
-	XS_pack_UA_RolePermissionType(sv, *data);
+	pack_UA_RolePermissionType(sv, p);
 }
 static void
 table_unpack_UA_RolePermissionType(SV *sv, void *p)
 {
-	UA_RolePermissionType *data = p;
-	*data = XS_unpack_UA_RolePermissionType(sv);
+	unpack_UA_RolePermissionType(p, sv);
 }
 #endif
 
@@ -8283,14 +7713,12 @@ XS_unpack_UA_RsaEncryptedSecret(SV *in)
 static void
 table_pack_UA_RsaEncryptedSecret(SV *sv, void *p)
 {
-	UA_RsaEncryptedSecret *data = p;
-	XS_pack_UA_RsaEncryptedSecret(sv, *data);
+	pack_UA_RsaEncryptedSecret(sv, p);
 }
 static void
 table_unpack_UA_RsaEncryptedSecret(SV *sv, void *p)
 {
-	UA_RsaEncryptedSecret *data = p;
-	*data = XS_unpack_UA_RsaEncryptedSecret(sv);
+	unpack_UA_RsaEncryptedSecret(p, sv);
 }
 #endif
 
@@ -8312,14 +7740,12 @@ XS_unpack_UA_SByte(SV *in)
 static void
 table_pack_UA_SByte(SV *sv, void *p)
 {
-	UA_SByte *data = p;
-	XS_pack_UA_SByte(sv, *data);
+	pack_UA_SByte(sv, p);
 }
 static void
 table_unpack_UA_SByte(SV *sv, void *p)
 {
-	UA_SByte *data = p;
-	*data = XS_unpack_UA_SByte(sv);
+	unpack_UA_SByte(p, sv);
 }
 #endif
 
@@ -8341,14 +7767,12 @@ XS_unpack_UA_SamplingIntervalDiagnosticsDataType(SV *in)
 static void
 table_pack_UA_SamplingIntervalDiagnosticsDataType(SV *sv, void *p)
 {
-	UA_SamplingIntervalDiagnosticsDataType *data = p;
-	XS_pack_UA_SamplingIntervalDiagnosticsDataType(sv, *data);
+	pack_UA_SamplingIntervalDiagnosticsDataType(sv, p);
 }
 static void
 table_unpack_UA_SamplingIntervalDiagnosticsDataType(SV *sv, void *p)
 {
-	UA_SamplingIntervalDiagnosticsDataType *data = p;
-	*data = XS_unpack_UA_SamplingIntervalDiagnosticsDataType(sv);
+	unpack_UA_SamplingIntervalDiagnosticsDataType(p, sv);
 }
 #endif
 
@@ -8370,14 +7794,12 @@ XS_unpack_UA_SecurityTokenRequestType(SV *in)
 static void
 table_pack_UA_SecurityTokenRequestType(SV *sv, void *p)
 {
-	UA_SecurityTokenRequestType *data = p;
-	XS_pack_UA_SecurityTokenRequestType(sv, *data);
+	pack_UA_SecurityTokenRequestType(sv, p);
 }
 static void
 table_unpack_UA_SecurityTokenRequestType(SV *sv, void *p)
 {
-	UA_SecurityTokenRequestType *data = p;
-	*data = XS_unpack_UA_SecurityTokenRequestType(sv);
+	unpack_UA_SecurityTokenRequestType(p, sv);
 }
 #endif
 
@@ -8399,14 +7821,12 @@ XS_unpack_UA_SemanticChangeStructureDataType(SV *in)
 static void
 table_pack_UA_SemanticChangeStructureDataType(SV *sv, void *p)
 {
-	UA_SemanticChangeStructureDataType *data = p;
-	XS_pack_UA_SemanticChangeStructureDataType(sv, *data);
+	pack_UA_SemanticChangeStructureDataType(sv, p);
 }
 static void
 table_unpack_UA_SemanticChangeStructureDataType(SV *sv, void *p)
 {
-	UA_SemanticChangeStructureDataType *data = p;
-	*data = XS_unpack_UA_SemanticChangeStructureDataType(sv);
+	unpack_UA_SemanticChangeStructureDataType(p, sv);
 }
 #endif
 
@@ -8428,14 +7848,12 @@ XS_unpack_UA_ServerDiagnosticsSummaryDataType(SV *in)
 static void
 table_pack_UA_ServerDiagnosticsSummaryDataType(SV *sv, void *p)
 {
-	UA_ServerDiagnosticsSummaryDataType *data = p;
-	XS_pack_UA_ServerDiagnosticsSummaryDataType(sv, *data);
+	pack_UA_ServerDiagnosticsSummaryDataType(sv, p);
 }
 static void
 table_unpack_UA_ServerDiagnosticsSummaryDataType(SV *sv, void *p)
 {
-	UA_ServerDiagnosticsSummaryDataType *data = p;
-	*data = XS_unpack_UA_ServerDiagnosticsSummaryDataType(sv);
+	unpack_UA_ServerDiagnosticsSummaryDataType(p, sv);
 }
 #endif
 
@@ -8457,14 +7875,12 @@ XS_unpack_UA_ServerOnNetwork(SV *in)
 static void
 table_pack_UA_ServerOnNetwork(SV *sv, void *p)
 {
-	UA_ServerOnNetwork *data = p;
-	XS_pack_UA_ServerOnNetwork(sv, *data);
+	pack_UA_ServerOnNetwork(sv, p);
 }
 static void
 table_unpack_UA_ServerOnNetwork(SV *sv, void *p)
 {
-	UA_ServerOnNetwork *data = p;
-	*data = XS_unpack_UA_ServerOnNetwork(sv);
+	unpack_UA_ServerOnNetwork(p, sv);
 }
 #endif
 
@@ -8486,14 +7902,12 @@ XS_unpack_UA_ServerState(SV *in)
 static void
 table_pack_UA_ServerState(SV *sv, void *p)
 {
-	UA_ServerState *data = p;
-	XS_pack_UA_ServerState(sv, *data);
+	pack_UA_ServerState(sv, p);
 }
 static void
 table_unpack_UA_ServerState(SV *sv, void *p)
 {
-	UA_ServerState *data = p;
-	*data = XS_unpack_UA_ServerState(sv);
+	unpack_UA_ServerState(p, sv);
 }
 #endif
 
@@ -8515,14 +7929,12 @@ XS_unpack_UA_ServerStatusDataType(SV *in)
 static void
 table_pack_UA_ServerStatusDataType(SV *sv, void *p)
 {
-	UA_ServerStatusDataType *data = p;
-	XS_pack_UA_ServerStatusDataType(sv, *data);
+	pack_UA_ServerStatusDataType(sv, p);
 }
 static void
 table_unpack_UA_ServerStatusDataType(SV *sv, void *p)
 {
-	UA_ServerStatusDataType *data = p;
-	*data = XS_unpack_UA_ServerStatusDataType(sv);
+	unpack_UA_ServerStatusDataType(p, sv);
 }
 #endif
 
@@ -8544,14 +7956,12 @@ XS_unpack_UA_ServiceCounterDataType(SV *in)
 static void
 table_pack_UA_ServiceCounterDataType(SV *sv, void *p)
 {
-	UA_ServiceCounterDataType *data = p;
-	XS_pack_UA_ServiceCounterDataType(sv, *data);
+	pack_UA_ServiceCounterDataType(sv, p);
 }
 static void
 table_unpack_UA_ServiceCounterDataType(SV *sv, void *p)
 {
-	UA_ServiceCounterDataType *data = p;
-	*data = XS_unpack_UA_ServiceCounterDataType(sv);
+	unpack_UA_ServiceCounterDataType(p, sv);
 }
 #endif
 
@@ -8573,14 +7983,12 @@ XS_unpack_UA_ServiceFault(SV *in)
 static void
 table_pack_UA_ServiceFault(SV *sv, void *p)
 {
-	UA_ServiceFault *data = p;
-	XS_pack_UA_ServiceFault(sv, *data);
+	pack_UA_ServiceFault(sv, p);
 }
 static void
 table_unpack_UA_ServiceFault(SV *sv, void *p)
 {
-	UA_ServiceFault *data = p;
-	*data = XS_unpack_UA_ServiceFault(sv);
+	unpack_UA_ServiceFault(p, sv);
 }
 #endif
 
@@ -8602,14 +8010,12 @@ XS_unpack_UA_SessionAuthenticationToken(SV *in)
 static void
 table_pack_UA_SessionAuthenticationToken(SV *sv, void *p)
 {
-	UA_SessionAuthenticationToken *data = p;
-	XS_pack_UA_SessionAuthenticationToken(sv, *data);
+	pack_UA_SessionAuthenticationToken(sv, p);
 }
 static void
 table_unpack_UA_SessionAuthenticationToken(SV *sv, void *p)
 {
-	UA_SessionAuthenticationToken *data = p;
-	*data = XS_unpack_UA_SessionAuthenticationToken(sv);
+	unpack_UA_SessionAuthenticationToken(p, sv);
 }
 #endif
 
@@ -8631,14 +8037,12 @@ XS_unpack_UA_SessionDiagnosticsDataType(SV *in)
 static void
 table_pack_UA_SessionDiagnosticsDataType(SV *sv, void *p)
 {
-	UA_SessionDiagnosticsDataType *data = p;
-	XS_pack_UA_SessionDiagnosticsDataType(sv, *data);
+	pack_UA_SessionDiagnosticsDataType(sv, p);
 }
 static void
 table_unpack_UA_SessionDiagnosticsDataType(SV *sv, void *p)
 {
-	UA_SessionDiagnosticsDataType *data = p;
-	*data = XS_unpack_UA_SessionDiagnosticsDataType(sv);
+	unpack_UA_SessionDiagnosticsDataType(p, sv);
 }
 #endif
 
@@ -8660,14 +8064,12 @@ XS_unpack_UA_SessionSecurityDiagnosticsDataType(SV *in)
 static void
 table_pack_UA_SessionSecurityDiagnosticsDataType(SV *sv, void *p)
 {
-	UA_SessionSecurityDiagnosticsDataType *data = p;
-	XS_pack_UA_SessionSecurityDiagnosticsDataType(sv, *data);
+	pack_UA_SessionSecurityDiagnosticsDataType(sv, p);
 }
 static void
 table_unpack_UA_SessionSecurityDiagnosticsDataType(SV *sv, void *p)
 {
-	UA_SessionSecurityDiagnosticsDataType *data = p;
-	*data = XS_unpack_UA_SessionSecurityDiagnosticsDataType(sv);
+	unpack_UA_SessionSecurityDiagnosticsDataType(p, sv);
 }
 #endif
 
@@ -8689,14 +8091,12 @@ XS_unpack_UA_SessionlessInvokeRequestType(SV *in)
 static void
 table_pack_UA_SessionlessInvokeRequestType(SV *sv, void *p)
 {
-	UA_SessionlessInvokeRequestType *data = p;
-	XS_pack_UA_SessionlessInvokeRequestType(sv, *data);
+	pack_UA_SessionlessInvokeRequestType(sv, p);
 }
 static void
 table_unpack_UA_SessionlessInvokeRequestType(SV *sv, void *p)
 {
-	UA_SessionlessInvokeRequestType *data = p;
-	*data = XS_unpack_UA_SessionlessInvokeRequestType(sv);
+	unpack_UA_SessionlessInvokeRequestType(p, sv);
 }
 #endif
 
@@ -8718,14 +8118,12 @@ XS_unpack_UA_SessionlessInvokeResponseType(SV *in)
 static void
 table_pack_UA_SessionlessInvokeResponseType(SV *sv, void *p)
 {
-	UA_SessionlessInvokeResponseType *data = p;
-	XS_pack_UA_SessionlessInvokeResponseType(sv, *data);
+	pack_UA_SessionlessInvokeResponseType(sv, p);
 }
 static void
 table_unpack_UA_SessionlessInvokeResponseType(SV *sv, void *p)
 {
-	UA_SessionlessInvokeResponseType *data = p;
-	*data = XS_unpack_UA_SessionlessInvokeResponseType(sv);
+	unpack_UA_SessionlessInvokeResponseType(p, sv);
 }
 #endif
 
@@ -8747,14 +8145,12 @@ XS_unpack_UA_SetMonitoringModeRequest(SV *in)
 static void
 table_pack_UA_SetMonitoringModeRequest(SV *sv, void *p)
 {
-	UA_SetMonitoringModeRequest *data = p;
-	XS_pack_UA_SetMonitoringModeRequest(sv, *data);
+	pack_UA_SetMonitoringModeRequest(sv, p);
 }
 static void
 table_unpack_UA_SetMonitoringModeRequest(SV *sv, void *p)
 {
-	UA_SetMonitoringModeRequest *data = p;
-	*data = XS_unpack_UA_SetMonitoringModeRequest(sv);
+	unpack_UA_SetMonitoringModeRequest(p, sv);
 }
 #endif
 
@@ -8776,14 +8172,12 @@ XS_unpack_UA_SetMonitoringModeResponse(SV *in)
 static void
 table_pack_UA_SetMonitoringModeResponse(SV *sv, void *p)
 {
-	UA_SetMonitoringModeResponse *data = p;
-	XS_pack_UA_SetMonitoringModeResponse(sv, *data);
+	pack_UA_SetMonitoringModeResponse(sv, p);
 }
 static void
 table_unpack_UA_SetMonitoringModeResponse(SV *sv, void *p)
 {
-	UA_SetMonitoringModeResponse *data = p;
-	*data = XS_unpack_UA_SetMonitoringModeResponse(sv);
+	unpack_UA_SetMonitoringModeResponse(p, sv);
 }
 #endif
 
@@ -8805,14 +8199,12 @@ XS_unpack_UA_SetPublishingModeRequest(SV *in)
 static void
 table_pack_UA_SetPublishingModeRequest(SV *sv, void *p)
 {
-	UA_SetPublishingModeRequest *data = p;
-	XS_pack_UA_SetPublishingModeRequest(sv, *data);
+	pack_UA_SetPublishingModeRequest(sv, p);
 }
 static void
 table_unpack_UA_SetPublishingModeRequest(SV *sv, void *p)
 {
-	UA_SetPublishingModeRequest *data = p;
-	*data = XS_unpack_UA_SetPublishingModeRequest(sv);
+	unpack_UA_SetPublishingModeRequest(p, sv);
 }
 #endif
 
@@ -8834,14 +8226,12 @@ XS_unpack_UA_SetPublishingModeResponse(SV *in)
 static void
 table_pack_UA_SetPublishingModeResponse(SV *sv, void *p)
 {
-	UA_SetPublishingModeResponse *data = p;
-	XS_pack_UA_SetPublishingModeResponse(sv, *data);
+	pack_UA_SetPublishingModeResponse(sv, p);
 }
 static void
 table_unpack_UA_SetPublishingModeResponse(SV *sv, void *p)
 {
-	UA_SetPublishingModeResponse *data = p;
-	*data = XS_unpack_UA_SetPublishingModeResponse(sv);
+	unpack_UA_SetPublishingModeResponse(p, sv);
 }
 #endif
 
@@ -8863,14 +8253,12 @@ XS_unpack_UA_SetTriggeringRequest(SV *in)
 static void
 table_pack_UA_SetTriggeringRequest(SV *sv, void *p)
 {
-	UA_SetTriggeringRequest *data = p;
-	XS_pack_UA_SetTriggeringRequest(sv, *data);
+	pack_UA_SetTriggeringRequest(sv, p);
 }
 static void
 table_unpack_UA_SetTriggeringRequest(SV *sv, void *p)
 {
-	UA_SetTriggeringRequest *data = p;
-	*data = XS_unpack_UA_SetTriggeringRequest(sv);
+	unpack_UA_SetTriggeringRequest(p, sv);
 }
 #endif
 
@@ -8892,14 +8280,12 @@ XS_unpack_UA_SetTriggeringResponse(SV *in)
 static void
 table_pack_UA_SetTriggeringResponse(SV *sv, void *p)
 {
-	UA_SetTriggeringResponse *data = p;
-	XS_pack_UA_SetTriggeringResponse(sv, *data);
+	pack_UA_SetTriggeringResponse(sv, p);
 }
 static void
 table_unpack_UA_SetTriggeringResponse(SV *sv, void *p)
 {
-	UA_SetTriggeringResponse *data = p;
-	*data = XS_unpack_UA_SetTriggeringResponse(sv);
+	unpack_UA_SetTriggeringResponse(p, sv);
 }
 #endif
 
@@ -8921,14 +8307,12 @@ XS_unpack_UA_SignatureData(SV *in)
 static void
 table_pack_UA_SignatureData(SV *sv, void *p)
 {
-	UA_SignatureData *data = p;
-	XS_pack_UA_SignatureData(sv, *data);
+	pack_UA_SignatureData(sv, p);
 }
 static void
 table_unpack_UA_SignatureData(SV *sv, void *p)
 {
-	UA_SignatureData *data = p;
-	*data = XS_unpack_UA_SignatureData(sv);
+	unpack_UA_SignatureData(p, sv);
 }
 #endif
 
@@ -8950,14 +8334,12 @@ XS_unpack_UA_SignedSoftwareCertificate(SV *in)
 static void
 table_pack_UA_SignedSoftwareCertificate(SV *sv, void *p)
 {
-	UA_SignedSoftwareCertificate *data = p;
-	XS_pack_UA_SignedSoftwareCertificate(sv, *data);
+	pack_UA_SignedSoftwareCertificate(sv, p);
 }
 static void
 table_unpack_UA_SignedSoftwareCertificate(SV *sv, void *p)
 {
-	UA_SignedSoftwareCertificate *data = p;
-	*data = XS_unpack_UA_SignedSoftwareCertificate(sv);
+	unpack_UA_SignedSoftwareCertificate(p, sv);
 }
 #endif
 
@@ -8979,14 +8361,12 @@ XS_unpack_UA_SimpleAttributeOperand(SV *in)
 static void
 table_pack_UA_SimpleAttributeOperand(SV *sv, void *p)
 {
-	UA_SimpleAttributeOperand *data = p;
-	XS_pack_UA_SimpleAttributeOperand(sv, *data);
+	pack_UA_SimpleAttributeOperand(sv, p);
 }
 static void
 table_unpack_UA_SimpleAttributeOperand(SV *sv, void *p)
 {
-	UA_SimpleAttributeOperand *data = p;
-	*data = XS_unpack_UA_SimpleAttributeOperand(sv);
+	unpack_UA_SimpleAttributeOperand(p, sv);
 }
 #endif
 
@@ -9008,14 +8388,12 @@ XS_unpack_UA_SimpleTypeDescription(SV *in)
 static void
 table_pack_UA_SimpleTypeDescription(SV *sv, void *p)
 {
-	UA_SimpleTypeDescription *data = p;
-	XS_pack_UA_SimpleTypeDescription(sv, *data);
+	pack_UA_SimpleTypeDescription(sv, p);
 }
 static void
 table_unpack_UA_SimpleTypeDescription(SV *sv, void *p)
 {
-	UA_SimpleTypeDescription *data = p;
-	*data = XS_unpack_UA_SimpleTypeDescription(sv);
+	unpack_UA_SimpleTypeDescription(p, sv);
 }
 #endif
 
@@ -9037,14 +8415,12 @@ XS_unpack_UA_StatusChangeNotification(SV *in)
 static void
 table_pack_UA_StatusChangeNotification(SV *sv, void *p)
 {
-	UA_StatusChangeNotification *data = p;
-	XS_pack_UA_StatusChangeNotification(sv, *data);
+	pack_UA_StatusChangeNotification(sv, p);
 }
 static void
 table_unpack_UA_StatusChangeNotification(SV *sv, void *p)
 {
-	UA_StatusChangeNotification *data = p;
-	*data = XS_unpack_UA_StatusChangeNotification(sv);
+	unpack_UA_StatusChangeNotification(p, sv);
 }
 #endif
 
@@ -9066,14 +8442,12 @@ XS_unpack_UA_StatusCode(SV *in)
 static void
 table_pack_UA_StatusCode(SV *sv, void *p)
 {
-	UA_StatusCode *data = p;
-	XS_pack_UA_StatusCode(sv, *data);
+	pack_UA_StatusCode(sv, p);
 }
 static void
 table_unpack_UA_StatusCode(SV *sv, void *p)
 {
-	UA_StatusCode *data = p;
-	*data = XS_unpack_UA_StatusCode(sv);
+	unpack_UA_StatusCode(p, sv);
 }
 #endif
 
@@ -9095,14 +8469,12 @@ XS_unpack_UA_StatusResult(SV *in)
 static void
 table_pack_UA_StatusResult(SV *sv, void *p)
 {
-	UA_StatusResult *data = p;
-	XS_pack_UA_StatusResult(sv, *data);
+	pack_UA_StatusResult(sv, p);
 }
 static void
 table_unpack_UA_StatusResult(SV *sv, void *p)
 {
-	UA_StatusResult *data = p;
-	*data = XS_unpack_UA_StatusResult(sv);
+	unpack_UA_StatusResult(p, sv);
 }
 #endif
 
@@ -9124,14 +8496,12 @@ XS_unpack_UA_String(SV *in)
 static void
 table_pack_UA_String(SV *sv, void *p)
 {
-	UA_String *data = p;
-	XS_pack_UA_String(sv, *data);
+	pack_UA_String(sv, p);
 }
 static void
 table_unpack_UA_String(SV *sv, void *p)
 {
-	UA_String *data = p;
-	*data = XS_unpack_UA_String(sv);
+	unpack_UA_String(p, sv);
 }
 #endif
 
@@ -9153,14 +8523,12 @@ XS_unpack_UA_StructureDefinition(SV *in)
 static void
 table_pack_UA_StructureDefinition(SV *sv, void *p)
 {
-	UA_StructureDefinition *data = p;
-	XS_pack_UA_StructureDefinition(sv, *data);
+	pack_UA_StructureDefinition(sv, p);
 }
 static void
 table_unpack_UA_StructureDefinition(SV *sv, void *p)
 {
-	UA_StructureDefinition *data = p;
-	*data = XS_unpack_UA_StructureDefinition(sv);
+	unpack_UA_StructureDefinition(p, sv);
 }
 #endif
 
@@ -9182,14 +8550,12 @@ XS_unpack_UA_StructureDescription(SV *in)
 static void
 table_pack_UA_StructureDescription(SV *sv, void *p)
 {
-	UA_StructureDescription *data = p;
-	XS_pack_UA_StructureDescription(sv, *data);
+	pack_UA_StructureDescription(sv, p);
 }
 static void
 table_unpack_UA_StructureDescription(SV *sv, void *p)
 {
-	UA_StructureDescription *data = p;
-	*data = XS_unpack_UA_StructureDescription(sv);
+	unpack_UA_StructureDescription(p, sv);
 }
 #endif
 
@@ -9211,14 +8577,12 @@ XS_unpack_UA_StructureField(SV *in)
 static void
 table_pack_UA_StructureField(SV *sv, void *p)
 {
-	UA_StructureField *data = p;
-	XS_pack_UA_StructureField(sv, *data);
+	pack_UA_StructureField(sv, p);
 }
 static void
 table_unpack_UA_StructureField(SV *sv, void *p)
 {
-	UA_StructureField *data = p;
-	*data = XS_unpack_UA_StructureField(sv);
+	unpack_UA_StructureField(p, sv);
 }
 #endif
 
@@ -9240,14 +8604,12 @@ XS_unpack_UA_StructureType(SV *in)
 static void
 table_pack_UA_StructureType(SV *sv, void *p)
 {
-	UA_StructureType *data = p;
-	XS_pack_UA_StructureType(sv, *data);
+	pack_UA_StructureType(sv, p);
 }
 static void
 table_unpack_UA_StructureType(SV *sv, void *p)
 {
-	UA_StructureType *data = p;
-	*data = XS_unpack_UA_StructureType(sv);
+	unpack_UA_StructureType(p, sv);
 }
 #endif
 
@@ -9269,14 +8631,12 @@ XS_unpack_UA_SubscribedDataSetDataType(SV *in)
 static void
 table_pack_UA_SubscribedDataSetDataType(SV *sv, void *p)
 {
-	UA_SubscribedDataSetDataType *data = p;
-	XS_pack_UA_SubscribedDataSetDataType(sv, *data);
+	pack_UA_SubscribedDataSetDataType(sv, p);
 }
 static void
 table_unpack_UA_SubscribedDataSetDataType(SV *sv, void *p)
 {
-	UA_SubscribedDataSetDataType *data = p;
-	*data = XS_unpack_UA_SubscribedDataSetDataType(sv);
+	unpack_UA_SubscribedDataSetDataType(p, sv);
 }
 #endif
 
@@ -9298,14 +8658,12 @@ XS_unpack_UA_SubscribedDataSetMirrorDataType(SV *in)
 static void
 table_pack_UA_SubscribedDataSetMirrorDataType(SV *sv, void *p)
 {
-	UA_SubscribedDataSetMirrorDataType *data = p;
-	XS_pack_UA_SubscribedDataSetMirrorDataType(sv, *data);
+	pack_UA_SubscribedDataSetMirrorDataType(sv, p);
 }
 static void
 table_unpack_UA_SubscribedDataSetMirrorDataType(SV *sv, void *p)
 {
-	UA_SubscribedDataSetMirrorDataType *data = p;
-	*data = XS_unpack_UA_SubscribedDataSetMirrorDataType(sv);
+	unpack_UA_SubscribedDataSetMirrorDataType(p, sv);
 }
 #endif
 
@@ -9327,14 +8685,12 @@ XS_unpack_UA_SubscriptionAcknowledgement(SV *in)
 static void
 table_pack_UA_SubscriptionAcknowledgement(SV *sv, void *p)
 {
-	UA_SubscriptionAcknowledgement *data = p;
-	XS_pack_UA_SubscriptionAcknowledgement(sv, *data);
+	pack_UA_SubscriptionAcknowledgement(sv, p);
 }
 static void
 table_unpack_UA_SubscriptionAcknowledgement(SV *sv, void *p)
 {
-	UA_SubscriptionAcknowledgement *data = p;
-	*data = XS_unpack_UA_SubscriptionAcknowledgement(sv);
+	unpack_UA_SubscriptionAcknowledgement(p, sv);
 }
 #endif
 
@@ -9356,14 +8712,12 @@ XS_unpack_UA_SubscriptionDiagnosticsDataType(SV *in)
 static void
 table_pack_UA_SubscriptionDiagnosticsDataType(SV *sv, void *p)
 {
-	UA_SubscriptionDiagnosticsDataType *data = p;
-	XS_pack_UA_SubscriptionDiagnosticsDataType(sv, *data);
+	pack_UA_SubscriptionDiagnosticsDataType(sv, p);
 }
 static void
 table_unpack_UA_SubscriptionDiagnosticsDataType(SV *sv, void *p)
 {
-	UA_SubscriptionDiagnosticsDataType *data = p;
-	*data = XS_unpack_UA_SubscriptionDiagnosticsDataType(sv);
+	unpack_UA_SubscriptionDiagnosticsDataType(p, sv);
 }
 #endif
 
@@ -9385,14 +8739,12 @@ XS_unpack_UA_TargetVariablesDataType(SV *in)
 static void
 table_pack_UA_TargetVariablesDataType(SV *sv, void *p)
 {
-	UA_TargetVariablesDataType *data = p;
-	XS_pack_UA_TargetVariablesDataType(sv, *data);
+	pack_UA_TargetVariablesDataType(sv, p);
 }
 static void
 table_unpack_UA_TargetVariablesDataType(SV *sv, void *p)
 {
-	UA_TargetVariablesDataType *data = p;
-	*data = XS_unpack_UA_TargetVariablesDataType(sv);
+	unpack_UA_TargetVariablesDataType(p, sv);
 }
 #endif
 
@@ -9414,14 +8766,12 @@ XS_unpack_UA_ThreeDCartesianCoordinates(SV *in)
 static void
 table_pack_UA_ThreeDCartesianCoordinates(SV *sv, void *p)
 {
-	UA_ThreeDCartesianCoordinates *data = p;
-	XS_pack_UA_ThreeDCartesianCoordinates(sv, *data);
+	pack_UA_ThreeDCartesianCoordinates(sv, p);
 }
 static void
 table_unpack_UA_ThreeDCartesianCoordinates(SV *sv, void *p)
 {
-	UA_ThreeDCartesianCoordinates *data = p;
-	*data = XS_unpack_UA_ThreeDCartesianCoordinates(sv);
+	unpack_UA_ThreeDCartesianCoordinates(p, sv);
 }
 #endif
 
@@ -9443,14 +8793,12 @@ XS_unpack_UA_ThreeDFrame(SV *in)
 static void
 table_pack_UA_ThreeDFrame(SV *sv, void *p)
 {
-	UA_ThreeDFrame *data = p;
-	XS_pack_UA_ThreeDFrame(sv, *data);
+	pack_UA_ThreeDFrame(sv, p);
 }
 static void
 table_unpack_UA_ThreeDFrame(SV *sv, void *p)
 {
-	UA_ThreeDFrame *data = p;
-	*data = XS_unpack_UA_ThreeDFrame(sv);
+	unpack_UA_ThreeDFrame(p, sv);
 }
 #endif
 
@@ -9472,14 +8820,12 @@ XS_unpack_UA_ThreeDOrientation(SV *in)
 static void
 table_pack_UA_ThreeDOrientation(SV *sv, void *p)
 {
-	UA_ThreeDOrientation *data = p;
-	XS_pack_UA_ThreeDOrientation(sv, *data);
+	pack_UA_ThreeDOrientation(sv, p);
 }
 static void
 table_unpack_UA_ThreeDOrientation(SV *sv, void *p)
 {
-	UA_ThreeDOrientation *data = p;
-	*data = XS_unpack_UA_ThreeDOrientation(sv);
+	unpack_UA_ThreeDOrientation(p, sv);
 }
 #endif
 
@@ -9501,14 +8847,12 @@ XS_unpack_UA_ThreeDVector(SV *in)
 static void
 table_pack_UA_ThreeDVector(SV *sv, void *p)
 {
-	UA_ThreeDVector *data = p;
-	XS_pack_UA_ThreeDVector(sv, *data);
+	pack_UA_ThreeDVector(sv, p);
 }
 static void
 table_unpack_UA_ThreeDVector(SV *sv, void *p)
 {
-	UA_ThreeDVector *data = p;
-	*data = XS_unpack_UA_ThreeDVector(sv);
+	unpack_UA_ThreeDVector(p, sv);
 }
 #endif
 
@@ -9530,14 +8874,12 @@ XS_unpack_UA_Time(SV *in)
 static void
 table_pack_UA_Time(SV *sv, void *p)
 {
-	UA_Time *data = p;
-	XS_pack_UA_Time(sv, *data);
+	pack_UA_Time(sv, p);
 }
 static void
 table_unpack_UA_Time(SV *sv, void *p)
 {
-	UA_Time *data = p;
-	*data = XS_unpack_UA_Time(sv);
+	unpack_UA_Time(p, sv);
 }
 #endif
 
@@ -9559,14 +8901,12 @@ XS_unpack_UA_TimeString(SV *in)
 static void
 table_pack_UA_TimeString(SV *sv, void *p)
 {
-	UA_TimeString *data = p;
-	XS_pack_UA_TimeString(sv, *data);
+	pack_UA_TimeString(sv, p);
 }
 static void
 table_unpack_UA_TimeString(SV *sv, void *p)
 {
-	UA_TimeString *data = p;
-	*data = XS_unpack_UA_TimeString(sv);
+	unpack_UA_TimeString(p, sv);
 }
 #endif
 
@@ -9588,14 +8928,12 @@ XS_unpack_UA_TimeZoneDataType(SV *in)
 static void
 table_pack_UA_TimeZoneDataType(SV *sv, void *p)
 {
-	UA_TimeZoneDataType *data = p;
-	XS_pack_UA_TimeZoneDataType(sv, *data);
+	pack_UA_TimeZoneDataType(sv, p);
 }
 static void
 table_unpack_UA_TimeZoneDataType(SV *sv, void *p)
 {
-	UA_TimeZoneDataType *data = p;
-	*data = XS_unpack_UA_TimeZoneDataType(sv);
+	unpack_UA_TimeZoneDataType(p, sv);
 }
 #endif
 
@@ -9617,14 +8955,12 @@ XS_unpack_UA_TimestampsToReturn(SV *in)
 static void
 table_pack_UA_TimestampsToReturn(SV *sv, void *p)
 {
-	UA_TimestampsToReturn *data = p;
-	XS_pack_UA_TimestampsToReturn(sv, *data);
+	pack_UA_TimestampsToReturn(sv, p);
 }
 static void
 table_unpack_UA_TimestampsToReturn(SV *sv, void *p)
 {
-	UA_TimestampsToReturn *data = p;
-	*data = XS_unpack_UA_TimestampsToReturn(sv);
+	unpack_UA_TimestampsToReturn(p, sv);
 }
 #endif
 
@@ -9646,14 +8982,12 @@ XS_unpack_UA_TransferResult(SV *in)
 static void
 table_pack_UA_TransferResult(SV *sv, void *p)
 {
-	UA_TransferResult *data = p;
-	XS_pack_UA_TransferResult(sv, *data);
+	pack_UA_TransferResult(sv, p);
 }
 static void
 table_unpack_UA_TransferResult(SV *sv, void *p)
 {
-	UA_TransferResult *data = p;
-	*data = XS_unpack_UA_TransferResult(sv);
+	unpack_UA_TransferResult(p, sv);
 }
 #endif
 
@@ -9675,14 +9009,12 @@ XS_unpack_UA_TransferSubscriptionsRequest(SV *in)
 static void
 table_pack_UA_TransferSubscriptionsRequest(SV *sv, void *p)
 {
-	UA_TransferSubscriptionsRequest *data = p;
-	XS_pack_UA_TransferSubscriptionsRequest(sv, *data);
+	pack_UA_TransferSubscriptionsRequest(sv, p);
 }
 static void
 table_unpack_UA_TransferSubscriptionsRequest(SV *sv, void *p)
 {
-	UA_TransferSubscriptionsRequest *data = p;
-	*data = XS_unpack_UA_TransferSubscriptionsRequest(sv);
+	unpack_UA_TransferSubscriptionsRequest(p, sv);
 }
 #endif
 
@@ -9704,14 +9036,12 @@ XS_unpack_UA_TransferSubscriptionsResponse(SV *in)
 static void
 table_pack_UA_TransferSubscriptionsResponse(SV *sv, void *p)
 {
-	UA_TransferSubscriptionsResponse *data = p;
-	XS_pack_UA_TransferSubscriptionsResponse(sv, *data);
+	pack_UA_TransferSubscriptionsResponse(sv, p);
 }
 static void
 table_unpack_UA_TransferSubscriptionsResponse(SV *sv, void *p)
 {
-	UA_TransferSubscriptionsResponse *data = p;
-	*data = XS_unpack_UA_TransferSubscriptionsResponse(sv);
+	unpack_UA_TransferSubscriptionsResponse(p, sv);
 }
 #endif
 
@@ -9733,14 +9063,12 @@ XS_unpack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *in)
 static void
 table_pack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *sv, void *p)
 {
-	UA_TranslateBrowsePathsToNodeIdsRequest *data = p;
-	XS_pack_UA_TranslateBrowsePathsToNodeIdsRequest(sv, *data);
+	pack_UA_TranslateBrowsePathsToNodeIdsRequest(sv, p);
 }
 static void
 table_unpack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *sv, void *p)
 {
-	UA_TranslateBrowsePathsToNodeIdsRequest *data = p;
-	*data = XS_unpack_UA_TranslateBrowsePathsToNodeIdsRequest(sv);
+	unpack_UA_TranslateBrowsePathsToNodeIdsRequest(p, sv);
 }
 #endif
 
@@ -9762,14 +9090,12 @@ XS_unpack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *in)
 static void
 table_pack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *sv, void *p)
 {
-	UA_TranslateBrowsePathsToNodeIdsResponse *data = p;
-	XS_pack_UA_TranslateBrowsePathsToNodeIdsResponse(sv, *data);
+	pack_UA_TranslateBrowsePathsToNodeIdsResponse(sv, p);
 }
 static void
 table_unpack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *sv, void *p)
 {
-	UA_TranslateBrowsePathsToNodeIdsResponse *data = p;
-	*data = XS_unpack_UA_TranslateBrowsePathsToNodeIdsResponse(sv);
+	unpack_UA_TranslateBrowsePathsToNodeIdsResponse(p, sv);
 }
 #endif
 
@@ -9791,14 +9117,12 @@ XS_unpack_UA_TrustListDataType(SV *in)
 static void
 table_pack_UA_TrustListDataType(SV *sv, void *p)
 {
-	UA_TrustListDataType *data = p;
-	XS_pack_UA_TrustListDataType(sv, *data);
+	pack_UA_TrustListDataType(sv, p);
 }
 static void
 table_unpack_UA_TrustListDataType(SV *sv, void *p)
 {
-	UA_TrustListDataType *data = p;
-	*data = XS_unpack_UA_TrustListDataType(sv);
+	unpack_UA_TrustListDataType(p, sv);
 }
 #endif
 
@@ -9820,14 +9144,12 @@ XS_unpack_UA_TrustListMasks(SV *in)
 static void
 table_pack_UA_TrustListMasks(SV *sv, void *p)
 {
-	UA_TrustListMasks *data = p;
-	XS_pack_UA_TrustListMasks(sv, *data);
+	pack_UA_TrustListMasks(sv, p);
 }
 static void
 table_unpack_UA_TrustListMasks(SV *sv, void *p)
 {
-	UA_TrustListMasks *data = p;
-	*data = XS_unpack_UA_TrustListMasks(sv);
+	unpack_UA_TrustListMasks(p, sv);
 }
 #endif
 
@@ -9849,14 +9171,12 @@ XS_unpack_UA_UABinaryFileDataType(SV *in)
 static void
 table_pack_UA_UABinaryFileDataType(SV *sv, void *p)
 {
-	UA_UABinaryFileDataType *data = p;
-	XS_pack_UA_UABinaryFileDataType(sv, *data);
+	pack_UA_UABinaryFileDataType(sv, p);
 }
 static void
 table_unpack_UA_UABinaryFileDataType(SV *sv, void *p)
 {
-	UA_UABinaryFileDataType *data = p;
-	*data = XS_unpack_UA_UABinaryFileDataType(sv);
+	unpack_UA_UABinaryFileDataType(p, sv);
 }
 #endif
 
@@ -9878,14 +9198,12 @@ XS_unpack_UA_UInt16(SV *in)
 static void
 table_pack_UA_UInt16(SV *sv, void *p)
 {
-	UA_UInt16 *data = p;
-	XS_pack_UA_UInt16(sv, *data);
+	pack_UA_UInt16(sv, p);
 }
 static void
 table_unpack_UA_UInt16(SV *sv, void *p)
 {
-	UA_UInt16 *data = p;
-	*data = XS_unpack_UA_UInt16(sv);
+	unpack_UA_UInt16(p, sv);
 }
 #endif
 
@@ -9907,14 +9225,12 @@ XS_unpack_UA_UInt32(SV *in)
 static void
 table_pack_UA_UInt32(SV *sv, void *p)
 {
-	UA_UInt32 *data = p;
-	XS_pack_UA_UInt32(sv, *data);
+	pack_UA_UInt32(sv, p);
 }
 static void
 table_unpack_UA_UInt32(SV *sv, void *p)
 {
-	UA_UInt32 *data = p;
-	*data = XS_unpack_UA_UInt32(sv);
+	unpack_UA_UInt32(p, sv);
 }
 #endif
 
@@ -9936,14 +9252,12 @@ XS_unpack_UA_UInt64(SV *in)
 static void
 table_pack_UA_UInt64(SV *sv, void *p)
 {
-	UA_UInt64 *data = p;
-	XS_pack_UA_UInt64(sv, *data);
+	pack_UA_UInt64(sv, p);
 }
 static void
 table_unpack_UA_UInt64(SV *sv, void *p)
 {
-	UA_UInt64 *data = p;
-	*data = XS_unpack_UA_UInt64(sv);
+	unpack_UA_UInt64(p, sv);
 }
 #endif
 
@@ -9965,14 +9279,12 @@ XS_unpack_UA_UadpDataSetMessageContentMask(SV *in)
 static void
 table_pack_UA_UadpDataSetMessageContentMask(SV *sv, void *p)
 {
-	UA_UadpDataSetMessageContentMask *data = p;
-	XS_pack_UA_UadpDataSetMessageContentMask(sv, *data);
+	pack_UA_UadpDataSetMessageContentMask(sv, p);
 }
 static void
 table_unpack_UA_UadpDataSetMessageContentMask(SV *sv, void *p)
 {
-	UA_UadpDataSetMessageContentMask *data = p;
-	*data = XS_unpack_UA_UadpDataSetMessageContentMask(sv);
+	unpack_UA_UadpDataSetMessageContentMask(p, sv);
 }
 #endif
 
@@ -9994,14 +9306,12 @@ XS_unpack_UA_UadpDataSetReaderMessageDataType(SV *in)
 static void
 table_pack_UA_UadpDataSetReaderMessageDataType(SV *sv, void *p)
 {
-	UA_UadpDataSetReaderMessageDataType *data = p;
-	XS_pack_UA_UadpDataSetReaderMessageDataType(sv, *data);
+	pack_UA_UadpDataSetReaderMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_UadpDataSetReaderMessageDataType(SV *sv, void *p)
 {
-	UA_UadpDataSetReaderMessageDataType *data = p;
-	*data = XS_unpack_UA_UadpDataSetReaderMessageDataType(sv);
+	unpack_UA_UadpDataSetReaderMessageDataType(p, sv);
 }
 #endif
 
@@ -10023,14 +9333,12 @@ XS_unpack_UA_UadpDataSetWriterMessageDataType(SV *in)
 static void
 table_pack_UA_UadpDataSetWriterMessageDataType(SV *sv, void *p)
 {
-	UA_UadpDataSetWriterMessageDataType *data = p;
-	XS_pack_UA_UadpDataSetWriterMessageDataType(sv, *data);
+	pack_UA_UadpDataSetWriterMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_UadpDataSetWriterMessageDataType(SV *sv, void *p)
 {
-	UA_UadpDataSetWriterMessageDataType *data = p;
-	*data = XS_unpack_UA_UadpDataSetWriterMessageDataType(sv);
+	unpack_UA_UadpDataSetWriterMessageDataType(p, sv);
 }
 #endif
 
@@ -10052,14 +9360,12 @@ XS_unpack_UA_UadpNetworkMessageContentMask(SV *in)
 static void
 table_pack_UA_UadpNetworkMessageContentMask(SV *sv, void *p)
 {
-	UA_UadpNetworkMessageContentMask *data = p;
-	XS_pack_UA_UadpNetworkMessageContentMask(sv, *data);
+	pack_UA_UadpNetworkMessageContentMask(sv, p);
 }
 static void
 table_unpack_UA_UadpNetworkMessageContentMask(SV *sv, void *p)
 {
-	UA_UadpNetworkMessageContentMask *data = p;
-	*data = XS_unpack_UA_UadpNetworkMessageContentMask(sv);
+	unpack_UA_UadpNetworkMessageContentMask(p, sv);
 }
 #endif
 
@@ -10081,14 +9387,12 @@ XS_unpack_UA_UadpWriterGroupMessageDataType(SV *in)
 static void
 table_pack_UA_UadpWriterGroupMessageDataType(SV *sv, void *p)
 {
-	UA_UadpWriterGroupMessageDataType *data = p;
-	XS_pack_UA_UadpWriterGroupMessageDataType(sv, *data);
+	pack_UA_UadpWriterGroupMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_UadpWriterGroupMessageDataType(SV *sv, void *p)
 {
-	UA_UadpWriterGroupMessageDataType *data = p;
-	*data = XS_unpack_UA_UadpWriterGroupMessageDataType(sv);
+	unpack_UA_UadpWriterGroupMessageDataType(p, sv);
 }
 #endif
 
@@ -10110,14 +9414,12 @@ XS_unpack_UA_Union(SV *in)
 static void
 table_pack_UA_Union(SV *sv, void *p)
 {
-	UA_Union *data = p;
-	XS_pack_UA_Union(sv, *data);
+	pack_UA_Union(sv, p);
 }
 static void
 table_unpack_UA_Union(SV *sv, void *p)
 {
-	UA_Union *data = p;
-	*data = XS_unpack_UA_Union(sv);
+	unpack_UA_Union(p, sv);
 }
 #endif
 
@@ -10139,14 +9441,12 @@ XS_unpack_UA_UnregisterNodesRequest(SV *in)
 static void
 table_pack_UA_UnregisterNodesRequest(SV *sv, void *p)
 {
-	UA_UnregisterNodesRequest *data = p;
-	XS_pack_UA_UnregisterNodesRequest(sv, *data);
+	pack_UA_UnregisterNodesRequest(sv, p);
 }
 static void
 table_unpack_UA_UnregisterNodesRequest(SV *sv, void *p)
 {
-	UA_UnregisterNodesRequest *data = p;
-	*data = XS_unpack_UA_UnregisterNodesRequest(sv);
+	unpack_UA_UnregisterNodesRequest(p, sv);
 }
 #endif
 
@@ -10168,14 +9468,12 @@ XS_unpack_UA_UnregisterNodesResponse(SV *in)
 static void
 table_pack_UA_UnregisterNodesResponse(SV *sv, void *p)
 {
-	UA_UnregisterNodesResponse *data = p;
-	XS_pack_UA_UnregisterNodesResponse(sv, *data);
+	pack_UA_UnregisterNodesResponse(sv, p);
 }
 static void
 table_unpack_UA_UnregisterNodesResponse(SV *sv, void *p)
 {
-	UA_UnregisterNodesResponse *data = p;
-	*data = XS_unpack_UA_UnregisterNodesResponse(sv);
+	unpack_UA_UnregisterNodesResponse(p, sv);
 }
 #endif
 
@@ -10197,14 +9495,12 @@ XS_unpack_UA_UpdateDataDetails(SV *in)
 static void
 table_pack_UA_UpdateDataDetails(SV *sv, void *p)
 {
-	UA_UpdateDataDetails *data = p;
-	XS_pack_UA_UpdateDataDetails(sv, *data);
+	pack_UA_UpdateDataDetails(sv, p);
 }
 static void
 table_unpack_UA_UpdateDataDetails(SV *sv, void *p)
 {
-	UA_UpdateDataDetails *data = p;
-	*data = XS_unpack_UA_UpdateDataDetails(sv);
+	unpack_UA_UpdateDataDetails(p, sv);
 }
 #endif
 
@@ -10226,14 +9522,12 @@ XS_unpack_UA_UpdateEventDetails(SV *in)
 static void
 table_pack_UA_UpdateEventDetails(SV *sv, void *p)
 {
-	UA_UpdateEventDetails *data = p;
-	XS_pack_UA_UpdateEventDetails(sv, *data);
+	pack_UA_UpdateEventDetails(sv, p);
 }
 static void
 table_unpack_UA_UpdateEventDetails(SV *sv, void *p)
 {
-	UA_UpdateEventDetails *data = p;
-	*data = XS_unpack_UA_UpdateEventDetails(sv);
+	unpack_UA_UpdateEventDetails(p, sv);
 }
 #endif
 
@@ -10255,14 +9549,12 @@ XS_unpack_UA_UpdateStructureDataDetails(SV *in)
 static void
 table_pack_UA_UpdateStructureDataDetails(SV *sv, void *p)
 {
-	UA_UpdateStructureDataDetails *data = p;
-	XS_pack_UA_UpdateStructureDataDetails(sv, *data);
+	pack_UA_UpdateStructureDataDetails(sv, p);
 }
 static void
 table_unpack_UA_UpdateStructureDataDetails(SV *sv, void *p)
 {
-	UA_UpdateStructureDataDetails *data = p;
-	*data = XS_unpack_UA_UpdateStructureDataDetails(sv);
+	unpack_UA_UpdateStructureDataDetails(p, sv);
 }
 #endif
 
@@ -10284,14 +9576,12 @@ XS_unpack_UA_UserIdentityToken(SV *in)
 static void
 table_pack_UA_UserIdentityToken(SV *sv, void *p)
 {
-	UA_UserIdentityToken *data = p;
-	XS_pack_UA_UserIdentityToken(sv, *data);
+	pack_UA_UserIdentityToken(sv, p);
 }
 static void
 table_unpack_UA_UserIdentityToken(SV *sv, void *p)
 {
-	UA_UserIdentityToken *data = p;
-	*data = XS_unpack_UA_UserIdentityToken(sv);
+	unpack_UA_UserIdentityToken(p, sv);
 }
 #endif
 
@@ -10313,14 +9603,12 @@ XS_unpack_UA_UserNameIdentityToken(SV *in)
 static void
 table_pack_UA_UserNameIdentityToken(SV *sv, void *p)
 {
-	UA_UserNameIdentityToken *data = p;
-	XS_pack_UA_UserNameIdentityToken(sv, *data);
+	pack_UA_UserNameIdentityToken(sv, p);
 }
 static void
 table_unpack_UA_UserNameIdentityToken(SV *sv, void *p)
 {
-	UA_UserNameIdentityToken *data = p;
-	*data = XS_unpack_UA_UserNameIdentityToken(sv);
+	unpack_UA_UserNameIdentityToken(p, sv);
 }
 #endif
 
@@ -10342,14 +9630,12 @@ XS_unpack_UA_UserTokenPolicy(SV *in)
 static void
 table_pack_UA_UserTokenPolicy(SV *sv, void *p)
 {
-	UA_UserTokenPolicy *data = p;
-	XS_pack_UA_UserTokenPolicy(sv, *data);
+	pack_UA_UserTokenPolicy(sv, p);
 }
 static void
 table_unpack_UA_UserTokenPolicy(SV *sv, void *p)
 {
-	UA_UserTokenPolicy *data = p;
-	*data = XS_unpack_UA_UserTokenPolicy(sv);
+	unpack_UA_UserTokenPolicy(p, sv);
 }
 #endif
 
@@ -10371,14 +9657,12 @@ XS_unpack_UA_UserTokenType(SV *in)
 static void
 table_pack_UA_UserTokenType(SV *sv, void *p)
 {
-	UA_UserTokenType *data = p;
-	XS_pack_UA_UserTokenType(sv, *data);
+	pack_UA_UserTokenType(sv, p);
 }
 static void
 table_unpack_UA_UserTokenType(SV *sv, void *p)
 {
-	UA_UserTokenType *data = p;
-	*data = XS_unpack_UA_UserTokenType(sv);
+	unpack_UA_UserTokenType(p, sv);
 }
 #endif
 
@@ -10400,14 +9684,12 @@ XS_unpack_UA_UtcTime(SV *in)
 static void
 table_pack_UA_UtcTime(SV *sv, void *p)
 {
-	UA_UtcTime *data = p;
-	XS_pack_UA_UtcTime(sv, *data);
+	pack_UA_UtcTime(sv, p);
 }
 static void
 table_unpack_UA_UtcTime(SV *sv, void *p)
 {
-	UA_UtcTime *data = p;
-	*data = XS_unpack_UA_UtcTime(sv);
+	unpack_UA_UtcTime(p, sv);
 }
 #endif
 
@@ -10429,14 +9711,12 @@ XS_unpack_UA_VariableAttributes(SV *in)
 static void
 table_pack_UA_VariableAttributes(SV *sv, void *p)
 {
-	UA_VariableAttributes *data = p;
-	XS_pack_UA_VariableAttributes(sv, *data);
+	pack_UA_VariableAttributes(sv, p);
 }
 static void
 table_unpack_UA_VariableAttributes(SV *sv, void *p)
 {
-	UA_VariableAttributes *data = p;
-	*data = XS_unpack_UA_VariableAttributes(sv);
+	unpack_UA_VariableAttributes(p, sv);
 }
 #endif
 
@@ -10458,14 +9738,12 @@ XS_unpack_UA_VariableTypeAttributes(SV *in)
 static void
 table_pack_UA_VariableTypeAttributes(SV *sv, void *p)
 {
-	UA_VariableTypeAttributes *data = p;
-	XS_pack_UA_VariableTypeAttributes(sv, *data);
+	pack_UA_VariableTypeAttributes(sv, p);
 }
 static void
 table_unpack_UA_VariableTypeAttributes(SV *sv, void *p)
 {
-	UA_VariableTypeAttributes *data = p;
-	*data = XS_unpack_UA_VariableTypeAttributes(sv);
+	unpack_UA_VariableTypeAttributes(p, sv);
 }
 #endif
 
@@ -10487,14 +9765,12 @@ XS_unpack_UA_Variant(SV *in)
 static void
 table_pack_UA_Variant(SV *sv, void *p)
 {
-	UA_Variant *data = p;
-	XS_pack_UA_Variant(sv, *data);
+	pack_UA_Variant(sv, p);
 }
 static void
 table_unpack_UA_Variant(SV *sv, void *p)
 {
-	UA_Variant *data = p;
-	*data = XS_unpack_UA_Variant(sv);
+	unpack_UA_Variant(p, sv);
 }
 #endif
 
@@ -10516,14 +9792,12 @@ XS_unpack_UA_Vector(SV *in)
 static void
 table_pack_UA_Vector(SV *sv, void *p)
 {
-	UA_Vector *data = p;
-	XS_pack_UA_Vector(sv, *data);
+	pack_UA_Vector(sv, p);
 }
 static void
 table_unpack_UA_Vector(SV *sv, void *p)
 {
-	UA_Vector *data = p;
-	*data = XS_unpack_UA_Vector(sv);
+	unpack_UA_Vector(p, sv);
 }
 #endif
 
@@ -10545,14 +9819,12 @@ XS_unpack_UA_VersionTime(SV *in)
 static void
 table_pack_UA_VersionTime(SV *sv, void *p)
 {
-	UA_VersionTime *data = p;
-	XS_pack_UA_VersionTime(sv, *data);
+	pack_UA_VersionTime(sv, p);
 }
 static void
 table_unpack_UA_VersionTime(SV *sv, void *p)
 {
-	UA_VersionTime *data = p;
-	*data = XS_unpack_UA_VersionTime(sv);
+	unpack_UA_VersionTime(p, sv);
 }
 #endif
 
@@ -10574,14 +9846,12 @@ XS_unpack_UA_ViewAttributes(SV *in)
 static void
 table_pack_UA_ViewAttributes(SV *sv, void *p)
 {
-	UA_ViewAttributes *data = p;
-	XS_pack_UA_ViewAttributes(sv, *data);
+	pack_UA_ViewAttributes(sv, p);
 }
 static void
 table_unpack_UA_ViewAttributes(SV *sv, void *p)
 {
-	UA_ViewAttributes *data = p;
-	*data = XS_unpack_UA_ViewAttributes(sv);
+	unpack_UA_ViewAttributes(p, sv);
 }
 #endif
 
@@ -10603,14 +9873,12 @@ XS_unpack_UA_ViewDescription(SV *in)
 static void
 table_pack_UA_ViewDescription(SV *sv, void *p)
 {
-	UA_ViewDescription *data = p;
-	XS_pack_UA_ViewDescription(sv, *data);
+	pack_UA_ViewDescription(sv, p);
 }
 static void
 table_unpack_UA_ViewDescription(SV *sv, void *p)
 {
-	UA_ViewDescription *data = p;
-	*data = XS_unpack_UA_ViewDescription(sv);
+	unpack_UA_ViewDescription(p, sv);
 }
 #endif
 
@@ -10632,14 +9900,12 @@ XS_unpack_UA_WriteRequest(SV *in)
 static void
 table_pack_UA_WriteRequest(SV *sv, void *p)
 {
-	UA_WriteRequest *data = p;
-	XS_pack_UA_WriteRequest(sv, *data);
+	pack_UA_WriteRequest(sv, p);
 }
 static void
 table_unpack_UA_WriteRequest(SV *sv, void *p)
 {
-	UA_WriteRequest *data = p;
-	*data = XS_unpack_UA_WriteRequest(sv);
+	unpack_UA_WriteRequest(p, sv);
 }
 #endif
 
@@ -10661,14 +9927,12 @@ XS_unpack_UA_WriteResponse(SV *in)
 static void
 table_pack_UA_WriteResponse(SV *sv, void *p)
 {
-	UA_WriteResponse *data = p;
-	XS_pack_UA_WriteResponse(sv, *data);
+	pack_UA_WriteResponse(sv, p);
 }
 static void
 table_unpack_UA_WriteResponse(SV *sv, void *p)
 {
-	UA_WriteResponse *data = p;
-	*data = XS_unpack_UA_WriteResponse(sv);
+	unpack_UA_WriteResponse(p, sv);
 }
 #endif
 
@@ -10690,14 +9954,12 @@ XS_unpack_UA_WriteValue(SV *in)
 static void
 table_pack_UA_WriteValue(SV *sv, void *p)
 {
-	UA_WriteValue *data = p;
-	XS_pack_UA_WriteValue(sv, *data);
+	pack_UA_WriteValue(sv, p);
 }
 static void
 table_unpack_UA_WriteValue(SV *sv, void *p)
 {
-	UA_WriteValue *data = p;
-	*data = XS_unpack_UA_WriteValue(sv);
+	unpack_UA_WriteValue(p, sv);
 }
 #endif
 
@@ -10719,14 +9981,12 @@ XS_unpack_UA_WriterGroupDataType(SV *in)
 static void
 table_pack_UA_WriterGroupDataType(SV *sv, void *p)
 {
-	UA_WriterGroupDataType *data = p;
-	XS_pack_UA_WriterGroupDataType(sv, *data);
+	pack_UA_WriterGroupDataType(sv, p);
 }
 static void
 table_unpack_UA_WriterGroupDataType(SV *sv, void *p)
 {
-	UA_WriterGroupDataType *data = p;
-	*data = XS_unpack_UA_WriterGroupDataType(sv);
+	unpack_UA_WriterGroupDataType(p, sv);
 }
 #endif
 
@@ -10748,14 +10008,12 @@ XS_unpack_UA_WriterGroupMessageDataType(SV *in)
 static void
 table_pack_UA_WriterGroupMessageDataType(SV *sv, void *p)
 {
-	UA_WriterGroupMessageDataType *data = p;
-	XS_pack_UA_WriterGroupMessageDataType(sv, *data);
+	pack_UA_WriterGroupMessageDataType(sv, p);
 }
 static void
 table_unpack_UA_WriterGroupMessageDataType(SV *sv, void *p)
 {
-	UA_WriterGroupMessageDataType *data = p;
-	*data = XS_unpack_UA_WriterGroupMessageDataType(sv);
+	unpack_UA_WriterGroupMessageDataType(p, sv);
 }
 #endif
 
@@ -10777,14 +10035,12 @@ XS_unpack_UA_WriterGroupTransportDataType(SV *in)
 static void
 table_pack_UA_WriterGroupTransportDataType(SV *sv, void *p)
 {
-	UA_WriterGroupTransportDataType *data = p;
-	XS_pack_UA_WriterGroupTransportDataType(sv, *data);
+	pack_UA_WriterGroupTransportDataType(sv, p);
 }
 static void
 table_unpack_UA_WriterGroupTransportDataType(SV *sv, void *p)
 {
-	UA_WriterGroupTransportDataType *data = p;
-	*data = XS_unpack_UA_WriterGroupTransportDataType(sv);
+	unpack_UA_WriterGroupTransportDataType(p, sv);
 }
 #endif
 
@@ -10806,14 +10062,12 @@ XS_unpack_UA_X509IdentityToken(SV *in)
 static void
 table_pack_UA_X509IdentityToken(SV *sv, void *p)
 {
-	UA_X509IdentityToken *data = p;
-	XS_pack_UA_X509IdentityToken(sv, *data);
+	pack_UA_X509IdentityToken(sv, p);
 }
 static void
 table_unpack_UA_X509IdentityToken(SV *sv, void *p)
 {
-	UA_X509IdentityToken *data = p;
-	*data = XS_unpack_UA_X509IdentityToken(sv);
+	unpack_UA_X509IdentityToken(p, sv);
 }
 #endif
 
@@ -10835,14 +10089,12 @@ XS_unpack_UA_XVType(SV *in)
 static void
 table_pack_UA_XVType(SV *sv, void *p)
 {
-	UA_XVType *data = p;
-	XS_pack_UA_XVType(sv, *data);
+	pack_UA_XVType(sv, p);
 }
 static void
 table_unpack_UA_XVType(SV *sv, void *p)
 {
-	UA_XVType *data = p;
-	*data = XS_unpack_UA_XVType(sv);
+	unpack_UA_XVType(p, sv);
 }
 #endif
 
@@ -10864,14 +10116,12 @@ XS_unpack_UA_XmlElement(SV *in)
 static void
 table_pack_UA_XmlElement(SV *sv, void *p)
 {
-	UA_XmlElement *data = p;
-	XS_pack_UA_XmlElement(sv, *data);
+	pack_UA_XmlElement(sv, p);
 }
 static void
 table_unpack_UA_XmlElement(SV *sv, void *p)
 {
-	UA_XmlElement *data = p;
-	*data = XS_unpack_UA_XmlElement(sv);
+	unpack_UA_XmlElement(p, sv);
 }
 #endif
 

--- a/Open62541-packed.xsh
+++ b/Open62541-packed.xsh
@@ -1,7 +1,5 @@
 /* Boolean */
 #ifdef UA_TYPES_BOOLEAN
-static void XS_pack_UA_Boolean(SV *out, UA_Boolean in)  __attribute__((unused));
-static UA_Boolean XS_unpack_UA_Boolean(SV *in)  __attribute__((unused));
 static void pack_UA_Boolean(SV *out, UA_Boolean *in);
 static void unpack_UA_Boolean(UA_Boolean *out, SV *in);
 /* implemented in Open62541.xs */
@@ -9,8 +7,6 @@ static void unpack_UA_Boolean(UA_Boolean *out, SV *in);
 
 /* SByte */
 #ifdef UA_TYPES_SBYTE
-static void XS_pack_UA_SByte(SV *out, UA_SByte in)  __attribute__((unused));
-static UA_SByte XS_unpack_UA_SByte(SV *in)  __attribute__((unused));
 static void pack_UA_SByte(SV *out, UA_SByte *in);
 static void unpack_UA_SByte(UA_SByte *out, SV *in);
 /* implemented in Open62541.xs */
@@ -18,8 +14,6 @@ static void unpack_UA_SByte(UA_SByte *out, SV *in);
 
 /* Byte */
 #ifdef UA_TYPES_BYTE
-static void XS_pack_UA_Byte(SV *out, UA_Byte in)  __attribute__((unused));
-static UA_Byte XS_unpack_UA_Byte(SV *in)  __attribute__((unused));
 static void pack_UA_Byte(SV *out, UA_Byte *in);
 static void unpack_UA_Byte(UA_Byte *out, SV *in);
 /* implemented in Open62541.xs */
@@ -27,8 +21,6 @@ static void unpack_UA_Byte(UA_Byte *out, SV *in);
 
 /* Int16 */
 #ifdef UA_TYPES_INT16
-static void XS_pack_UA_Int16(SV *out, UA_Int16 in)  __attribute__((unused));
-static UA_Int16 XS_unpack_UA_Int16(SV *in)  __attribute__((unused));
 static void pack_UA_Int16(SV *out, UA_Int16 *in);
 static void unpack_UA_Int16(UA_Int16 *out, SV *in);
 /* implemented in Open62541.xs */
@@ -36,8 +28,6 @@ static void unpack_UA_Int16(UA_Int16 *out, SV *in);
 
 /* UInt16 */
 #ifdef UA_TYPES_UINT16
-static void XS_pack_UA_UInt16(SV *out, UA_UInt16 in)  __attribute__((unused));
-static UA_UInt16 XS_unpack_UA_UInt16(SV *in)  __attribute__((unused));
 static void pack_UA_UInt16(SV *out, UA_UInt16 *in);
 static void unpack_UA_UInt16(UA_UInt16 *out, SV *in);
 /* implemented in Open62541.xs */
@@ -45,8 +35,6 @@ static void unpack_UA_UInt16(UA_UInt16 *out, SV *in);
 
 /* Int32 */
 #ifdef UA_TYPES_INT32
-static void XS_pack_UA_Int32(SV *out, UA_Int32 in)  __attribute__((unused));
-static UA_Int32 XS_unpack_UA_Int32(SV *in)  __attribute__((unused));
 static void pack_UA_Int32(SV *out, UA_Int32 *in);
 static void unpack_UA_Int32(UA_Int32 *out, SV *in);
 /* implemented in Open62541.xs */
@@ -54,8 +42,6 @@ static void unpack_UA_Int32(UA_Int32 *out, SV *in);
 
 /* UInt32 */
 #ifdef UA_TYPES_UINT32
-static void XS_pack_UA_UInt32(SV *out, UA_UInt32 in)  __attribute__((unused));
-static UA_UInt32 XS_unpack_UA_UInt32(SV *in)  __attribute__((unused));
 static void pack_UA_UInt32(SV *out, UA_UInt32 *in);
 static void unpack_UA_UInt32(UA_UInt32 *out, SV *in);
 /* implemented in Open62541.xs */
@@ -63,8 +49,6 @@ static void unpack_UA_UInt32(UA_UInt32 *out, SV *in);
 
 /* Int64 */
 #ifdef UA_TYPES_INT64
-static void XS_pack_UA_Int64(SV *out, UA_Int64 in)  __attribute__((unused));
-static UA_Int64 XS_unpack_UA_Int64(SV *in)  __attribute__((unused));
 static void pack_UA_Int64(SV *out, UA_Int64 *in);
 static void unpack_UA_Int64(UA_Int64 *out, SV *in);
 /* implemented in Open62541.xs */
@@ -72,8 +56,6 @@ static void unpack_UA_Int64(UA_Int64 *out, SV *in);
 
 /* UInt64 */
 #ifdef UA_TYPES_UINT64
-static void XS_pack_UA_UInt64(SV *out, UA_UInt64 in)  __attribute__((unused));
-static UA_UInt64 XS_unpack_UA_UInt64(SV *in)  __attribute__((unused));
 static void pack_UA_UInt64(SV *out, UA_UInt64 *in);
 static void unpack_UA_UInt64(UA_UInt64 *out, SV *in);
 /* implemented in Open62541.xs */
@@ -81,8 +63,6 @@ static void unpack_UA_UInt64(UA_UInt64 *out, SV *in);
 
 /* Float */
 #ifdef UA_TYPES_FLOAT
-static void XS_pack_UA_Float(SV *out, UA_Float in)  __attribute__((unused));
-static UA_Float XS_unpack_UA_Float(SV *in)  __attribute__((unused));
 static void pack_UA_Float(SV *out, UA_Float *in);
 static void unpack_UA_Float(UA_Float *out, SV *in);
 /* implemented in Open62541.xs */
@@ -90,8 +70,6 @@ static void unpack_UA_Float(UA_Float *out, SV *in);
 
 /* Double */
 #ifdef UA_TYPES_DOUBLE
-static void XS_pack_UA_Double(SV *out, UA_Double in)  __attribute__((unused));
-static UA_Double XS_unpack_UA_Double(SV *in)  __attribute__((unused));
 static void pack_UA_Double(SV *out, UA_Double *in);
 static void unpack_UA_Double(UA_Double *out, SV *in);
 /* implemented in Open62541.xs */
@@ -99,8 +77,6 @@ static void unpack_UA_Double(UA_Double *out, SV *in);
 
 /* String */
 #ifdef UA_TYPES_STRING
-static void XS_pack_UA_String(SV *out, UA_String in)  __attribute__((unused));
-static UA_String XS_unpack_UA_String(SV *in)  __attribute__((unused));
 static void pack_UA_String(SV *out, UA_String *in);
 static void unpack_UA_String(UA_String *out, SV *in);
 /* implemented in Open62541.xs */
@@ -108,8 +84,6 @@ static void unpack_UA_String(UA_String *out, SV *in);
 
 /* DateTime */
 #ifdef UA_TYPES_DATETIME
-static void XS_pack_UA_DateTime(SV *out, UA_DateTime in)  __attribute__((unused));
-static UA_DateTime XS_unpack_UA_DateTime(SV *in)  __attribute__((unused));
 static void pack_UA_DateTime(SV *out, UA_DateTime *in);
 static void unpack_UA_DateTime(UA_DateTime *out, SV *in);
 /* implemented in Open62541.xs */
@@ -117,8 +91,6 @@ static void unpack_UA_DateTime(UA_DateTime *out, SV *in);
 
 /* Guid */
 #ifdef UA_TYPES_GUID
-static void XS_pack_UA_Guid(SV *out, UA_Guid in)  __attribute__((unused));
-static UA_Guid XS_unpack_UA_Guid(SV *in)  __attribute__((unused));
 static void pack_UA_Guid(SV *out, UA_Guid *in);
 static void unpack_UA_Guid(UA_Guid *out, SV *in);
 /* implemented in Open62541.xs */
@@ -126,8 +98,6 @@ static void unpack_UA_Guid(UA_Guid *out, SV *in);
 
 /* ByteString */
 #ifdef UA_TYPES_BYTESTRING
-static void XS_pack_UA_ByteString(SV *out, UA_ByteString in)  __attribute__((unused));
-static UA_ByteString XS_unpack_UA_ByteString(SV *in)  __attribute__((unused));
 static void pack_UA_ByteString(SV *out, UA_ByteString *in);
 static void unpack_UA_ByteString(UA_ByteString *out, SV *in);
 /* implemented in Open62541.xs */
@@ -135,8 +105,6 @@ static void unpack_UA_ByteString(UA_ByteString *out, SV *in);
 
 /* XmlElement */
 #ifdef UA_TYPES_XMLELEMENT
-static void XS_pack_UA_XmlElement(SV *out, UA_XmlElement in)  __attribute__((unused));
-static UA_XmlElement XS_unpack_UA_XmlElement(SV *in)  __attribute__((unused));
 static void pack_UA_XmlElement(SV *out, UA_XmlElement *in);
 static void unpack_UA_XmlElement(UA_XmlElement *out, SV *in);
 /* implemented in Open62541.xs */
@@ -144,8 +112,6 @@ static void unpack_UA_XmlElement(UA_XmlElement *out, SV *in);
 
 /* NodeId */
 #ifdef UA_TYPES_NODEID
-static void XS_pack_UA_NodeId(SV *out, UA_NodeId in)  __attribute__((unused));
-static UA_NodeId XS_unpack_UA_NodeId(SV *in)  __attribute__((unused));
 static void pack_UA_NodeId(SV *out, UA_NodeId *in);
 static void unpack_UA_NodeId(UA_NodeId *out, SV *in);
 /* implemented in Open62541.xs */
@@ -153,8 +119,6 @@ static void unpack_UA_NodeId(UA_NodeId *out, SV *in);
 
 /* ExpandedNodeId */
 #ifdef UA_TYPES_EXPANDEDNODEID
-static void XS_pack_UA_ExpandedNodeId(SV *out, UA_ExpandedNodeId in)  __attribute__((unused));
-static UA_ExpandedNodeId XS_unpack_UA_ExpandedNodeId(SV *in)  __attribute__((unused));
 static void pack_UA_ExpandedNodeId(SV *out, UA_ExpandedNodeId *in);
 static void unpack_UA_ExpandedNodeId(UA_ExpandedNodeId *out, SV *in);
 /* implemented in Open62541.xs */
@@ -162,8 +126,6 @@ static void unpack_UA_ExpandedNodeId(UA_ExpandedNodeId *out, SV *in);
 
 /* StatusCode */
 #ifdef UA_TYPES_STATUSCODE
-static void XS_pack_UA_StatusCode(SV *out, UA_StatusCode in)  __attribute__((unused));
-static UA_StatusCode XS_unpack_UA_StatusCode(SV *in)  __attribute__((unused));
 static void pack_UA_StatusCode(SV *out, UA_StatusCode *in);
 static void unpack_UA_StatusCode(UA_StatusCode *out, SV *in);
 /* implemented in Open62541.xs */
@@ -171,8 +133,6 @@ static void unpack_UA_StatusCode(UA_StatusCode *out, SV *in);
 
 /* QualifiedName */
 #ifdef UA_TYPES_QUALIFIEDNAME
-static void XS_pack_UA_QualifiedName(SV *out, UA_QualifiedName in)  __attribute__((unused));
-static UA_QualifiedName XS_unpack_UA_QualifiedName(SV *in)  __attribute__((unused));
 static void pack_UA_QualifiedName(SV *out, UA_QualifiedName *in);
 static void unpack_UA_QualifiedName(UA_QualifiedName *out, SV *in);
 /* implemented in Open62541.xs */
@@ -180,8 +140,6 @@ static void unpack_UA_QualifiedName(UA_QualifiedName *out, SV *in);
 
 /* LocalizedText */
 #ifdef UA_TYPES_LOCALIZEDTEXT
-static void XS_pack_UA_LocalizedText(SV *out, UA_LocalizedText in)  __attribute__((unused));
-static UA_LocalizedText XS_unpack_UA_LocalizedText(SV *in)  __attribute__((unused));
 static void pack_UA_LocalizedText(SV *out, UA_LocalizedText *in);
 static void unpack_UA_LocalizedText(UA_LocalizedText *out, SV *in);
 /* implemented in Open62541.xs */
@@ -189,8 +147,6 @@ static void unpack_UA_LocalizedText(UA_LocalizedText *out, SV *in);
 
 /* ExtensionObject */
 #ifdef UA_TYPES_EXTENSIONOBJECT
-static void XS_pack_UA_ExtensionObject(SV *out, UA_ExtensionObject in)  __attribute__((unused));
-static UA_ExtensionObject XS_unpack_UA_ExtensionObject(SV *in)  __attribute__((unused));
 static void pack_UA_ExtensionObject(SV *out, UA_ExtensionObject *in);
 static void unpack_UA_ExtensionObject(UA_ExtensionObject *out, SV *in);
 /* implemented in Open62541.xs */
@@ -198,8 +154,6 @@ static void unpack_UA_ExtensionObject(UA_ExtensionObject *out, SV *in);
 
 /* DataValue */
 #ifdef UA_TYPES_DATAVALUE
-static void XS_pack_UA_DataValue(SV *out, UA_DataValue in)  __attribute__((unused));
-static UA_DataValue XS_unpack_UA_DataValue(SV *in)  __attribute__((unused));
 static void pack_UA_DataValue(SV *out, UA_DataValue *in);
 static void unpack_UA_DataValue(UA_DataValue *out, SV *in);
 /* implemented in Open62541.xs */
@@ -207,8 +161,6 @@ static void unpack_UA_DataValue(UA_DataValue *out, SV *in);
 
 /* Variant */
 #ifdef UA_TYPES_VARIANT
-static void XS_pack_UA_Variant(SV *out, UA_Variant in)  __attribute__((unused));
-static UA_Variant XS_unpack_UA_Variant(SV *in)  __attribute__((unused));
 static void pack_UA_Variant(SV *out, UA_Variant *in);
 static void unpack_UA_Variant(UA_Variant *out, SV *in);
 /* implemented in Open62541.xs */
@@ -216,8 +168,6 @@ static void unpack_UA_Variant(UA_Variant *out, SV *in);
 
 /* DiagnosticInfo */
 #ifdef UA_TYPES_DIAGNOSTICINFO
-static void XS_pack_UA_DiagnosticInfo(SV *out, UA_DiagnosticInfo in)  __attribute__((unused));
-static UA_DiagnosticInfo XS_unpack_UA_DiagnosticInfo(SV *in)  __attribute__((unused));
 static void pack_UA_DiagnosticInfo(SV *out, UA_DiagnosticInfo *in);
 static void unpack_UA_DiagnosticInfo(UA_DiagnosticInfo *out, SV *in);
 /* implemented in Open62541.xs */
@@ -225,8 +175,6 @@ static void unpack_UA_DiagnosticInfo(UA_DiagnosticInfo *out, SV *in);
 
 /* NamingRuleType */
 #ifdef UA_TYPES_NAMINGRULETYPE
-static void XS_pack_UA_NamingRuleType(SV *out, UA_NamingRuleType in)  __attribute__((unused));
-static UA_NamingRuleType XS_unpack_UA_NamingRuleType(SV *in)  __attribute__((unused));
 static void pack_UA_NamingRuleType(SV *out, UA_NamingRuleType *in);
 static void unpack_UA_NamingRuleType(UA_NamingRuleType *out, SV *in);
 
@@ -247,8 +195,6 @@ unpack_UA_NamingRuleType(UA_NamingRuleType *out, SV *in)
 
 /* ImageBMP */
 #ifdef UA_TYPES_IMAGEBMP
-static void XS_pack_UA_ImageBMP(SV *out, UA_ImageBMP in)  __attribute__((unused));
-static UA_ImageBMP XS_unpack_UA_ImageBMP(SV *in)  __attribute__((unused));
 static void pack_UA_ImageBMP(SV *out, UA_ImageBMP *in);
 static void unpack_UA_ImageBMP(UA_ImageBMP *out, SV *in);
 
@@ -256,21 +202,19 @@ static void
 pack_UA_ImageBMP(SV *out, UA_ImageBMP *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_ImageBMP(UA_ImageBMP *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* ImageGIF */
 #ifdef UA_TYPES_IMAGEGIF
-static void XS_pack_UA_ImageGIF(SV *out, UA_ImageGIF in)  __attribute__((unused));
-static UA_ImageGIF XS_unpack_UA_ImageGIF(SV *in)  __attribute__((unused));
 static void pack_UA_ImageGIF(SV *out, UA_ImageGIF *in);
 static void unpack_UA_ImageGIF(UA_ImageGIF *out, SV *in);
 
@@ -278,21 +222,19 @@ static void
 pack_UA_ImageGIF(SV *out, UA_ImageGIF *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_ImageGIF(UA_ImageGIF *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* ImageJPG */
 #ifdef UA_TYPES_IMAGEJPG
-static void XS_pack_UA_ImageJPG(SV *out, UA_ImageJPG in)  __attribute__((unused));
-static UA_ImageJPG XS_unpack_UA_ImageJPG(SV *in)  __attribute__((unused));
 static void pack_UA_ImageJPG(SV *out, UA_ImageJPG *in);
 static void unpack_UA_ImageJPG(UA_ImageJPG *out, SV *in);
 
@@ -300,21 +242,19 @@ static void
 pack_UA_ImageJPG(SV *out, UA_ImageJPG *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_ImageJPG(UA_ImageJPG *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* ImagePNG */
 #ifdef UA_TYPES_IMAGEPNG
-static void XS_pack_UA_ImagePNG(SV *out, UA_ImagePNG in)  __attribute__((unused));
-static UA_ImagePNG XS_unpack_UA_ImagePNG(SV *in)  __attribute__((unused));
 static void pack_UA_ImagePNG(SV *out, UA_ImagePNG *in);
 static void unpack_UA_ImagePNG(UA_ImagePNG *out, SV *in);
 
@@ -322,21 +262,19 @@ static void
 pack_UA_ImagePNG(SV *out, UA_ImagePNG *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_ImagePNG(UA_ImagePNG *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* AudioDataType */
 #ifdef UA_TYPES_AUDIODATATYPE
-static void XS_pack_UA_AudioDataType(SV *out, UA_AudioDataType in)  __attribute__((unused));
-static UA_AudioDataType XS_unpack_UA_AudioDataType(SV *in)  __attribute__((unused));
 static void pack_UA_AudioDataType(SV *out, UA_AudioDataType *in);
 static void unpack_UA_AudioDataType(UA_AudioDataType *out, SV *in);
 
@@ -344,21 +282,19 @@ static void
 pack_UA_AudioDataType(SV *out, UA_AudioDataType *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_AudioDataType(UA_AudioDataType *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* BitFieldMaskDataType */
 #ifdef UA_TYPES_BITFIELDMASKDATATYPE
-static void XS_pack_UA_BitFieldMaskDataType(SV *out, UA_BitFieldMaskDataType in)  __attribute__((unused));
-static UA_BitFieldMaskDataType XS_unpack_UA_BitFieldMaskDataType(SV *in)  __attribute__((unused));
 static void pack_UA_BitFieldMaskDataType(SV *out, UA_BitFieldMaskDataType *in);
 static void unpack_UA_BitFieldMaskDataType(UA_BitFieldMaskDataType *out, SV *in);
 
@@ -366,21 +302,19 @@ static void
 pack_UA_BitFieldMaskDataType(SV *out, UA_BitFieldMaskDataType *in)
 {
 	dTHX;
-	XS_pack_UA_UInt64(out, *in);
+	pack_UA_UInt64(out, in);
 }
 
 static void
 unpack_UA_BitFieldMaskDataType(UA_BitFieldMaskDataType *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_UInt64(in);
+	unpack_UA_UInt64(out, in);
 }
 #endif
 
 /* KeyValuePair */
 #ifdef UA_TYPES_KEYVALUEPAIR
-static void XS_pack_UA_KeyValuePair(SV *out, UA_KeyValuePair in)  __attribute__((unused));
-static UA_KeyValuePair XS_unpack_UA_KeyValuePair(SV *in)  __attribute__((unused));
 static void pack_UA_KeyValuePair(SV *out, UA_KeyValuePair *in);
 static void unpack_UA_KeyValuePair(UA_KeyValuePair *out, SV *in);
 
@@ -389,49 +323,49 @@ pack_UA_KeyValuePair(SV *out, UA_KeyValuePair *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->key);
-	hv_stores(hv, "KeyValuePair_key", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->value);
-	hv_stores(hv, "KeyValuePair_value", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "KeyValuePair_key", sv);
+	pack_UA_QualifiedName(sv, &in->key);
+
+	sv = newSV(0);
+	hv_stores(hv, "KeyValuePair_value", sv);
+	pack_UA_Variant(sv, &in->value);
+
+	return;
 }
 
 static void
 unpack_UA_KeyValuePair(UA_KeyValuePair *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_KeyValuePair_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "KeyValuePair_key", 0);
 	if (svp != NULL)
-		out->key = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->key, *svp);
 
 	svp = hv_fetchs(hv, "KeyValuePair_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->value, *svp);
 
-
+	return;
 }
 #endif
 
 /* RationalNumber */
 #ifdef UA_TYPES_RATIONALNUMBER
-static void XS_pack_UA_RationalNumber(SV *out, UA_RationalNumber in)  __attribute__((unused));
-static UA_RationalNumber XS_unpack_UA_RationalNumber(SV *in)  __attribute__((unused));
 static void pack_UA_RationalNumber(SV *out, UA_RationalNumber *in);
 static void unpack_UA_RationalNumber(UA_RationalNumber *out, SV *in);
 
@@ -440,49 +374,49 @@ pack_UA_RationalNumber(SV *out, UA_RationalNumber *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->numerator);
-	hv_stores(hv, "RationalNumber_numerator", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->denominator);
-	hv_stores(hv, "RationalNumber_denominator", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "RationalNumber_numerator", sv);
+	pack_UA_Int32(sv, &in->numerator);
+
+	sv = newSV(0);
+	hv_stores(hv, "RationalNumber_denominator", sv);
+	pack_UA_UInt32(sv, &in->denominator);
+
+	return;
 }
 
 static void
 unpack_UA_RationalNumber(UA_RationalNumber *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RationalNumber_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RationalNumber_numerator", 0);
 	if (svp != NULL)
-		out->numerator = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->numerator, *svp);
 
 	svp = hv_fetchs(hv, "RationalNumber_denominator", 0);
 	if (svp != NULL)
-		out->denominator = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->denominator, *svp);
 
-
+	return;
 }
 #endif
 
 /* Vector */
 #ifdef UA_TYPES_VECTOR
-static void XS_pack_UA_Vector(SV *out, UA_Vector in)  __attribute__((unused));
-static UA_Vector XS_unpack_UA_Vector(SV *in)  __attribute__((unused));
 static void pack_UA_Vector(SV *out, UA_Vector *in);
 static void unpack_UA_Vector(UA_Vector *out, SV *in);
 
@@ -503,8 +437,6 @@ unpack_UA_Vector(UA_Vector *out, SV *in)
 
 /* ThreeDVector */
 #ifdef UA_TYPES_THREEDVECTOR
-static void XS_pack_UA_ThreeDVector(SV *out, UA_ThreeDVector in)  __attribute__((unused));
-static UA_ThreeDVector XS_unpack_UA_ThreeDVector(SV *in)  __attribute__((unused));
 static void pack_UA_ThreeDVector(SV *out, UA_ThreeDVector *in);
 static void unpack_UA_ThreeDVector(UA_ThreeDVector *out, SV *in);
 
@@ -513,57 +445,57 @@ pack_UA_ThreeDVector(SV *out, UA_ThreeDVector *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->x);
-	hv_stores(hv, "ThreeDVector_x", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->y);
-	hv_stores(hv, "ThreeDVector_y", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->z);
-	hv_stores(hv, "ThreeDVector_z", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDVector_x", sv);
+	pack_UA_Double(sv, &in->x);
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDVector_y", sv);
+	pack_UA_Double(sv, &in->y);
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDVector_z", sv);
+	pack_UA_Double(sv, &in->z);
+
+	return;
 }
 
 static void
 unpack_UA_ThreeDVector(UA_ThreeDVector *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ThreeDVector_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ThreeDVector_x", 0);
 	if (svp != NULL)
-		out->x = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->x, *svp);
 
 	svp = hv_fetchs(hv, "ThreeDVector_y", 0);
 	if (svp != NULL)
-		out->y = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->y, *svp);
 
 	svp = hv_fetchs(hv, "ThreeDVector_z", 0);
 	if (svp != NULL)
-		out->z = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->z, *svp);
 
-
+	return;
 }
 #endif
 
 /* CartesianCoordinates */
 #ifdef UA_TYPES_CARTESIANCOORDINATES
-static void XS_pack_UA_CartesianCoordinates(SV *out, UA_CartesianCoordinates in)  __attribute__((unused));
-static UA_CartesianCoordinates XS_unpack_UA_CartesianCoordinates(SV *in)  __attribute__((unused));
 static void pack_UA_CartesianCoordinates(SV *out, UA_CartesianCoordinates *in);
 static void unpack_UA_CartesianCoordinates(UA_CartesianCoordinates *out, SV *in);
 
@@ -584,8 +516,6 @@ unpack_UA_CartesianCoordinates(UA_CartesianCoordinates *out, SV *in)
 
 /* ThreeDCartesianCoordinates */
 #ifdef UA_TYPES_THREEDCARTESIANCOORDINATES
-static void XS_pack_UA_ThreeDCartesianCoordinates(SV *out, UA_ThreeDCartesianCoordinates in)  __attribute__((unused));
-static UA_ThreeDCartesianCoordinates XS_unpack_UA_ThreeDCartesianCoordinates(SV *in)  __attribute__((unused));
 static void pack_UA_ThreeDCartesianCoordinates(SV *out, UA_ThreeDCartesianCoordinates *in);
 static void unpack_UA_ThreeDCartesianCoordinates(UA_ThreeDCartesianCoordinates *out, SV *in);
 
@@ -594,57 +524,57 @@ pack_UA_ThreeDCartesianCoordinates(SV *out, UA_ThreeDCartesianCoordinates *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->x);
-	hv_stores(hv, "ThreeDCartesianCoordinates_x", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->y);
-	hv_stores(hv, "ThreeDCartesianCoordinates_y", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->z);
-	hv_stores(hv, "ThreeDCartesianCoordinates_z", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDCartesianCoordinates_x", sv);
+	pack_UA_Double(sv, &in->x);
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDCartesianCoordinates_y", sv);
+	pack_UA_Double(sv, &in->y);
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDCartesianCoordinates_z", sv);
+	pack_UA_Double(sv, &in->z);
+
+	return;
 }
 
 static void
 unpack_UA_ThreeDCartesianCoordinates(UA_ThreeDCartesianCoordinates *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ThreeDCartesianCoordinates_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ThreeDCartesianCoordinates_x", 0);
 	if (svp != NULL)
-		out->x = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->x, *svp);
 
 	svp = hv_fetchs(hv, "ThreeDCartesianCoordinates_y", 0);
 	if (svp != NULL)
-		out->y = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->y, *svp);
 
 	svp = hv_fetchs(hv, "ThreeDCartesianCoordinates_z", 0);
 	if (svp != NULL)
-		out->z = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->z, *svp);
 
-
+	return;
 }
 #endif
 
 /* Orientation */
 #ifdef UA_TYPES_ORIENTATION
-static void XS_pack_UA_Orientation(SV *out, UA_Orientation in)  __attribute__((unused));
-static UA_Orientation XS_unpack_UA_Orientation(SV *in)  __attribute__((unused));
 static void pack_UA_Orientation(SV *out, UA_Orientation *in);
 static void unpack_UA_Orientation(UA_Orientation *out, SV *in);
 
@@ -665,8 +595,6 @@ unpack_UA_Orientation(UA_Orientation *out, SV *in)
 
 /* ThreeDOrientation */
 #ifdef UA_TYPES_THREEDORIENTATION
-static void XS_pack_UA_ThreeDOrientation(SV *out, UA_ThreeDOrientation in)  __attribute__((unused));
-static UA_ThreeDOrientation XS_unpack_UA_ThreeDOrientation(SV *in)  __attribute__((unused));
 static void pack_UA_ThreeDOrientation(SV *out, UA_ThreeDOrientation *in);
 static void unpack_UA_ThreeDOrientation(UA_ThreeDOrientation *out, SV *in);
 
@@ -675,57 +603,57 @@ pack_UA_ThreeDOrientation(SV *out, UA_ThreeDOrientation *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->a);
-	hv_stores(hv, "ThreeDOrientation_a", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->b);
-	hv_stores(hv, "ThreeDOrientation_b", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->c);
-	hv_stores(hv, "ThreeDOrientation_c", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDOrientation_a", sv);
+	pack_UA_Double(sv, &in->a);
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDOrientation_b", sv);
+	pack_UA_Double(sv, &in->b);
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDOrientation_c", sv);
+	pack_UA_Double(sv, &in->c);
+
+	return;
 }
 
 static void
 unpack_UA_ThreeDOrientation(UA_ThreeDOrientation *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ThreeDOrientation_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ThreeDOrientation_a", 0);
 	if (svp != NULL)
-		out->a = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->a, *svp);
 
 	svp = hv_fetchs(hv, "ThreeDOrientation_b", 0);
 	if (svp != NULL)
-		out->b = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->b, *svp);
 
 	svp = hv_fetchs(hv, "ThreeDOrientation_c", 0);
 	if (svp != NULL)
-		out->c = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->c, *svp);
 
-
+	return;
 }
 #endif
 
 /* Frame */
 #ifdef UA_TYPES_FRAME
-static void XS_pack_UA_Frame(SV *out, UA_Frame in)  __attribute__((unused));
-static UA_Frame XS_unpack_UA_Frame(SV *in)  __attribute__((unused));
 static void pack_UA_Frame(SV *out, UA_Frame *in);
 static void unpack_UA_Frame(UA_Frame *out, SV *in);
 
@@ -746,8 +674,6 @@ unpack_UA_Frame(UA_Frame *out, SV *in)
 
 /* ThreeDFrame */
 #ifdef UA_TYPES_THREEDFRAME
-static void XS_pack_UA_ThreeDFrame(SV *out, UA_ThreeDFrame in)  __attribute__((unused));
-static UA_ThreeDFrame XS_unpack_UA_ThreeDFrame(SV *in)  __attribute__((unused));
 static void pack_UA_ThreeDFrame(SV *out, UA_ThreeDFrame *in);
 static void unpack_UA_ThreeDFrame(UA_ThreeDFrame *out, SV *in);
 
@@ -756,49 +682,49 @@ pack_UA_ThreeDFrame(SV *out, UA_ThreeDFrame *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ThreeDCartesianCoordinates(sv, in->cartesianCoordinates);
-	hv_stores(hv, "ThreeDFrame_cartesianCoordinates", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ThreeDOrientation(sv, in->orientation);
-	hv_stores(hv, "ThreeDFrame_orientation", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDFrame_cartesianCoordinates", sv);
+	pack_UA_ThreeDCartesianCoordinates(sv, &in->cartesianCoordinates);
+
+	sv = newSV(0);
+	hv_stores(hv, "ThreeDFrame_orientation", sv);
+	pack_UA_ThreeDOrientation(sv, &in->orientation);
+
+	return;
 }
 
 static void
 unpack_UA_ThreeDFrame(UA_ThreeDFrame *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ThreeDFrame_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ThreeDFrame_cartesianCoordinates", 0);
 	if (svp != NULL)
-		out->cartesianCoordinates = XS_unpack_UA_ThreeDCartesianCoordinates(*svp);
+		unpack_UA_ThreeDCartesianCoordinates(&out->cartesianCoordinates, *svp);
 
 	svp = hv_fetchs(hv, "ThreeDFrame_orientation", 0);
 	if (svp != NULL)
-		out->orientation = XS_unpack_UA_ThreeDOrientation(*svp);
+		unpack_UA_ThreeDOrientation(&out->orientation, *svp);
 
-
+	return;
 }
 #endif
 
 /* OpenFileMode */
 #ifdef UA_TYPES_OPENFILEMODE
-static void XS_pack_UA_OpenFileMode(SV *out, UA_OpenFileMode in)  __attribute__((unused));
-static UA_OpenFileMode XS_unpack_UA_OpenFileMode(SV *in)  __attribute__((unused));
 static void pack_UA_OpenFileMode(SV *out, UA_OpenFileMode *in);
 static void unpack_UA_OpenFileMode(UA_OpenFileMode *out, SV *in);
 
@@ -819,8 +745,6 @@ unpack_UA_OpenFileMode(UA_OpenFileMode *out, SV *in)
 
 /* IdentityCriteriaType */
 #ifdef UA_TYPES_IDENTITYCRITERIATYPE
-static void XS_pack_UA_IdentityCriteriaType(SV *out, UA_IdentityCriteriaType in)  __attribute__((unused));
-static UA_IdentityCriteriaType XS_unpack_UA_IdentityCriteriaType(SV *in)  __attribute__((unused));
 static void pack_UA_IdentityCriteriaType(SV *out, UA_IdentityCriteriaType *in);
 static void unpack_UA_IdentityCriteriaType(UA_IdentityCriteriaType *out, SV *in);
 
@@ -841,8 +765,6 @@ unpack_UA_IdentityCriteriaType(UA_IdentityCriteriaType *out, SV *in)
 
 /* IdentityMappingRuleType */
 #ifdef UA_TYPES_IDENTITYMAPPINGRULETYPE
-static void XS_pack_UA_IdentityMappingRuleType(SV *out, UA_IdentityMappingRuleType in)  __attribute__((unused));
-static UA_IdentityMappingRuleType XS_unpack_UA_IdentityMappingRuleType(SV *in)  __attribute__((unused));
 static void pack_UA_IdentityMappingRuleType(SV *out, UA_IdentityMappingRuleType *in);
 static void unpack_UA_IdentityMappingRuleType(UA_IdentityMappingRuleType *out, SV *in);
 
@@ -851,49 +773,49 @@ pack_UA_IdentityMappingRuleType(SV *out, UA_IdentityMappingRuleType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_IdentityCriteriaType(sv, in->criteriaType);
-	hv_stores(hv, "IdentityMappingRuleType_criteriaType", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->criteria);
-	hv_stores(hv, "IdentityMappingRuleType_criteria", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "IdentityMappingRuleType_criteriaType", sv);
+	pack_UA_IdentityCriteriaType(sv, &in->criteriaType);
+
+	sv = newSV(0);
+	hv_stores(hv, "IdentityMappingRuleType_criteria", sv);
+	pack_UA_String(sv, &in->criteria);
+
+	return;
 }
 
 static void
 unpack_UA_IdentityMappingRuleType(UA_IdentityMappingRuleType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_IdentityMappingRuleType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "IdentityMappingRuleType_criteriaType", 0);
 	if (svp != NULL)
-		out->criteriaType = XS_unpack_UA_IdentityCriteriaType(*svp);
+		unpack_UA_IdentityCriteriaType(&out->criteriaType, *svp);
 
 	svp = hv_fetchs(hv, "IdentityMappingRuleType_criteria", 0);
 	if (svp != NULL)
-		out->criteria = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->criteria, *svp);
 
-
+	return;
 }
 #endif
 
 /* CurrencyUnitType */
 #ifdef UA_TYPES_CURRENCYUNITTYPE
-static void XS_pack_UA_CurrencyUnitType(SV *out, UA_CurrencyUnitType in)  __attribute__((unused));
-static UA_CurrencyUnitType XS_unpack_UA_CurrencyUnitType(SV *in)  __attribute__((unused));
 static void pack_UA_CurrencyUnitType(SV *out, UA_CurrencyUnitType *in);
 static void unpack_UA_CurrencyUnitType(UA_CurrencyUnitType *out, SV *in);
 
@@ -902,65 +824,65 @@ pack_UA_CurrencyUnitType(SV *out, UA_CurrencyUnitType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Int16(sv, in->numericCode);
-	hv_stores(hv, "CurrencyUnitType_numericCode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_SByte(sv, in->exponent);
-	hv_stores(hv, "CurrencyUnitType_exponent", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->alphabeticCode);
-	hv_stores(hv, "CurrencyUnitType_alphabeticCode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->currency);
-	hv_stores(hv, "CurrencyUnitType_currency", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "CurrencyUnitType_numericCode", sv);
+	pack_UA_Int16(sv, &in->numericCode);
+
+	sv = newSV(0);
+	hv_stores(hv, "CurrencyUnitType_exponent", sv);
+	pack_UA_SByte(sv, &in->exponent);
+
+	sv = newSV(0);
+	hv_stores(hv, "CurrencyUnitType_alphabeticCode", sv);
+	pack_UA_String(sv, &in->alphabeticCode);
+
+	sv = newSV(0);
+	hv_stores(hv, "CurrencyUnitType_currency", sv);
+	pack_UA_LocalizedText(sv, &in->currency);
+
+	return;
 }
 
 static void
 unpack_UA_CurrencyUnitType(UA_CurrencyUnitType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CurrencyUnitType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CurrencyUnitType_numericCode", 0);
 	if (svp != NULL)
-		out->numericCode = XS_unpack_UA_Int16(*svp);
+		unpack_UA_Int16(&out->numericCode, *svp);
 
 	svp = hv_fetchs(hv, "CurrencyUnitType_exponent", 0);
 	if (svp != NULL)
-		out->exponent = XS_unpack_UA_SByte(*svp);
+		unpack_UA_SByte(&out->exponent, *svp);
 
 	svp = hv_fetchs(hv, "CurrencyUnitType_alphabeticCode", 0);
 	if (svp != NULL)
-		out->alphabeticCode = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->alphabeticCode, *svp);
 
 	svp = hv_fetchs(hv, "CurrencyUnitType_currency", 0);
 	if (svp != NULL)
-		out->currency = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->currency, *svp);
 
-
+	return;
 }
 #endif
 
 /* TrustListMasks */
 #ifdef UA_TYPES_TRUSTLISTMASKS
-static void XS_pack_UA_TrustListMasks(SV *out, UA_TrustListMasks in)  __attribute__((unused));
-static UA_TrustListMasks XS_unpack_UA_TrustListMasks(SV *in)  __attribute__((unused));
 static void pack_UA_TrustListMasks(SV *out, UA_TrustListMasks *in);
 static void unpack_UA_TrustListMasks(UA_TrustListMasks *out, SV *in);
 
@@ -981,8 +903,6 @@ unpack_UA_TrustListMasks(UA_TrustListMasks *out, SV *in)
 
 /* TrustListDataType */
 #ifdef UA_TYPES_TRUSTLISTDATATYPE
-static void XS_pack_UA_TrustListDataType(SV *out, UA_TrustListDataType in)  __attribute__((unused));
-static UA_TrustListDataType XS_unpack_UA_TrustListDataType(SV *in)  __attribute__((unused));
 static void pack_UA_TrustListDataType(SV *out, UA_TrustListDataType *in);
 static void unpack_UA_TrustListDataType(UA_TrustListDataType *out, SV *in);
 
@@ -993,159 +913,147 @@ pack_UA_TrustListDataType(SV *out, UA_TrustListDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedLists);
 	hv_stores(hv, "TrustListDataType_specifiedLists", sv);
+	pack_UA_UInt32(sv, &in->specifiedLists);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TrustListDataType_trustedCertificates", newRV_noinc((SV*)av));
 	av_extend(av, in->trustedCertificatesSize);
 	for (i = 0; i < in->trustedCertificatesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ByteString(sv, in->trustedCertificates[i]);
 		av_push(av, sv);
+		pack_UA_ByteString(sv, &in->trustedCertificates[i]);
 	}
-	hv_stores(hv, "TrustListDataType_trustedCertificates", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TrustListDataType_trustedCrls", newRV_noinc((SV*)av));
 	av_extend(av, in->trustedCrlsSize);
 	for (i = 0; i < in->trustedCrlsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ByteString(sv, in->trustedCrls[i]);
 		av_push(av, sv);
+		pack_UA_ByteString(sv, &in->trustedCrls[i]);
 	}
-	hv_stores(hv, "TrustListDataType_trustedCrls", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TrustListDataType_issuerCertificates", newRV_noinc((SV*)av));
 	av_extend(av, in->issuerCertificatesSize);
 	for (i = 0; i < in->issuerCertificatesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ByteString(sv, in->issuerCertificates[i]);
 		av_push(av, sv);
+		pack_UA_ByteString(sv, &in->issuerCertificates[i]);
 	}
-	hv_stores(hv, "TrustListDataType_issuerCertificates", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TrustListDataType_issuerCrls", newRV_noinc((SV*)av));
 	av_extend(av, in->issuerCrlsSize);
 	for (i = 0; i < in->issuerCrlsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ByteString(sv, in->issuerCrls[i]);
 		av_push(av, sv);
+		pack_UA_ByteString(sv, &in->issuerCrls[i]);
 	}
-	hv_stores(hv, "TrustListDataType_issuerCrls", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_TrustListDataType(UA_TrustListDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_TrustListDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "TrustListDataType_specifiedLists", 0);
 	if (svp != NULL)
-		out->specifiedLists = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedLists, *svp);
 
 	svp = hv_fetchs(hv, "TrustListDataType_trustedCertificates", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TrustListDataType_trustedCertificates");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->trustedCertificates = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BYTESTRING]);
-		if (out->trustedCertificates == NULL) {
+		if (out->trustedCertificates == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->trustedCertificatesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->trustedCertificates[i] = XS_unpack_UA_ByteString(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ByteString(&out->trustedCertificates[i], *svp);
 		}
-		out->trustedCertificatesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "TrustListDataType_trustedCrls", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TrustListDataType_trustedCrls");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->trustedCrls = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BYTESTRING]);
-		if (out->trustedCrls == NULL) {
+		if (out->trustedCrls == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->trustedCrlsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->trustedCrls[i] = XS_unpack_UA_ByteString(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ByteString(&out->trustedCrls[i], *svp);
 		}
-		out->trustedCrlsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "TrustListDataType_issuerCertificates", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TrustListDataType_issuerCertificates");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->issuerCertificates = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BYTESTRING]);
-		if (out->issuerCertificates == NULL) {
+		if (out->issuerCertificates == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->issuerCertificatesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->issuerCertificates[i] = XS_unpack_UA_ByteString(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ByteString(&out->issuerCertificates[i], *svp);
 		}
-		out->issuerCertificatesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "TrustListDataType_issuerCrls", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TrustListDataType_issuerCrls");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->issuerCrls = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BYTESTRING]);
-		if (out->issuerCrls == NULL) {
+		if (out->issuerCrls == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->issuerCrlsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->issuerCrls[i] = XS_unpack_UA_ByteString(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ByteString(&out->issuerCrls[i], *svp);
 		}
-		out->issuerCrlsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DecimalDataType */
 #ifdef UA_TYPES_DECIMALDATATYPE
-static void XS_pack_UA_DecimalDataType(SV *out, UA_DecimalDataType in)  __attribute__((unused));
-static UA_DecimalDataType XS_unpack_UA_DecimalDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DecimalDataType(SV *out, UA_DecimalDataType *in);
 static void unpack_UA_DecimalDataType(UA_DecimalDataType *out, SV *in);
 
@@ -1154,49 +1062,49 @@ pack_UA_DecimalDataType(SV *out, UA_DecimalDataType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Int16(sv, in->scale);
-	hv_stores(hv, "DecimalDataType_scale", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->value);
-	hv_stores(hv, "DecimalDataType_value", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "DecimalDataType_scale", sv);
+	pack_UA_Int16(sv, &in->scale);
+
+	sv = newSV(0);
+	hv_stores(hv, "DecimalDataType_value", sv);
+	pack_UA_ByteString(sv, &in->value);
+
+	return;
 }
 
 static void
 unpack_UA_DecimalDataType(UA_DecimalDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DecimalDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DecimalDataType_scale", 0);
 	if (svp != NULL)
-		out->scale = XS_unpack_UA_Int16(*svp);
+		unpack_UA_Int16(&out->scale, *svp);
 
 	svp = hv_fetchs(hv, "DecimalDataType_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->value, *svp);
 
-
+	return;
 }
 #endif
 
 /* DataTypeDescription */
 #ifdef UA_TYPES_DATATYPEDESCRIPTION
-static void XS_pack_UA_DataTypeDescription(SV *out, UA_DataTypeDescription in)  __attribute__((unused));
-static UA_DataTypeDescription XS_unpack_UA_DataTypeDescription(SV *in)  __attribute__((unused));
 static void pack_UA_DataTypeDescription(SV *out, UA_DataTypeDescription *in);
 static void unpack_UA_DataTypeDescription(UA_DataTypeDescription *out, SV *in);
 
@@ -1205,49 +1113,49 @@ pack_UA_DataTypeDescription(SV *out, UA_DataTypeDescription *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->dataTypeId);
-	hv_stores(hv, "DataTypeDescription_dataTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->name);
-	hv_stores(hv, "DataTypeDescription_name", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "DataTypeDescription_dataTypeId", sv);
+	pack_UA_NodeId(sv, &in->dataTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "DataTypeDescription_name", sv);
+	pack_UA_QualifiedName(sv, &in->name);
+
+	return;
 }
 
 static void
 unpack_UA_DataTypeDescription(UA_DataTypeDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DataTypeDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DataTypeDescription_dataTypeId", 0);
 	if (svp != NULL)
-		out->dataTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->dataTypeId, *svp);
 
 	svp = hv_fetchs(hv, "DataTypeDescription_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->name, *svp);
 
-
+	return;
 }
 #endif
 
 /* SimpleTypeDescription */
 #ifdef UA_TYPES_SIMPLETYPEDESCRIPTION
-static void XS_pack_UA_SimpleTypeDescription(SV *out, UA_SimpleTypeDescription in)  __attribute__((unused));
-static UA_SimpleTypeDescription XS_unpack_UA_SimpleTypeDescription(SV *in)  __attribute__((unused));
 static void pack_UA_SimpleTypeDescription(SV *out, UA_SimpleTypeDescription *in);
 static void unpack_UA_SimpleTypeDescription(UA_SimpleTypeDescription *out, SV *in);
 
@@ -1256,65 +1164,65 @@ pack_UA_SimpleTypeDescription(SV *out, UA_SimpleTypeDescription *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->dataTypeId);
-	hv_stores(hv, "SimpleTypeDescription_dataTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->name);
-	hv_stores(hv, "SimpleTypeDescription_name", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->baseDataType);
-	hv_stores(hv, "SimpleTypeDescription_baseDataType", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->builtInType);
-	hv_stores(hv, "SimpleTypeDescription_builtInType", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "SimpleTypeDescription_dataTypeId", sv);
+	pack_UA_NodeId(sv, &in->dataTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "SimpleTypeDescription_name", sv);
+	pack_UA_QualifiedName(sv, &in->name);
+
+	sv = newSV(0);
+	hv_stores(hv, "SimpleTypeDescription_baseDataType", sv);
+	pack_UA_NodeId(sv, &in->baseDataType);
+
+	sv = newSV(0);
+	hv_stores(hv, "SimpleTypeDescription_builtInType", sv);
+	pack_UA_Byte(sv, &in->builtInType);
+
+	return;
 }
 
 static void
 unpack_UA_SimpleTypeDescription(UA_SimpleTypeDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SimpleTypeDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SimpleTypeDescription_dataTypeId", 0);
 	if (svp != NULL)
-		out->dataTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->dataTypeId, *svp);
 
 	svp = hv_fetchs(hv, "SimpleTypeDescription_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "SimpleTypeDescription_baseDataType", 0);
 	if (svp != NULL)
-		out->baseDataType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->baseDataType, *svp);
 
 	svp = hv_fetchs(hv, "SimpleTypeDescription_builtInType", 0);
 	if (svp != NULL)
-		out->builtInType = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->builtInType, *svp);
 
-
+	return;
 }
 #endif
 
 /* PubSubState */
 #ifdef UA_TYPES_PUBSUBSTATE
-static void XS_pack_UA_PubSubState(SV *out, UA_PubSubState in)  __attribute__((unused));
-static UA_PubSubState XS_unpack_UA_PubSubState(SV *in)  __attribute__((unused));
 static void pack_UA_PubSubState(SV *out, UA_PubSubState *in);
 static void unpack_UA_PubSubState(UA_PubSubState *out, SV *in);
 
@@ -1335,8 +1243,6 @@ unpack_UA_PubSubState(UA_PubSubState *out, SV *in)
 
 /* DataSetFieldFlags */
 #ifdef UA_TYPES_DATASETFIELDFLAGS
-static void XS_pack_UA_DataSetFieldFlags(SV *out, UA_DataSetFieldFlags in)  __attribute__((unused));
-static UA_DataSetFieldFlags XS_unpack_UA_DataSetFieldFlags(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetFieldFlags(SV *out, UA_DataSetFieldFlags *in);
 static void unpack_UA_DataSetFieldFlags(UA_DataSetFieldFlags *out, SV *in);
 
@@ -1357,8 +1263,6 @@ unpack_UA_DataSetFieldFlags(UA_DataSetFieldFlags *out, SV *in)
 
 /* ConfigurationVersionDataType */
 #ifdef UA_TYPES_CONFIGURATIONVERSIONDATATYPE
-static void XS_pack_UA_ConfigurationVersionDataType(SV *out, UA_ConfigurationVersionDataType in)  __attribute__((unused));
-static UA_ConfigurationVersionDataType XS_unpack_UA_ConfigurationVersionDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ConfigurationVersionDataType(SV *out, UA_ConfigurationVersionDataType *in);
 static void unpack_UA_ConfigurationVersionDataType(UA_ConfigurationVersionDataType *out, SV *in);
 
@@ -1367,49 +1271,49 @@ pack_UA_ConfigurationVersionDataType(SV *out, UA_ConfigurationVersionDataType *i
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->majorVersion);
-	hv_stores(hv, "ConfigurationVersionDataType_majorVersion", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->minorVersion);
-	hv_stores(hv, "ConfigurationVersionDataType_minorVersion", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ConfigurationVersionDataType_majorVersion", sv);
+	pack_UA_UInt32(sv, &in->majorVersion);
+
+	sv = newSV(0);
+	hv_stores(hv, "ConfigurationVersionDataType_minorVersion", sv);
+	pack_UA_UInt32(sv, &in->minorVersion);
+
+	return;
 }
 
 static void
 unpack_UA_ConfigurationVersionDataType(UA_ConfigurationVersionDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ConfigurationVersionDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ConfigurationVersionDataType_majorVersion", 0);
 	if (svp != NULL)
-		out->majorVersion = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->majorVersion, *svp);
 
 	svp = hv_fetchs(hv, "ConfigurationVersionDataType_minorVersion", 0);
 	if (svp != NULL)
-		out->minorVersion = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->minorVersion, *svp);
 
-
+	return;
 }
 #endif
 
 /* PublishedDataSetSourceDataType */
 #ifdef UA_TYPES_PUBLISHEDDATASETSOURCEDATATYPE
-static void XS_pack_UA_PublishedDataSetSourceDataType(SV *out, UA_PublishedDataSetSourceDataType in)  __attribute__((unused));
-static UA_PublishedDataSetSourceDataType XS_unpack_UA_PublishedDataSetSourceDataType(SV *in)  __attribute__((unused));
 static void pack_UA_PublishedDataSetSourceDataType(SV *out, UA_PublishedDataSetSourceDataType *in);
 static void unpack_UA_PublishedDataSetSourceDataType(UA_PublishedDataSetSourceDataType *out, SV *in);
 
@@ -1430,8 +1334,6 @@ unpack_UA_PublishedDataSetSourceDataType(UA_PublishedDataSetSourceDataType *out,
 
 /* PublishedVariableDataType */
 #ifdef UA_TYPES_PUBLISHEDVARIABLEDATATYPE
-static void XS_pack_UA_PublishedVariableDataType(SV *out, UA_PublishedVariableDataType in)  __attribute__((unused));
-static UA_PublishedVariableDataType XS_unpack_UA_PublishedVariableDataType(SV *in)  __attribute__((unused));
 static void pack_UA_PublishedVariableDataType(SV *out, UA_PublishedVariableDataType *in);
 static void unpack_UA_PublishedVariableDataType(UA_PublishedVariableDataType *out, SV *in);
 
@@ -1442,120 +1344,117 @@ pack_UA_PublishedVariableDataType(SV *out, UA_PublishedVariableDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->publishedVariable);
 	hv_stores(hv, "PublishedVariableDataType_publishedVariable", sv);
+	pack_UA_NodeId(sv, &in->publishedVariable);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->attributeId);
 	hv_stores(hv, "PublishedVariableDataType_attributeId", sv);
+	pack_UA_UInt32(sv, &in->attributeId);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->samplingIntervalHint);
 	hv_stores(hv, "PublishedVariableDataType_samplingIntervalHint", sv);
+	pack_UA_Double(sv, &in->samplingIntervalHint);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->deadbandType);
 	hv_stores(hv, "PublishedVariableDataType_deadbandType", sv);
+	pack_UA_UInt32(sv, &in->deadbandType);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->deadbandValue);
 	hv_stores(hv, "PublishedVariableDataType_deadbandValue", sv);
+	pack_UA_Double(sv, &in->deadbandValue);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->indexRange);
 	hv_stores(hv, "PublishedVariableDataType_indexRange", sv);
+	pack_UA_String(sv, &in->indexRange);
 
 	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->substituteValue);
 	hv_stores(hv, "PublishedVariableDataType_substituteValue", sv);
+	pack_UA_Variant(sv, &in->substituteValue);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PublishedVariableDataType_metaDataProperties", newRV_noinc((SV*)av));
 	av_extend(av, in->metaDataPropertiesSize);
 	for (i = 0; i < in->metaDataPropertiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_QualifiedName(sv, in->metaDataProperties[i]);
 		av_push(av, sv);
+		pack_UA_QualifiedName(sv, &in->metaDataProperties[i]);
 	}
-	hv_stores(hv, "PublishedVariableDataType_metaDataProperties", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_PublishedVariableDataType(UA_PublishedVariableDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_PublishedVariableDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "PublishedVariableDataType_publishedVariable", 0);
 	if (svp != NULL)
-		out->publishedVariable = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->publishedVariable, *svp);
 
 	svp = hv_fetchs(hv, "PublishedVariableDataType_attributeId", 0);
 	if (svp != NULL)
-		out->attributeId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->attributeId, *svp);
 
 	svp = hv_fetchs(hv, "PublishedVariableDataType_samplingIntervalHint", 0);
 	if (svp != NULL)
-		out->samplingIntervalHint = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->samplingIntervalHint, *svp);
 
 	svp = hv_fetchs(hv, "PublishedVariableDataType_deadbandType", 0);
 	if (svp != NULL)
-		out->deadbandType = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->deadbandType, *svp);
 
 	svp = hv_fetchs(hv, "PublishedVariableDataType_deadbandValue", 0);
 	if (svp != NULL)
-		out->deadbandValue = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->deadbandValue, *svp);
 
 	svp = hv_fetchs(hv, "PublishedVariableDataType_indexRange", 0);
 	if (svp != NULL)
-		out->indexRange = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->indexRange, *svp);
 
 	svp = hv_fetchs(hv, "PublishedVariableDataType_substituteValue", 0);
 	if (svp != NULL)
-		out->substituteValue = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->substituteValue, *svp);
 
 	svp = hv_fetchs(hv, "PublishedVariableDataType_metaDataProperties", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PublishedVariableDataType_metaDataProperties");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->metaDataProperties = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
-		if (out->metaDataProperties == NULL) {
+		if (out->metaDataProperties == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->metaDataPropertiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->metaDataProperties[i] = XS_unpack_UA_QualifiedName(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_QualifiedName(&out->metaDataProperties[i], *svp);
 		}
-		out->metaDataPropertiesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* PublishedDataItemsDataType */
 #ifdef UA_TYPES_PUBLISHEDDATAITEMSDATATYPE
-static void XS_pack_UA_PublishedDataItemsDataType(SV *out, UA_PublishedDataItemsDataType in)  __attribute__((unused));
-static UA_PublishedDataItemsDataType XS_unpack_UA_PublishedDataItemsDataType(SV *in)  __attribute__((unused));
 static void pack_UA_PublishedDataItemsDataType(SV *out, UA_PublishedDataItemsDataType *in);
 static void unpack_UA_PublishedDataItemsDataType(UA_PublishedDataItemsDataType *out, SV *in);
 
@@ -1566,64 +1465,61 @@ pack_UA_PublishedDataItemsDataType(SV *out, UA_PublishedDataItemsDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "PublishedDataItemsDataType_publishedData", newRV_noinc((SV*)av));
 	av_extend(av, in->publishedDataSize);
 	for (i = 0; i < in->publishedDataSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_PublishedVariableDataType(sv, in->publishedData[i]);
 		av_push(av, sv);
+		pack_UA_PublishedVariableDataType(sv, &in->publishedData[i]);
 	}
-	hv_stores(hv, "PublishedDataItemsDataType_publishedData", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_PublishedDataItemsDataType(UA_PublishedDataItemsDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_PublishedDataItemsDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "PublishedDataItemsDataType_publishedData", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PublishedDataItemsDataType_publishedData");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->publishedData = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_PUBLISHEDVARIABLEDATATYPE]);
-		if (out->publishedData == NULL) {
+		if (out->publishedData == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->publishedDataSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->publishedData[i] = XS_unpack_UA_PublishedVariableDataType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_PublishedVariableDataType(&out->publishedData[i], *svp);
 		}
-		out->publishedDataSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DataSetFieldContentMask */
 #ifdef UA_TYPES_DATASETFIELDCONTENTMASK
-static void XS_pack_UA_DataSetFieldContentMask(SV *out, UA_DataSetFieldContentMask in)  __attribute__((unused));
-static UA_DataSetFieldContentMask XS_unpack_UA_DataSetFieldContentMask(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetFieldContentMask(SV *out, UA_DataSetFieldContentMask *in);
 static void unpack_UA_DataSetFieldContentMask(UA_DataSetFieldContentMask *out, SV *in);
 
@@ -1644,8 +1540,6 @@ unpack_UA_DataSetFieldContentMask(UA_DataSetFieldContentMask *out, SV *in)
 
 /* DataSetWriterDataType */
 #ifdef UA_TYPES_DATASETWRITERDATATYPE
-static void XS_pack_UA_DataSetWriterDataType(SV *out, UA_DataSetWriterDataType in)  __attribute__((unused));
-static UA_DataSetWriterDataType XS_unpack_UA_DataSetWriterDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetWriterDataType(SV *out, UA_DataSetWriterDataType *in);
 static void unpack_UA_DataSetWriterDataType(UA_DataSetWriterDataType *out, SV *in);
 
@@ -1656,128 +1550,125 @@ pack_UA_DataSetWriterDataType(SV *out, UA_DataSetWriterDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "DataSetWriterDataType_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->enabled);
 	hv_stores(hv, "DataSetWriterDataType_enabled", sv);
+	pack_UA_Boolean(sv, &in->enabled);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt16(sv, in->dataSetWriterId);
 	hv_stores(hv, "DataSetWriterDataType_dataSetWriterId", sv);
+	pack_UA_UInt16(sv, &in->dataSetWriterId);
 
 	sv = newSV(0);
-	XS_pack_UA_DataSetFieldContentMask(sv, in->dataSetFieldContentMask);
 	hv_stores(hv, "DataSetWriterDataType_dataSetFieldContentMask", sv);
+	pack_UA_DataSetFieldContentMask(sv, &in->dataSetFieldContentMask);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->keyFrameCount);
 	hv_stores(hv, "DataSetWriterDataType_keyFrameCount", sv);
+	pack_UA_UInt32(sv, &in->keyFrameCount);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->dataSetName);
 	hv_stores(hv, "DataSetWriterDataType_dataSetName", sv);
+	pack_UA_String(sv, &in->dataSetName);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataSetWriterDataType_dataSetWriterProperties", newRV_noinc((SV*)av));
 	av_extend(av, in->dataSetWriterPropertiesSize);
 	for (i = 0; i < in->dataSetWriterPropertiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_KeyValuePair(sv, in->dataSetWriterProperties[i]);
 		av_push(av, sv);
+		pack_UA_KeyValuePair(sv, &in->dataSetWriterProperties[i]);
 	}
-	hv_stores(hv, "DataSetWriterDataType_dataSetWriterProperties", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->transportSettings);
 	hv_stores(hv, "DataSetWriterDataType_transportSettings", sv);
+	pack_UA_ExtensionObject(sv, &in->transportSettings);
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->messageSettings);
 	hv_stores(hv, "DataSetWriterDataType_messageSettings", sv);
+	pack_UA_ExtensionObject(sv, &in->messageSettings);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DataSetWriterDataType(UA_DataSetWriterDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DataSetWriterDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DataSetWriterDataType_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "DataSetWriterDataType_enabled", 0);
 	if (svp != NULL)
-		out->enabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->enabled, *svp);
 
 	svp = hv_fetchs(hv, "DataSetWriterDataType_dataSetWriterId", 0);
 	if (svp != NULL)
-		out->dataSetWriterId = XS_unpack_UA_UInt16(*svp);
+		unpack_UA_UInt16(&out->dataSetWriterId, *svp);
 
 	svp = hv_fetchs(hv, "DataSetWriterDataType_dataSetFieldContentMask", 0);
 	if (svp != NULL)
-		out->dataSetFieldContentMask = XS_unpack_UA_DataSetFieldContentMask(*svp);
+		unpack_UA_DataSetFieldContentMask(&out->dataSetFieldContentMask, *svp);
 
 	svp = hv_fetchs(hv, "DataSetWriterDataType_keyFrameCount", 0);
 	if (svp != NULL)
-		out->keyFrameCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->keyFrameCount, *svp);
 
 	svp = hv_fetchs(hv, "DataSetWriterDataType_dataSetName", 0);
 	if (svp != NULL)
-		out->dataSetName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->dataSetName, *svp);
 
 	svp = hv_fetchs(hv, "DataSetWriterDataType_dataSetWriterProperties", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataSetWriterDataType_dataSetWriterProperties");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataSetWriterProperties = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-		if (out->dataSetWriterProperties == NULL) {
+		if (out->dataSetWriterProperties == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataSetWriterPropertiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataSetWriterProperties[i] = XS_unpack_UA_KeyValuePair(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_KeyValuePair(&out->dataSetWriterProperties[i], *svp);
 		}
-		out->dataSetWriterPropertiesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataSetWriterDataType_transportSettings", 0);
 	if (svp != NULL)
-		out->transportSettings = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->transportSettings, *svp);
 
 	svp = hv_fetchs(hv, "DataSetWriterDataType_messageSettings", 0);
 	if (svp != NULL)
-		out->messageSettings = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->messageSettings, *svp);
 
-
+	return;
 }
 #endif
 
 /* DataSetWriterTransportDataType */
 #ifdef UA_TYPES_DATASETWRITERTRANSPORTDATATYPE
-static void XS_pack_UA_DataSetWriterTransportDataType(SV *out, UA_DataSetWriterTransportDataType in)  __attribute__((unused));
-static UA_DataSetWriterTransportDataType XS_unpack_UA_DataSetWriterTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetWriterTransportDataType(SV *out, UA_DataSetWriterTransportDataType *in);
 static void unpack_UA_DataSetWriterTransportDataType(UA_DataSetWriterTransportDataType *out, SV *in);
 
@@ -1798,8 +1689,6 @@ unpack_UA_DataSetWriterTransportDataType(UA_DataSetWriterTransportDataType *out,
 
 /* DataSetWriterMessageDataType */
 #ifdef UA_TYPES_DATASETWRITERMESSAGEDATATYPE
-static void XS_pack_UA_DataSetWriterMessageDataType(SV *out, UA_DataSetWriterMessageDataType in)  __attribute__((unused));
-static UA_DataSetWriterMessageDataType XS_unpack_UA_DataSetWriterMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetWriterMessageDataType(SV *out, UA_DataSetWriterMessageDataType *in);
 static void unpack_UA_DataSetWriterMessageDataType(UA_DataSetWriterMessageDataType *out, SV *in);
 
@@ -1820,8 +1709,6 @@ unpack_UA_DataSetWriterMessageDataType(UA_DataSetWriterMessageDataType *out, SV 
 
 /* WriterGroupTransportDataType */
 #ifdef UA_TYPES_WRITERGROUPTRANSPORTDATATYPE
-static void XS_pack_UA_WriterGroupTransportDataType(SV *out, UA_WriterGroupTransportDataType in)  __attribute__((unused));
-static UA_WriterGroupTransportDataType XS_unpack_UA_WriterGroupTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_WriterGroupTransportDataType(SV *out, UA_WriterGroupTransportDataType *in);
 static void unpack_UA_WriterGroupTransportDataType(UA_WriterGroupTransportDataType *out, SV *in);
 
@@ -1842,8 +1729,6 @@ unpack_UA_WriterGroupTransportDataType(UA_WriterGroupTransportDataType *out, SV 
 
 /* WriterGroupMessageDataType */
 #ifdef UA_TYPES_WRITERGROUPMESSAGEDATATYPE
-static void XS_pack_UA_WriterGroupMessageDataType(SV *out, UA_WriterGroupMessageDataType in)  __attribute__((unused));
-static UA_WriterGroupMessageDataType XS_unpack_UA_WriterGroupMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_WriterGroupMessageDataType(SV *out, UA_WriterGroupMessageDataType *in);
 static void unpack_UA_WriterGroupMessageDataType(UA_WriterGroupMessageDataType *out, SV *in);
 
@@ -1864,8 +1749,6 @@ unpack_UA_WriterGroupMessageDataType(UA_WriterGroupMessageDataType *out, SV *in)
 
 /* ConnectionTransportDataType */
 #ifdef UA_TYPES_CONNECTIONTRANSPORTDATATYPE
-static void XS_pack_UA_ConnectionTransportDataType(SV *out, UA_ConnectionTransportDataType in)  __attribute__((unused));
-static UA_ConnectionTransportDataType XS_unpack_UA_ConnectionTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ConnectionTransportDataType(SV *out, UA_ConnectionTransportDataType *in);
 static void unpack_UA_ConnectionTransportDataType(UA_ConnectionTransportDataType *out, SV *in);
 
@@ -1886,8 +1769,6 @@ unpack_UA_ConnectionTransportDataType(UA_ConnectionTransportDataType *out, SV *i
 
 /* NetworkAddressDataType */
 #ifdef UA_TYPES_NETWORKADDRESSDATATYPE
-static void XS_pack_UA_NetworkAddressDataType(SV *out, UA_NetworkAddressDataType in)  __attribute__((unused));
-static UA_NetworkAddressDataType XS_unpack_UA_NetworkAddressDataType(SV *in)  __attribute__((unused));
 static void pack_UA_NetworkAddressDataType(SV *out, UA_NetworkAddressDataType *in);
 static void unpack_UA_NetworkAddressDataType(UA_NetworkAddressDataType *out, SV *in);
 
@@ -1896,41 +1777,41 @@ pack_UA_NetworkAddressDataType(SV *out, UA_NetworkAddressDataType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->networkInterface);
 	hv_stores(hv, "NetworkAddressDataType_networkInterface", sv);
+	pack_UA_String(sv, &in->networkInterface);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_NetworkAddressDataType(UA_NetworkAddressDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_NetworkAddressDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "NetworkAddressDataType_networkInterface", 0);
 	if (svp != NULL)
-		out->networkInterface = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->networkInterface, *svp);
 
-
+	return;
 }
 #endif
 
 /* NetworkAddressUrlDataType */
 #ifdef UA_TYPES_NETWORKADDRESSURLDATATYPE
-static void XS_pack_UA_NetworkAddressUrlDataType(SV *out, UA_NetworkAddressUrlDataType in)  __attribute__((unused));
-static UA_NetworkAddressUrlDataType XS_unpack_UA_NetworkAddressUrlDataType(SV *in)  __attribute__((unused));
 static void pack_UA_NetworkAddressUrlDataType(SV *out, UA_NetworkAddressUrlDataType *in);
 static void unpack_UA_NetworkAddressUrlDataType(UA_NetworkAddressUrlDataType *out, SV *in);
 
@@ -1939,49 +1820,49 @@ pack_UA_NetworkAddressUrlDataType(SV *out, UA_NetworkAddressUrlDataType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->networkInterface);
-	hv_stores(hv, "NetworkAddressUrlDataType_networkInterface", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->url);
-	hv_stores(hv, "NetworkAddressUrlDataType_url", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "NetworkAddressUrlDataType_networkInterface", sv);
+	pack_UA_String(sv, &in->networkInterface);
+
+	sv = newSV(0);
+	hv_stores(hv, "NetworkAddressUrlDataType_url", sv);
+	pack_UA_String(sv, &in->url);
+
+	return;
 }
 
 static void
 unpack_UA_NetworkAddressUrlDataType(UA_NetworkAddressUrlDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_NetworkAddressUrlDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "NetworkAddressUrlDataType_networkInterface", 0);
 	if (svp != NULL)
-		out->networkInterface = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->networkInterface, *svp);
 
 	svp = hv_fetchs(hv, "NetworkAddressUrlDataType_url", 0);
 	if (svp != NULL)
-		out->url = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->url, *svp);
 
-
+	return;
 }
 #endif
 
 /* ReaderGroupTransportDataType */
 #ifdef UA_TYPES_READERGROUPTRANSPORTDATATYPE
-static void XS_pack_UA_ReaderGroupTransportDataType(SV *out, UA_ReaderGroupTransportDataType in)  __attribute__((unused));
-static UA_ReaderGroupTransportDataType XS_unpack_UA_ReaderGroupTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ReaderGroupTransportDataType(SV *out, UA_ReaderGroupTransportDataType *in);
 static void unpack_UA_ReaderGroupTransportDataType(UA_ReaderGroupTransportDataType *out, SV *in);
 
@@ -2002,8 +1883,6 @@ unpack_UA_ReaderGroupTransportDataType(UA_ReaderGroupTransportDataType *out, SV 
 
 /* ReaderGroupMessageDataType */
 #ifdef UA_TYPES_READERGROUPMESSAGEDATATYPE
-static void XS_pack_UA_ReaderGroupMessageDataType(SV *out, UA_ReaderGroupMessageDataType in)  __attribute__((unused));
-static UA_ReaderGroupMessageDataType XS_unpack_UA_ReaderGroupMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ReaderGroupMessageDataType(SV *out, UA_ReaderGroupMessageDataType *in);
 static void unpack_UA_ReaderGroupMessageDataType(UA_ReaderGroupMessageDataType *out, SV *in);
 
@@ -2024,8 +1903,6 @@ unpack_UA_ReaderGroupMessageDataType(UA_ReaderGroupMessageDataType *out, SV *in)
 
 /* DataSetReaderTransportDataType */
 #ifdef UA_TYPES_DATASETREADERTRANSPORTDATATYPE
-static void XS_pack_UA_DataSetReaderTransportDataType(SV *out, UA_DataSetReaderTransportDataType in)  __attribute__((unused));
-static UA_DataSetReaderTransportDataType XS_unpack_UA_DataSetReaderTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetReaderTransportDataType(SV *out, UA_DataSetReaderTransportDataType *in);
 static void unpack_UA_DataSetReaderTransportDataType(UA_DataSetReaderTransportDataType *out, SV *in);
 
@@ -2046,8 +1923,6 @@ unpack_UA_DataSetReaderTransportDataType(UA_DataSetReaderTransportDataType *out,
 
 /* DataSetReaderMessageDataType */
 #ifdef UA_TYPES_DATASETREADERMESSAGEDATATYPE
-static void XS_pack_UA_DataSetReaderMessageDataType(SV *out, UA_DataSetReaderMessageDataType in)  __attribute__((unused));
-static UA_DataSetReaderMessageDataType XS_unpack_UA_DataSetReaderMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetReaderMessageDataType(SV *out, UA_DataSetReaderMessageDataType *in);
 static void unpack_UA_DataSetReaderMessageDataType(UA_DataSetReaderMessageDataType *out, SV *in);
 
@@ -2068,8 +1943,6 @@ unpack_UA_DataSetReaderMessageDataType(UA_DataSetReaderMessageDataType *out, SV 
 
 /* SubscribedDataSetDataType */
 #ifdef UA_TYPES_SUBSCRIBEDDATASETDATATYPE
-static void XS_pack_UA_SubscribedDataSetDataType(SV *out, UA_SubscribedDataSetDataType in)  __attribute__((unused));
-static UA_SubscribedDataSetDataType XS_unpack_UA_SubscribedDataSetDataType(SV *in)  __attribute__((unused));
 static void pack_UA_SubscribedDataSetDataType(SV *out, UA_SubscribedDataSetDataType *in);
 static void unpack_UA_SubscribedDataSetDataType(UA_SubscribedDataSetDataType *out, SV *in);
 
@@ -2090,8 +1963,6 @@ unpack_UA_SubscribedDataSetDataType(UA_SubscribedDataSetDataType *out, SV *in)
 
 /* OverrideValueHandling */
 #ifdef UA_TYPES_OVERRIDEVALUEHANDLING
-static void XS_pack_UA_OverrideValueHandling(SV *out, UA_OverrideValueHandling in)  __attribute__((unused));
-static UA_OverrideValueHandling XS_unpack_UA_OverrideValueHandling(SV *in)  __attribute__((unused));
 static void pack_UA_OverrideValueHandling(SV *out, UA_OverrideValueHandling *in);
 static void unpack_UA_OverrideValueHandling(UA_OverrideValueHandling *out, SV *in);
 
@@ -2112,8 +1983,6 @@ unpack_UA_OverrideValueHandling(UA_OverrideValueHandling *out, SV *in)
 
 /* DataSetOrderingType */
 #ifdef UA_TYPES_DATASETORDERINGTYPE
-static void XS_pack_UA_DataSetOrderingType(SV *out, UA_DataSetOrderingType in)  __attribute__((unused));
-static UA_DataSetOrderingType XS_unpack_UA_DataSetOrderingType(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetOrderingType(SV *out, UA_DataSetOrderingType *in);
 static void unpack_UA_DataSetOrderingType(UA_DataSetOrderingType *out, SV *in);
 
@@ -2134,8 +2003,6 @@ unpack_UA_DataSetOrderingType(UA_DataSetOrderingType *out, SV *in)
 
 /* UadpNetworkMessageContentMask */
 #ifdef UA_TYPES_UADPNETWORKMESSAGECONTENTMASK
-static void XS_pack_UA_UadpNetworkMessageContentMask(SV *out, UA_UadpNetworkMessageContentMask in)  __attribute__((unused));
-static UA_UadpNetworkMessageContentMask XS_unpack_UA_UadpNetworkMessageContentMask(SV *in)  __attribute__((unused));
 static void pack_UA_UadpNetworkMessageContentMask(SV *out, UA_UadpNetworkMessageContentMask *in);
 static void unpack_UA_UadpNetworkMessageContentMask(UA_UadpNetworkMessageContentMask *out, SV *in);
 
@@ -2156,8 +2023,6 @@ unpack_UA_UadpNetworkMessageContentMask(UA_UadpNetworkMessageContentMask *out, S
 
 /* UadpWriterGroupMessageDataType */
 #ifdef UA_TYPES_UADPWRITERGROUPMESSAGEDATATYPE
-static void XS_pack_UA_UadpWriterGroupMessageDataType(SV *out, UA_UadpWriterGroupMessageDataType in)  __attribute__((unused));
-static UA_UadpWriterGroupMessageDataType XS_unpack_UA_UadpWriterGroupMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_UadpWriterGroupMessageDataType(SV *out, UA_UadpWriterGroupMessageDataType *in);
 static void unpack_UA_UadpWriterGroupMessageDataType(UA_UadpWriterGroupMessageDataType *out, SV *in);
 
@@ -2168,96 +2033,93 @@ pack_UA_UadpWriterGroupMessageDataType(SV *out, UA_UadpWriterGroupMessageDataTyp
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->groupVersion);
 	hv_stores(hv, "UadpWriterGroupMessageDataType_groupVersion", sv);
+	pack_UA_UInt32(sv, &in->groupVersion);
 
 	sv = newSV(0);
-	XS_pack_UA_DataSetOrderingType(sv, in->dataSetOrdering);
 	hv_stores(hv, "UadpWriterGroupMessageDataType_dataSetOrdering", sv);
+	pack_UA_DataSetOrderingType(sv, &in->dataSetOrdering);
 
 	sv = newSV(0);
-	XS_pack_UA_UadpNetworkMessageContentMask(sv, in->networkMessageContentMask);
 	hv_stores(hv, "UadpWriterGroupMessageDataType_networkMessageContentMask", sv);
+	pack_UA_UadpNetworkMessageContentMask(sv, &in->networkMessageContentMask);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->samplingOffset);
 	hv_stores(hv, "UadpWriterGroupMessageDataType_samplingOffset", sv);
+	pack_UA_Double(sv, &in->samplingOffset);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "UadpWriterGroupMessageDataType_publishingOffset", newRV_noinc((SV*)av));
 	av_extend(av, in->publishingOffsetSize);
 	for (i = 0; i < in->publishingOffsetSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Double(sv, in->publishingOffset[i]);
 		av_push(av, sv);
+		pack_UA_Double(sv, &in->publishingOffset[i]);
 	}
-	hv_stores(hv, "UadpWriterGroupMessageDataType_publishingOffset", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_UadpWriterGroupMessageDataType(UA_UadpWriterGroupMessageDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UadpWriterGroupMessageDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UadpWriterGroupMessageDataType_groupVersion", 0);
 	if (svp != NULL)
-		out->groupVersion = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->groupVersion, *svp);
 
 	svp = hv_fetchs(hv, "UadpWriterGroupMessageDataType_dataSetOrdering", 0);
 	if (svp != NULL)
-		out->dataSetOrdering = XS_unpack_UA_DataSetOrderingType(*svp);
+		unpack_UA_DataSetOrderingType(&out->dataSetOrdering, *svp);
 
 	svp = hv_fetchs(hv, "UadpWriterGroupMessageDataType_networkMessageContentMask", 0);
 	if (svp != NULL)
-		out->networkMessageContentMask = XS_unpack_UA_UadpNetworkMessageContentMask(*svp);
+		unpack_UA_UadpNetworkMessageContentMask(&out->networkMessageContentMask, *svp);
 
 	svp = hv_fetchs(hv, "UadpWriterGroupMessageDataType_samplingOffset", 0);
 	if (svp != NULL)
-		out->samplingOffset = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->samplingOffset, *svp);
 
 	svp = hv_fetchs(hv, "UadpWriterGroupMessageDataType_publishingOffset", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UadpWriterGroupMessageDataType_publishingOffset");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->publishingOffset = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DOUBLE]);
-		if (out->publishingOffset == NULL) {
+		if (out->publishingOffset == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->publishingOffsetSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->publishingOffset[i] = XS_unpack_UA_Double(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Double(&out->publishingOffset[i], *svp);
 		}
-		out->publishingOffsetSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* UadpDataSetMessageContentMask */
 #ifdef UA_TYPES_UADPDATASETMESSAGECONTENTMASK
-static void XS_pack_UA_UadpDataSetMessageContentMask(SV *out, UA_UadpDataSetMessageContentMask in)  __attribute__((unused));
-static UA_UadpDataSetMessageContentMask XS_unpack_UA_UadpDataSetMessageContentMask(SV *in)  __attribute__((unused));
 static void pack_UA_UadpDataSetMessageContentMask(SV *out, UA_UadpDataSetMessageContentMask *in);
 static void unpack_UA_UadpDataSetMessageContentMask(UA_UadpDataSetMessageContentMask *out, SV *in);
 
@@ -2278,8 +2140,6 @@ unpack_UA_UadpDataSetMessageContentMask(UA_UadpDataSetMessageContentMask *out, S
 
 /* UadpDataSetWriterMessageDataType */
 #ifdef UA_TYPES_UADPDATASETWRITERMESSAGEDATATYPE
-static void XS_pack_UA_UadpDataSetWriterMessageDataType(SV *out, UA_UadpDataSetWriterMessageDataType in)  __attribute__((unused));
-static UA_UadpDataSetWriterMessageDataType XS_unpack_UA_UadpDataSetWriterMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_UadpDataSetWriterMessageDataType(SV *out, UA_UadpDataSetWriterMessageDataType *in);
 static void unpack_UA_UadpDataSetWriterMessageDataType(UA_UadpDataSetWriterMessageDataType *out, SV *in);
 
@@ -2288,65 +2148,65 @@ pack_UA_UadpDataSetWriterMessageDataType(SV *out, UA_UadpDataSetWriterMessageDat
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UadpDataSetMessageContentMask(sv, in->dataSetMessageContentMask);
-	hv_stores(hv, "UadpDataSetWriterMessageDataType_dataSetMessageContentMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt16(sv, in->configuredSize);
-	hv_stores(hv, "UadpDataSetWriterMessageDataType_configuredSize", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt16(sv, in->networkMessageNumber);
-	hv_stores(hv, "UadpDataSetWriterMessageDataType_networkMessageNumber", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt16(sv, in->dataSetOffset);
-	hv_stores(hv, "UadpDataSetWriterMessageDataType_dataSetOffset", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetWriterMessageDataType_dataSetMessageContentMask", sv);
+	pack_UA_UadpDataSetMessageContentMask(sv, &in->dataSetMessageContentMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetWriterMessageDataType_configuredSize", sv);
+	pack_UA_UInt16(sv, &in->configuredSize);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetWriterMessageDataType_networkMessageNumber", sv);
+	pack_UA_UInt16(sv, &in->networkMessageNumber);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetWriterMessageDataType_dataSetOffset", sv);
+	pack_UA_UInt16(sv, &in->dataSetOffset);
+
+	return;
 }
 
 static void
 unpack_UA_UadpDataSetWriterMessageDataType(UA_UadpDataSetWriterMessageDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UadpDataSetWriterMessageDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UadpDataSetWriterMessageDataType_dataSetMessageContentMask", 0);
 	if (svp != NULL)
-		out->dataSetMessageContentMask = XS_unpack_UA_UadpDataSetMessageContentMask(*svp);
+		unpack_UA_UadpDataSetMessageContentMask(&out->dataSetMessageContentMask, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetWriterMessageDataType_configuredSize", 0);
 	if (svp != NULL)
-		out->configuredSize = XS_unpack_UA_UInt16(*svp);
+		unpack_UA_UInt16(&out->configuredSize, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetWriterMessageDataType_networkMessageNumber", 0);
 	if (svp != NULL)
-		out->networkMessageNumber = XS_unpack_UA_UInt16(*svp);
+		unpack_UA_UInt16(&out->networkMessageNumber, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetWriterMessageDataType_dataSetOffset", 0);
 	if (svp != NULL)
-		out->dataSetOffset = XS_unpack_UA_UInt16(*svp);
+		unpack_UA_UInt16(&out->dataSetOffset, *svp);
 
-
+	return;
 }
 #endif
 
 /* UadpDataSetReaderMessageDataType */
 #ifdef UA_TYPES_UADPDATASETREADERMESSAGEDATATYPE
-static void XS_pack_UA_UadpDataSetReaderMessageDataType(SV *out, UA_UadpDataSetReaderMessageDataType in)  __attribute__((unused));
-static UA_UadpDataSetReaderMessageDataType XS_unpack_UA_UadpDataSetReaderMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_UadpDataSetReaderMessageDataType(SV *out, UA_UadpDataSetReaderMessageDataType *in);
 static void unpack_UA_UadpDataSetReaderMessageDataType(UA_UadpDataSetReaderMessageDataType *out, SV *in);
 
@@ -2355,105 +2215,105 @@ pack_UA_UadpDataSetReaderMessageDataType(SV *out, UA_UadpDataSetReaderMessageDat
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->groupVersion);
-	hv_stores(hv, "UadpDataSetReaderMessageDataType_groupVersion", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt16(sv, in->networkMessageNumber);
-	hv_stores(hv, "UadpDataSetReaderMessageDataType_networkMessageNumber", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt16(sv, in->dataSetOffset);
-	hv_stores(hv, "UadpDataSetReaderMessageDataType_dataSetOffset", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Guid(sv, in->dataSetClassId);
-	hv_stores(hv, "UadpDataSetReaderMessageDataType_dataSetClassId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UadpNetworkMessageContentMask(sv, in->networkMessageContentMask);
-	hv_stores(hv, "UadpDataSetReaderMessageDataType_networkMessageContentMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UadpDataSetMessageContentMask(sv, in->dataSetMessageContentMask);
-	hv_stores(hv, "UadpDataSetReaderMessageDataType_dataSetMessageContentMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->publishingInterval);
-	hv_stores(hv, "UadpDataSetReaderMessageDataType_publishingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->receiveOffset);
-	hv_stores(hv, "UadpDataSetReaderMessageDataType_receiveOffset", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->processingOffset);
-	hv_stores(hv, "UadpDataSetReaderMessageDataType_processingOffset", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetReaderMessageDataType_groupVersion", sv);
+	pack_UA_UInt32(sv, &in->groupVersion);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetReaderMessageDataType_networkMessageNumber", sv);
+	pack_UA_UInt16(sv, &in->networkMessageNumber);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetReaderMessageDataType_dataSetOffset", sv);
+	pack_UA_UInt16(sv, &in->dataSetOffset);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetReaderMessageDataType_dataSetClassId", sv);
+	pack_UA_Guid(sv, &in->dataSetClassId);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetReaderMessageDataType_networkMessageContentMask", sv);
+	pack_UA_UadpNetworkMessageContentMask(sv, &in->networkMessageContentMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetReaderMessageDataType_dataSetMessageContentMask", sv);
+	pack_UA_UadpDataSetMessageContentMask(sv, &in->dataSetMessageContentMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetReaderMessageDataType_publishingInterval", sv);
+	pack_UA_Double(sv, &in->publishingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetReaderMessageDataType_receiveOffset", sv);
+	pack_UA_Double(sv, &in->receiveOffset);
+
+	sv = newSV(0);
+	hv_stores(hv, "UadpDataSetReaderMessageDataType_processingOffset", sv);
+	pack_UA_Double(sv, &in->processingOffset);
+
+	return;
 }
 
 static void
 unpack_UA_UadpDataSetReaderMessageDataType(UA_UadpDataSetReaderMessageDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UadpDataSetReaderMessageDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UadpDataSetReaderMessageDataType_groupVersion", 0);
 	if (svp != NULL)
-		out->groupVersion = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->groupVersion, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetReaderMessageDataType_networkMessageNumber", 0);
 	if (svp != NULL)
-		out->networkMessageNumber = XS_unpack_UA_UInt16(*svp);
+		unpack_UA_UInt16(&out->networkMessageNumber, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetReaderMessageDataType_dataSetOffset", 0);
 	if (svp != NULL)
-		out->dataSetOffset = XS_unpack_UA_UInt16(*svp);
+		unpack_UA_UInt16(&out->dataSetOffset, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetReaderMessageDataType_dataSetClassId", 0);
 	if (svp != NULL)
-		out->dataSetClassId = XS_unpack_UA_Guid(*svp);
+		unpack_UA_Guid(&out->dataSetClassId, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetReaderMessageDataType_networkMessageContentMask", 0);
 	if (svp != NULL)
-		out->networkMessageContentMask = XS_unpack_UA_UadpNetworkMessageContentMask(*svp);
+		unpack_UA_UadpNetworkMessageContentMask(&out->networkMessageContentMask, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetReaderMessageDataType_dataSetMessageContentMask", 0);
 	if (svp != NULL)
-		out->dataSetMessageContentMask = XS_unpack_UA_UadpDataSetMessageContentMask(*svp);
+		unpack_UA_UadpDataSetMessageContentMask(&out->dataSetMessageContentMask, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetReaderMessageDataType_publishingInterval", 0);
 	if (svp != NULL)
-		out->publishingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->publishingInterval, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetReaderMessageDataType_receiveOffset", 0);
 	if (svp != NULL)
-		out->receiveOffset = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->receiveOffset, *svp);
 
 	svp = hv_fetchs(hv, "UadpDataSetReaderMessageDataType_processingOffset", 0);
 	if (svp != NULL)
-		out->processingOffset = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->processingOffset, *svp);
 
-
+	return;
 }
 #endif
 
 /* JsonNetworkMessageContentMask */
 #ifdef UA_TYPES_JSONNETWORKMESSAGECONTENTMASK
-static void XS_pack_UA_JsonNetworkMessageContentMask(SV *out, UA_JsonNetworkMessageContentMask in)  __attribute__((unused));
-static UA_JsonNetworkMessageContentMask XS_unpack_UA_JsonNetworkMessageContentMask(SV *in)  __attribute__((unused));
 static void pack_UA_JsonNetworkMessageContentMask(SV *out, UA_JsonNetworkMessageContentMask *in);
 static void unpack_UA_JsonNetworkMessageContentMask(UA_JsonNetworkMessageContentMask *out, SV *in);
 
@@ -2474,8 +2334,6 @@ unpack_UA_JsonNetworkMessageContentMask(UA_JsonNetworkMessageContentMask *out, S
 
 /* JsonWriterGroupMessageDataType */
 #ifdef UA_TYPES_JSONWRITERGROUPMESSAGEDATATYPE
-static void XS_pack_UA_JsonWriterGroupMessageDataType(SV *out, UA_JsonWriterGroupMessageDataType in)  __attribute__((unused));
-static UA_JsonWriterGroupMessageDataType XS_unpack_UA_JsonWriterGroupMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_JsonWriterGroupMessageDataType(SV *out, UA_JsonWriterGroupMessageDataType *in);
 static void unpack_UA_JsonWriterGroupMessageDataType(UA_JsonWriterGroupMessageDataType *out, SV *in);
 
@@ -2484,41 +2342,41 @@ pack_UA_JsonWriterGroupMessageDataType(SV *out, UA_JsonWriterGroupMessageDataTyp
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_JsonNetworkMessageContentMask(sv, in->networkMessageContentMask);
 	hv_stores(hv, "JsonWriterGroupMessageDataType_networkMessageContentMask", sv);
+	pack_UA_JsonNetworkMessageContentMask(sv, &in->networkMessageContentMask);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_JsonWriterGroupMessageDataType(UA_JsonWriterGroupMessageDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_JsonWriterGroupMessageDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "JsonWriterGroupMessageDataType_networkMessageContentMask", 0);
 	if (svp != NULL)
-		out->networkMessageContentMask = XS_unpack_UA_JsonNetworkMessageContentMask(*svp);
+		unpack_UA_JsonNetworkMessageContentMask(&out->networkMessageContentMask, *svp);
 
-
+	return;
 }
 #endif
 
 /* JsonDataSetMessageContentMask */
 #ifdef UA_TYPES_JSONDATASETMESSAGECONTENTMASK
-static void XS_pack_UA_JsonDataSetMessageContentMask(SV *out, UA_JsonDataSetMessageContentMask in)  __attribute__((unused));
-static UA_JsonDataSetMessageContentMask XS_unpack_UA_JsonDataSetMessageContentMask(SV *in)  __attribute__((unused));
 static void pack_UA_JsonDataSetMessageContentMask(SV *out, UA_JsonDataSetMessageContentMask *in);
 static void unpack_UA_JsonDataSetMessageContentMask(UA_JsonDataSetMessageContentMask *out, SV *in);
 
@@ -2539,8 +2397,6 @@ unpack_UA_JsonDataSetMessageContentMask(UA_JsonDataSetMessageContentMask *out, S
 
 /* JsonDataSetWriterMessageDataType */
 #ifdef UA_TYPES_JSONDATASETWRITERMESSAGEDATATYPE
-static void XS_pack_UA_JsonDataSetWriterMessageDataType(SV *out, UA_JsonDataSetWriterMessageDataType in)  __attribute__((unused));
-static UA_JsonDataSetWriterMessageDataType XS_unpack_UA_JsonDataSetWriterMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_JsonDataSetWriterMessageDataType(SV *out, UA_JsonDataSetWriterMessageDataType *in);
 static void unpack_UA_JsonDataSetWriterMessageDataType(UA_JsonDataSetWriterMessageDataType *out, SV *in);
 
@@ -2549,41 +2405,41 @@ pack_UA_JsonDataSetWriterMessageDataType(SV *out, UA_JsonDataSetWriterMessageDat
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_JsonDataSetMessageContentMask(sv, in->dataSetMessageContentMask);
 	hv_stores(hv, "JsonDataSetWriterMessageDataType_dataSetMessageContentMask", sv);
+	pack_UA_JsonDataSetMessageContentMask(sv, &in->dataSetMessageContentMask);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_JsonDataSetWriterMessageDataType(UA_JsonDataSetWriterMessageDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_JsonDataSetWriterMessageDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "JsonDataSetWriterMessageDataType_dataSetMessageContentMask", 0);
 	if (svp != NULL)
-		out->dataSetMessageContentMask = XS_unpack_UA_JsonDataSetMessageContentMask(*svp);
+		unpack_UA_JsonDataSetMessageContentMask(&out->dataSetMessageContentMask, *svp);
 
-
+	return;
 }
 #endif
 
 /* JsonDataSetReaderMessageDataType */
 #ifdef UA_TYPES_JSONDATASETREADERMESSAGEDATATYPE
-static void XS_pack_UA_JsonDataSetReaderMessageDataType(SV *out, UA_JsonDataSetReaderMessageDataType in)  __attribute__((unused));
-static UA_JsonDataSetReaderMessageDataType XS_unpack_UA_JsonDataSetReaderMessageDataType(SV *in)  __attribute__((unused));
 static void pack_UA_JsonDataSetReaderMessageDataType(SV *out, UA_JsonDataSetReaderMessageDataType *in);
 static void unpack_UA_JsonDataSetReaderMessageDataType(UA_JsonDataSetReaderMessageDataType *out, SV *in);
 
@@ -2592,49 +2448,49 @@ pack_UA_JsonDataSetReaderMessageDataType(SV *out, UA_JsonDataSetReaderMessageDat
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_JsonNetworkMessageContentMask(sv, in->networkMessageContentMask);
-	hv_stores(hv, "JsonDataSetReaderMessageDataType_networkMessageContentMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_JsonDataSetMessageContentMask(sv, in->dataSetMessageContentMask);
-	hv_stores(hv, "JsonDataSetReaderMessageDataType_dataSetMessageContentMask", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "JsonDataSetReaderMessageDataType_networkMessageContentMask", sv);
+	pack_UA_JsonNetworkMessageContentMask(sv, &in->networkMessageContentMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "JsonDataSetReaderMessageDataType_dataSetMessageContentMask", sv);
+	pack_UA_JsonDataSetMessageContentMask(sv, &in->dataSetMessageContentMask);
+
+	return;
 }
 
 static void
 unpack_UA_JsonDataSetReaderMessageDataType(UA_JsonDataSetReaderMessageDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_JsonDataSetReaderMessageDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "JsonDataSetReaderMessageDataType_networkMessageContentMask", 0);
 	if (svp != NULL)
-		out->networkMessageContentMask = XS_unpack_UA_JsonNetworkMessageContentMask(*svp);
+		unpack_UA_JsonNetworkMessageContentMask(&out->networkMessageContentMask, *svp);
 
 	svp = hv_fetchs(hv, "JsonDataSetReaderMessageDataType_dataSetMessageContentMask", 0);
 	if (svp != NULL)
-		out->dataSetMessageContentMask = XS_unpack_UA_JsonDataSetMessageContentMask(*svp);
+		unpack_UA_JsonDataSetMessageContentMask(&out->dataSetMessageContentMask, *svp);
 
-
+	return;
 }
 #endif
 
 /* DatagramConnectionTransportDataType */
 #ifdef UA_TYPES_DATAGRAMCONNECTIONTRANSPORTDATATYPE
-static void XS_pack_UA_DatagramConnectionTransportDataType(SV *out, UA_DatagramConnectionTransportDataType in)  __attribute__((unused));
-static UA_DatagramConnectionTransportDataType XS_unpack_UA_DatagramConnectionTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DatagramConnectionTransportDataType(SV *out, UA_DatagramConnectionTransportDataType *in);
 static void unpack_UA_DatagramConnectionTransportDataType(UA_DatagramConnectionTransportDataType *out, SV *in);
 
@@ -2643,41 +2499,41 @@ pack_UA_DatagramConnectionTransportDataType(SV *out, UA_DatagramConnectionTransp
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->discoveryAddress);
 	hv_stores(hv, "DatagramConnectionTransportDataType_discoveryAddress", sv);
+	pack_UA_ExtensionObject(sv, &in->discoveryAddress);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DatagramConnectionTransportDataType(UA_DatagramConnectionTransportDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DatagramConnectionTransportDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DatagramConnectionTransportDataType_discoveryAddress", 0);
 	if (svp != NULL)
-		out->discoveryAddress = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->discoveryAddress, *svp);
 
-
+	return;
 }
 #endif
 
 /* DatagramWriterGroupTransportDataType */
 #ifdef UA_TYPES_DATAGRAMWRITERGROUPTRANSPORTDATATYPE
-static void XS_pack_UA_DatagramWriterGroupTransportDataType(SV *out, UA_DatagramWriterGroupTransportDataType in)  __attribute__((unused));
-static UA_DatagramWriterGroupTransportDataType XS_unpack_UA_DatagramWriterGroupTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DatagramWriterGroupTransportDataType(SV *out, UA_DatagramWriterGroupTransportDataType *in);
 static void unpack_UA_DatagramWriterGroupTransportDataType(UA_DatagramWriterGroupTransportDataType *out, SV *in);
 
@@ -2686,49 +2542,49 @@ pack_UA_DatagramWriterGroupTransportDataType(SV *out, UA_DatagramWriterGroupTran
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->messageRepeatCount);
-	hv_stores(hv, "DatagramWriterGroupTransportDataType_messageRepeatCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->messageRepeatDelay);
-	hv_stores(hv, "DatagramWriterGroupTransportDataType_messageRepeatDelay", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "DatagramWriterGroupTransportDataType_messageRepeatCount", sv);
+	pack_UA_Byte(sv, &in->messageRepeatCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "DatagramWriterGroupTransportDataType_messageRepeatDelay", sv);
+	pack_UA_Double(sv, &in->messageRepeatDelay);
+
+	return;
 }
 
 static void
 unpack_UA_DatagramWriterGroupTransportDataType(UA_DatagramWriterGroupTransportDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DatagramWriterGroupTransportDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DatagramWriterGroupTransportDataType_messageRepeatCount", 0);
 	if (svp != NULL)
-		out->messageRepeatCount = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->messageRepeatCount, *svp);
 
 	svp = hv_fetchs(hv, "DatagramWriterGroupTransportDataType_messageRepeatDelay", 0);
 	if (svp != NULL)
-		out->messageRepeatDelay = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->messageRepeatDelay, *svp);
 
-
+	return;
 }
 #endif
 
 /* BrokerConnectionTransportDataType */
 #ifdef UA_TYPES_BROKERCONNECTIONTRANSPORTDATATYPE
-static void XS_pack_UA_BrokerConnectionTransportDataType(SV *out, UA_BrokerConnectionTransportDataType in)  __attribute__((unused));
-static UA_BrokerConnectionTransportDataType XS_unpack_UA_BrokerConnectionTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_BrokerConnectionTransportDataType(SV *out, UA_BrokerConnectionTransportDataType *in);
 static void unpack_UA_BrokerConnectionTransportDataType(UA_BrokerConnectionTransportDataType *out, SV *in);
 
@@ -2737,49 +2593,49 @@ pack_UA_BrokerConnectionTransportDataType(SV *out, UA_BrokerConnectionTransportD
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->resourceUri);
-	hv_stores(hv, "BrokerConnectionTransportDataType_resourceUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->authenticationProfileUri);
-	hv_stores(hv, "BrokerConnectionTransportDataType_authenticationProfileUri", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerConnectionTransportDataType_resourceUri", sv);
+	pack_UA_String(sv, &in->resourceUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerConnectionTransportDataType_authenticationProfileUri", sv);
+	pack_UA_String(sv, &in->authenticationProfileUri);
+
+	return;
 }
 
 static void
 unpack_UA_BrokerConnectionTransportDataType(UA_BrokerConnectionTransportDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrokerConnectionTransportDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrokerConnectionTransportDataType_resourceUri", 0);
 	if (svp != NULL)
-		out->resourceUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->resourceUri, *svp);
 
 	svp = hv_fetchs(hv, "BrokerConnectionTransportDataType_authenticationProfileUri", 0);
 	if (svp != NULL)
-		out->authenticationProfileUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->authenticationProfileUri, *svp);
 
-
+	return;
 }
 #endif
 
 /* BrokerTransportQualityOfService */
 #ifdef UA_TYPES_BROKERTRANSPORTQUALITYOFSERVICE
-static void XS_pack_UA_BrokerTransportQualityOfService(SV *out, UA_BrokerTransportQualityOfService in)  __attribute__((unused));
-static UA_BrokerTransportQualityOfService XS_unpack_UA_BrokerTransportQualityOfService(SV *in)  __attribute__((unused));
 static void pack_UA_BrokerTransportQualityOfService(SV *out, UA_BrokerTransportQualityOfService *in);
 static void unpack_UA_BrokerTransportQualityOfService(UA_BrokerTransportQualityOfService *out, SV *in);
 
@@ -2800,8 +2656,6 @@ unpack_UA_BrokerTransportQualityOfService(UA_BrokerTransportQualityOfService *ou
 
 /* BrokerWriterGroupTransportDataType */
 #ifdef UA_TYPES_BROKERWRITERGROUPTRANSPORTDATATYPE
-static void XS_pack_UA_BrokerWriterGroupTransportDataType(SV *out, UA_BrokerWriterGroupTransportDataType in)  __attribute__((unused));
-static UA_BrokerWriterGroupTransportDataType XS_unpack_UA_BrokerWriterGroupTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_BrokerWriterGroupTransportDataType(SV *out, UA_BrokerWriterGroupTransportDataType *in);
 static void unpack_UA_BrokerWriterGroupTransportDataType(UA_BrokerWriterGroupTransportDataType *out, SV *in);
 
@@ -2810,65 +2664,65 @@ pack_UA_BrokerWriterGroupTransportDataType(SV *out, UA_BrokerWriterGroupTranspor
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->queueName);
-	hv_stores(hv, "BrokerWriterGroupTransportDataType_queueName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->resourceUri);
-	hv_stores(hv, "BrokerWriterGroupTransportDataType_resourceUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->authenticationProfileUri);
-	hv_stores(hv, "BrokerWriterGroupTransportDataType_authenticationProfileUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_BrokerTransportQualityOfService(sv, in->requestedDeliveryGuarantee);
-	hv_stores(hv, "BrokerWriterGroupTransportDataType_requestedDeliveryGuarantee", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerWriterGroupTransportDataType_queueName", sv);
+	pack_UA_String(sv, &in->queueName);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerWriterGroupTransportDataType_resourceUri", sv);
+	pack_UA_String(sv, &in->resourceUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerWriterGroupTransportDataType_authenticationProfileUri", sv);
+	pack_UA_String(sv, &in->authenticationProfileUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerWriterGroupTransportDataType_requestedDeliveryGuarantee", sv);
+	pack_UA_BrokerTransportQualityOfService(sv, &in->requestedDeliveryGuarantee);
+
+	return;
 }
 
 static void
 unpack_UA_BrokerWriterGroupTransportDataType(UA_BrokerWriterGroupTransportDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrokerWriterGroupTransportDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrokerWriterGroupTransportDataType_queueName", 0);
 	if (svp != NULL)
-		out->queueName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->queueName, *svp);
 
 	svp = hv_fetchs(hv, "BrokerWriterGroupTransportDataType_resourceUri", 0);
 	if (svp != NULL)
-		out->resourceUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->resourceUri, *svp);
 
 	svp = hv_fetchs(hv, "BrokerWriterGroupTransportDataType_authenticationProfileUri", 0);
 	if (svp != NULL)
-		out->authenticationProfileUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->authenticationProfileUri, *svp);
 
 	svp = hv_fetchs(hv, "BrokerWriterGroupTransportDataType_requestedDeliveryGuarantee", 0);
 	if (svp != NULL)
-		out->requestedDeliveryGuarantee = XS_unpack_UA_BrokerTransportQualityOfService(*svp);
+		unpack_UA_BrokerTransportQualityOfService(&out->requestedDeliveryGuarantee, *svp);
 
-
+	return;
 }
 #endif
 
 /* BrokerDataSetWriterTransportDataType */
 #ifdef UA_TYPES_BROKERDATASETWRITERTRANSPORTDATATYPE
-static void XS_pack_UA_BrokerDataSetWriterTransportDataType(SV *out, UA_BrokerDataSetWriterTransportDataType in)  __attribute__((unused));
-static UA_BrokerDataSetWriterTransportDataType XS_unpack_UA_BrokerDataSetWriterTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_BrokerDataSetWriterTransportDataType(SV *out, UA_BrokerDataSetWriterTransportDataType *in);
 static void unpack_UA_BrokerDataSetWriterTransportDataType(UA_BrokerDataSetWriterTransportDataType *out, SV *in);
 
@@ -2877,81 +2731,81 @@ pack_UA_BrokerDataSetWriterTransportDataType(SV *out, UA_BrokerDataSetWriterTran
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->queueName);
-	hv_stores(hv, "BrokerDataSetWriterTransportDataType_queueName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->resourceUri);
-	hv_stores(hv, "BrokerDataSetWriterTransportDataType_resourceUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->authenticationProfileUri);
-	hv_stores(hv, "BrokerDataSetWriterTransportDataType_authenticationProfileUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_BrokerTransportQualityOfService(sv, in->requestedDeliveryGuarantee);
-	hv_stores(hv, "BrokerDataSetWriterTransportDataType_requestedDeliveryGuarantee", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->metaDataQueueName);
-	hv_stores(hv, "BrokerDataSetWriterTransportDataType_metaDataQueueName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->metaDataUpdateTime);
-	hv_stores(hv, "BrokerDataSetWriterTransportDataType_metaDataUpdateTime", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetWriterTransportDataType_queueName", sv);
+	pack_UA_String(sv, &in->queueName);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetWriterTransportDataType_resourceUri", sv);
+	pack_UA_String(sv, &in->resourceUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetWriterTransportDataType_authenticationProfileUri", sv);
+	pack_UA_String(sv, &in->authenticationProfileUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetWriterTransportDataType_requestedDeliveryGuarantee", sv);
+	pack_UA_BrokerTransportQualityOfService(sv, &in->requestedDeliveryGuarantee);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetWriterTransportDataType_metaDataQueueName", sv);
+	pack_UA_String(sv, &in->metaDataQueueName);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetWriterTransportDataType_metaDataUpdateTime", sv);
+	pack_UA_Double(sv, &in->metaDataUpdateTime);
+
+	return;
 }
 
 static void
 unpack_UA_BrokerDataSetWriterTransportDataType(UA_BrokerDataSetWriterTransportDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrokerDataSetWriterTransportDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrokerDataSetWriterTransportDataType_queueName", 0);
 	if (svp != NULL)
-		out->queueName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->queueName, *svp);
 
 	svp = hv_fetchs(hv, "BrokerDataSetWriterTransportDataType_resourceUri", 0);
 	if (svp != NULL)
-		out->resourceUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->resourceUri, *svp);
 
 	svp = hv_fetchs(hv, "BrokerDataSetWriterTransportDataType_authenticationProfileUri", 0);
 	if (svp != NULL)
-		out->authenticationProfileUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->authenticationProfileUri, *svp);
 
 	svp = hv_fetchs(hv, "BrokerDataSetWriterTransportDataType_requestedDeliveryGuarantee", 0);
 	if (svp != NULL)
-		out->requestedDeliveryGuarantee = XS_unpack_UA_BrokerTransportQualityOfService(*svp);
+		unpack_UA_BrokerTransportQualityOfService(&out->requestedDeliveryGuarantee, *svp);
 
 	svp = hv_fetchs(hv, "BrokerDataSetWriterTransportDataType_metaDataQueueName", 0);
 	if (svp != NULL)
-		out->metaDataQueueName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->metaDataQueueName, *svp);
 
 	svp = hv_fetchs(hv, "BrokerDataSetWriterTransportDataType_metaDataUpdateTime", 0);
 	if (svp != NULL)
-		out->metaDataUpdateTime = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->metaDataUpdateTime, *svp);
 
-
+	return;
 }
 #endif
 
 /* BrokerDataSetReaderTransportDataType */
 #ifdef UA_TYPES_BROKERDATASETREADERTRANSPORTDATATYPE
-static void XS_pack_UA_BrokerDataSetReaderTransportDataType(SV *out, UA_BrokerDataSetReaderTransportDataType in)  __attribute__((unused));
-static UA_BrokerDataSetReaderTransportDataType XS_unpack_UA_BrokerDataSetReaderTransportDataType(SV *in)  __attribute__((unused));
 static void pack_UA_BrokerDataSetReaderTransportDataType(SV *out, UA_BrokerDataSetReaderTransportDataType *in);
 static void unpack_UA_BrokerDataSetReaderTransportDataType(UA_BrokerDataSetReaderTransportDataType *out, SV *in);
 
@@ -2960,73 +2814,73 @@ pack_UA_BrokerDataSetReaderTransportDataType(SV *out, UA_BrokerDataSetReaderTran
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->queueName);
-	hv_stores(hv, "BrokerDataSetReaderTransportDataType_queueName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->resourceUri);
-	hv_stores(hv, "BrokerDataSetReaderTransportDataType_resourceUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->authenticationProfileUri);
-	hv_stores(hv, "BrokerDataSetReaderTransportDataType_authenticationProfileUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_BrokerTransportQualityOfService(sv, in->requestedDeliveryGuarantee);
-	hv_stores(hv, "BrokerDataSetReaderTransportDataType_requestedDeliveryGuarantee", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->metaDataQueueName);
-	hv_stores(hv, "BrokerDataSetReaderTransportDataType_metaDataQueueName", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetReaderTransportDataType_queueName", sv);
+	pack_UA_String(sv, &in->queueName);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetReaderTransportDataType_resourceUri", sv);
+	pack_UA_String(sv, &in->resourceUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetReaderTransportDataType_authenticationProfileUri", sv);
+	pack_UA_String(sv, &in->authenticationProfileUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetReaderTransportDataType_requestedDeliveryGuarantee", sv);
+	pack_UA_BrokerTransportQualityOfService(sv, &in->requestedDeliveryGuarantee);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrokerDataSetReaderTransportDataType_metaDataQueueName", sv);
+	pack_UA_String(sv, &in->metaDataQueueName);
+
+	return;
 }
 
 static void
 unpack_UA_BrokerDataSetReaderTransportDataType(UA_BrokerDataSetReaderTransportDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrokerDataSetReaderTransportDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrokerDataSetReaderTransportDataType_queueName", 0);
 	if (svp != NULL)
-		out->queueName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->queueName, *svp);
 
 	svp = hv_fetchs(hv, "BrokerDataSetReaderTransportDataType_resourceUri", 0);
 	if (svp != NULL)
-		out->resourceUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->resourceUri, *svp);
 
 	svp = hv_fetchs(hv, "BrokerDataSetReaderTransportDataType_authenticationProfileUri", 0);
 	if (svp != NULL)
-		out->authenticationProfileUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->authenticationProfileUri, *svp);
 
 	svp = hv_fetchs(hv, "BrokerDataSetReaderTransportDataType_requestedDeliveryGuarantee", 0);
 	if (svp != NULL)
-		out->requestedDeliveryGuarantee = XS_unpack_UA_BrokerTransportQualityOfService(*svp);
+		unpack_UA_BrokerTransportQualityOfService(&out->requestedDeliveryGuarantee, *svp);
 
 	svp = hv_fetchs(hv, "BrokerDataSetReaderTransportDataType_metaDataQueueName", 0);
 	if (svp != NULL)
-		out->metaDataQueueName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->metaDataQueueName, *svp);
 
-
+	return;
 }
 #endif
 
 /* DiagnosticsLevel */
 #ifdef UA_TYPES_DIAGNOSTICSLEVEL
-static void XS_pack_UA_DiagnosticsLevel(SV *out, UA_DiagnosticsLevel in)  __attribute__((unused));
-static UA_DiagnosticsLevel XS_unpack_UA_DiagnosticsLevel(SV *in)  __attribute__((unused));
 static void pack_UA_DiagnosticsLevel(SV *out, UA_DiagnosticsLevel *in);
 static void unpack_UA_DiagnosticsLevel(UA_DiagnosticsLevel *out, SV *in);
 
@@ -3047,8 +2901,6 @@ unpack_UA_DiagnosticsLevel(UA_DiagnosticsLevel *out, SV *in)
 
 /* PubSubDiagnosticsCounterClassification */
 #ifdef UA_TYPES_PUBSUBDIAGNOSTICSCOUNTERCLASSIFICATION
-static void XS_pack_UA_PubSubDiagnosticsCounterClassification(SV *out, UA_PubSubDiagnosticsCounterClassification in)  __attribute__((unused));
-static UA_PubSubDiagnosticsCounterClassification XS_unpack_UA_PubSubDiagnosticsCounterClassification(SV *in)  __attribute__((unused));
 static void pack_UA_PubSubDiagnosticsCounterClassification(SV *out, UA_PubSubDiagnosticsCounterClassification *in);
 static void unpack_UA_PubSubDiagnosticsCounterClassification(UA_PubSubDiagnosticsCounterClassification *out, SV *in);
 
@@ -3069,8 +2921,6 @@ unpack_UA_PubSubDiagnosticsCounterClassification(UA_PubSubDiagnosticsCounterClas
 
 /* IdType */
 #ifdef UA_TYPES_IDTYPE
-static void XS_pack_UA_IdType(SV *out, UA_IdType in)  __attribute__((unused));
-static UA_IdType XS_unpack_UA_IdType(SV *in)  __attribute__((unused));
 static void pack_UA_IdType(SV *out, UA_IdType *in);
 static void unpack_UA_IdType(UA_IdType *out, SV *in);
 
@@ -3091,8 +2941,6 @@ unpack_UA_IdType(UA_IdType *out, SV *in)
 
 /* NodeClass */
 #ifdef UA_TYPES_NODECLASS
-static void XS_pack_UA_NodeClass(SV *out, UA_NodeClass in)  __attribute__((unused));
-static UA_NodeClass XS_unpack_UA_NodeClass(SV *in)  __attribute__((unused));
 static void pack_UA_NodeClass(SV *out, UA_NodeClass *in);
 static void unpack_UA_NodeClass(UA_NodeClass *out, SV *in);
 
@@ -3113,8 +2961,6 @@ unpack_UA_NodeClass(UA_NodeClass *out, SV *in)
 
 /* PermissionType */
 #ifdef UA_TYPES_PERMISSIONTYPE
-static void XS_pack_UA_PermissionType(SV *out, UA_PermissionType in)  __attribute__((unused));
-static UA_PermissionType XS_unpack_UA_PermissionType(SV *in)  __attribute__((unused));
 static void pack_UA_PermissionType(SV *out, UA_PermissionType *in);
 static void unpack_UA_PermissionType(UA_PermissionType *out, SV *in);
 
@@ -3135,8 +2981,6 @@ unpack_UA_PermissionType(UA_PermissionType *out, SV *in)
 
 /* AccessLevelType */
 #ifdef UA_TYPES_ACCESSLEVELTYPE
-static void XS_pack_UA_AccessLevelType(SV *out, UA_AccessLevelType in)  __attribute__((unused));
-static UA_AccessLevelType XS_unpack_UA_AccessLevelType(SV *in)  __attribute__((unused));
 static void pack_UA_AccessLevelType(SV *out, UA_AccessLevelType *in);
 static void unpack_UA_AccessLevelType(UA_AccessLevelType *out, SV *in);
 
@@ -3157,8 +3001,6 @@ unpack_UA_AccessLevelType(UA_AccessLevelType *out, SV *in)
 
 /* AccessLevelExType */
 #ifdef UA_TYPES_ACCESSLEVELEXTYPE
-static void XS_pack_UA_AccessLevelExType(SV *out, UA_AccessLevelExType in)  __attribute__((unused));
-static UA_AccessLevelExType XS_unpack_UA_AccessLevelExType(SV *in)  __attribute__((unused));
 static void pack_UA_AccessLevelExType(SV *out, UA_AccessLevelExType *in);
 static void unpack_UA_AccessLevelExType(UA_AccessLevelExType *out, SV *in);
 
@@ -3179,8 +3021,6 @@ unpack_UA_AccessLevelExType(UA_AccessLevelExType *out, SV *in)
 
 /* EventNotifierType */
 #ifdef UA_TYPES_EVENTNOTIFIERTYPE
-static void XS_pack_UA_EventNotifierType(SV *out, UA_EventNotifierType in)  __attribute__((unused));
-static UA_EventNotifierType XS_unpack_UA_EventNotifierType(SV *in)  __attribute__((unused));
 static void pack_UA_EventNotifierType(SV *out, UA_EventNotifierType *in);
 static void unpack_UA_EventNotifierType(UA_EventNotifierType *out, SV *in);
 
@@ -3201,8 +3041,6 @@ unpack_UA_EventNotifierType(UA_EventNotifierType *out, SV *in)
 
 /* AccessRestrictionType */
 #ifdef UA_TYPES_ACCESSRESTRICTIONTYPE
-static void XS_pack_UA_AccessRestrictionType(SV *out, UA_AccessRestrictionType in)  __attribute__((unused));
-static UA_AccessRestrictionType XS_unpack_UA_AccessRestrictionType(SV *in)  __attribute__((unused));
 static void pack_UA_AccessRestrictionType(SV *out, UA_AccessRestrictionType *in);
 static void unpack_UA_AccessRestrictionType(UA_AccessRestrictionType *out, SV *in);
 
@@ -3223,8 +3061,6 @@ unpack_UA_AccessRestrictionType(UA_AccessRestrictionType *out, SV *in)
 
 /* RolePermissionType */
 #ifdef UA_TYPES_ROLEPERMISSIONTYPE
-static void XS_pack_UA_RolePermissionType(SV *out, UA_RolePermissionType in)  __attribute__((unused));
-static UA_RolePermissionType XS_unpack_UA_RolePermissionType(SV *in)  __attribute__((unused));
 static void pack_UA_RolePermissionType(SV *out, UA_RolePermissionType *in);
 static void unpack_UA_RolePermissionType(UA_RolePermissionType *out, SV *in);
 
@@ -3233,49 +3069,49 @@ pack_UA_RolePermissionType(SV *out, UA_RolePermissionType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->roleId);
-	hv_stores(hv, "RolePermissionType_roleId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_PermissionType(sv, in->permissions);
-	hv_stores(hv, "RolePermissionType_permissions", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "RolePermissionType_roleId", sv);
+	pack_UA_NodeId(sv, &in->roleId);
+
+	sv = newSV(0);
+	hv_stores(hv, "RolePermissionType_permissions", sv);
+	pack_UA_PermissionType(sv, &in->permissions);
+
+	return;
 }
 
 static void
 unpack_UA_RolePermissionType(UA_RolePermissionType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RolePermissionType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RolePermissionType_roleId", 0);
 	if (svp != NULL)
-		out->roleId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->roleId, *svp);
 
 	svp = hv_fetchs(hv, "RolePermissionType_permissions", 0);
 	if (svp != NULL)
-		out->permissions = XS_unpack_UA_PermissionType(*svp);
+		unpack_UA_PermissionType(&out->permissions, *svp);
 
-
+	return;
 }
 #endif
 
 /* StructureType */
 #ifdef UA_TYPES_STRUCTURETYPE
-static void XS_pack_UA_StructureType(SV *out, UA_StructureType in)  __attribute__((unused));
-static UA_StructureType XS_unpack_UA_StructureType(SV *in)  __attribute__((unused));
 static void pack_UA_StructureType(SV *out, UA_StructureType *in);
 static void unpack_UA_StructureType(UA_StructureType *out, SV *in);
 
@@ -3296,8 +3132,6 @@ unpack_UA_StructureType(UA_StructureType *out, SV *in)
 
 /* StructureField */
 #ifdef UA_TYPES_STRUCTUREFIELD
-static void XS_pack_UA_StructureField(SV *out, UA_StructureField in)  __attribute__((unused));
-static UA_StructureField XS_unpack_UA_StructureField(SV *in)  __attribute__((unused));
 static void pack_UA_StructureField(SV *out, UA_StructureField *in);
 static void unpack_UA_StructureField(UA_StructureField *out, SV *in);
 
@@ -3308,112 +3142,109 @@ pack_UA_StructureField(SV *out, UA_StructureField *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "StructureField_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
 	hv_stores(hv, "StructureField_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->dataType);
 	hv_stores(hv, "StructureField_dataType", sv);
+	pack_UA_NodeId(sv, &in->dataType);
 
 	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->valueRank);
 	hv_stores(hv, "StructureField_valueRank", sv);
+	pack_UA_Int32(sv, &in->valueRank);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "StructureField_arrayDimensions", newRV_noinc((SV*)av));
 	av_extend(av, in->arrayDimensionsSize);
 	for (i = 0; i < in->arrayDimensionsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->arrayDimensions[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->arrayDimensions[i]);
 	}
-	hv_stores(hv, "StructureField_arrayDimensions", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxStringLength);
 	hv_stores(hv, "StructureField_maxStringLength", sv);
+	pack_UA_UInt32(sv, &in->maxStringLength);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isOptional);
 	hv_stores(hv, "StructureField_isOptional", sv);
+	pack_UA_Boolean(sv, &in->isOptional);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_StructureField(UA_StructureField *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_StructureField_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "StructureField_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "StructureField_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "StructureField_dataType", 0);
 	if (svp != NULL)
-		out->dataType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->dataType, *svp);
 
 	svp = hv_fetchs(hv, "StructureField_valueRank", 0);
 	if (svp != NULL)
-		out->valueRank = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->valueRank, *svp);
 
 	svp = hv_fetchs(hv, "StructureField_arrayDimensions", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for StructureField_arrayDimensions");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->arrayDimensions = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->arrayDimensions == NULL) {
+		if (out->arrayDimensions == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->arrayDimensionsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->arrayDimensions[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->arrayDimensions[i], *svp);
 		}
-		out->arrayDimensionsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "StructureField_maxStringLength", 0);
 	if (svp != NULL)
-		out->maxStringLength = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxStringLength, *svp);
 
 	svp = hv_fetchs(hv, "StructureField_isOptional", 0);
 	if (svp != NULL)
-		out->isOptional = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isOptional, *svp);
 
-
+	return;
 }
 #endif
 
 /* StructureDefinition */
 #ifdef UA_TYPES_STRUCTUREDEFINITION
-static void XS_pack_UA_StructureDefinition(SV *out, UA_StructureDefinition in)  __attribute__((unused));
-static UA_StructureDefinition XS_unpack_UA_StructureDefinition(SV *in)  __attribute__((unused));
 static void pack_UA_StructureDefinition(SV *out, UA_StructureDefinition *in);
 static void unpack_UA_StructureDefinition(UA_StructureDefinition *out, SV *in);
 
@@ -3424,88 +3255,85 @@ pack_UA_StructureDefinition(SV *out, UA_StructureDefinition *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->defaultEncodingId);
 	hv_stores(hv, "StructureDefinition_defaultEncodingId", sv);
+	pack_UA_NodeId(sv, &in->defaultEncodingId);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->baseDataType);
 	hv_stores(hv, "StructureDefinition_baseDataType", sv);
+	pack_UA_NodeId(sv, &in->baseDataType);
 
 	sv = newSV(0);
-	XS_pack_UA_StructureType(sv, in->structureType);
 	hv_stores(hv, "StructureDefinition_structureType", sv);
+	pack_UA_StructureType(sv, &in->structureType);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "StructureDefinition_fields", newRV_noinc((SV*)av));
 	av_extend(av, in->fieldsSize);
 	for (i = 0; i < in->fieldsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StructureField(sv, in->fields[i]);
 		av_push(av, sv);
+		pack_UA_StructureField(sv, &in->fields[i]);
 	}
-	hv_stores(hv, "StructureDefinition_fields", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_StructureDefinition(UA_StructureDefinition *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_StructureDefinition_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "StructureDefinition_defaultEncodingId", 0);
 	if (svp != NULL)
-		out->defaultEncodingId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->defaultEncodingId, *svp);
 
 	svp = hv_fetchs(hv, "StructureDefinition_baseDataType", 0);
 	if (svp != NULL)
-		out->baseDataType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->baseDataType, *svp);
 
 	svp = hv_fetchs(hv, "StructureDefinition_structureType", 0);
 	if (svp != NULL)
-		out->structureType = XS_unpack_UA_StructureType(*svp);
+		unpack_UA_StructureType(&out->structureType, *svp);
 
 	svp = hv_fetchs(hv, "StructureDefinition_fields", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for StructureDefinition_fields");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->fields = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRUCTUREFIELD]);
-		if (out->fields == NULL) {
+		if (out->fields == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->fieldsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->fields[i] = XS_unpack_UA_StructureField(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StructureField(&out->fields[i], *svp);
 		}
-		out->fieldsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ReferenceNode */
 #ifdef UA_TYPES_REFERENCENODE
-static void XS_pack_UA_ReferenceNode(SV *out, UA_ReferenceNode in)  __attribute__((unused));
-static UA_ReferenceNode XS_unpack_UA_ReferenceNode(SV *in)  __attribute__((unused));
 static void pack_UA_ReferenceNode(SV *out, UA_ReferenceNode *in);
 static void unpack_UA_ReferenceNode(UA_ReferenceNode *out, SV *in);
 
@@ -3514,57 +3342,57 @@ pack_UA_ReferenceNode(SV *out, UA_ReferenceNode *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->referenceTypeId);
-	hv_stores(hv, "ReferenceNode_referenceTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isInverse);
-	hv_stores(hv, "ReferenceNode_isInverse", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->targetId);
-	hv_stores(hv, "ReferenceNode_targetId", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceNode_referenceTypeId", sv);
+	pack_UA_NodeId(sv, &in->referenceTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceNode_isInverse", sv);
+	pack_UA_Boolean(sv, &in->isInverse);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceNode_targetId", sv);
+	pack_UA_ExpandedNodeId(sv, &in->targetId);
+
+	return;
 }
 
 static void
 unpack_UA_ReferenceNode(UA_ReferenceNode *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReferenceNode_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReferenceNode_referenceTypeId", 0);
 	if (svp != NULL)
-		out->referenceTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->referenceTypeId, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceNode_isInverse", 0);
 	if (svp != NULL)
-		out->isInverse = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isInverse, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceNode_targetId", 0);
 	if (svp != NULL)
-		out->targetId = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->targetId, *svp);
 
-
+	return;
 }
 #endif
 
 /* Argument */
 #ifdef UA_TYPES_ARGUMENT
-static void XS_pack_UA_Argument(SV *out, UA_Argument in)  __attribute__((unused));
-static UA_Argument XS_unpack_UA_Argument(SV *in)  __attribute__((unused));
 static void pack_UA_Argument(SV *out, UA_Argument *in);
 static void unpack_UA_Argument(UA_Argument *out, SV *in);
 
@@ -3575,96 +3403,93 @@ pack_UA_Argument(SV *out, UA_Argument *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "Argument_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->dataType);
 	hv_stores(hv, "Argument_dataType", sv);
+	pack_UA_NodeId(sv, &in->dataType);
 
 	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->valueRank);
 	hv_stores(hv, "Argument_valueRank", sv);
+	pack_UA_Int32(sv, &in->valueRank);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "Argument_arrayDimensions", newRV_noinc((SV*)av));
 	av_extend(av, in->arrayDimensionsSize);
 	for (i = 0; i < in->arrayDimensionsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->arrayDimensions[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->arrayDimensions[i]);
 	}
-	hv_stores(hv, "Argument_arrayDimensions", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
 	hv_stores(hv, "Argument_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_Argument(UA_Argument *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_Argument_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "Argument_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "Argument_dataType", 0);
 	if (svp != NULL)
-		out->dataType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->dataType, *svp);
 
 	svp = hv_fetchs(hv, "Argument_valueRank", 0);
 	if (svp != NULL)
-		out->valueRank = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->valueRank, *svp);
 
 	svp = hv_fetchs(hv, "Argument_arrayDimensions", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for Argument_arrayDimensions");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->arrayDimensions = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->arrayDimensions == NULL) {
+		if (out->arrayDimensions == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->arrayDimensionsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->arrayDimensions[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->arrayDimensions[i], *svp);
 		}
-		out->arrayDimensionsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "Argument_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
-
+	return;
 }
 #endif
 
 /* EnumValueType */
 #ifdef UA_TYPES_ENUMVALUETYPE
-static void XS_pack_UA_EnumValueType(SV *out, UA_EnumValueType in)  __attribute__((unused));
-static UA_EnumValueType XS_unpack_UA_EnumValueType(SV *in)  __attribute__((unused));
 static void pack_UA_EnumValueType(SV *out, UA_EnumValueType *in);
 static void unpack_UA_EnumValueType(UA_EnumValueType *out, SV *in);
 
@@ -3673,57 +3498,57 @@ pack_UA_EnumValueType(SV *out, UA_EnumValueType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Int64(sv, in->value);
-	hv_stores(hv, "EnumValueType_value", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "EnumValueType_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "EnumValueType_description", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumValueType_value", sv);
+	pack_UA_Int64(sv, &in->value);
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumValueType_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumValueType_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	return;
 }
 
 static void
 unpack_UA_EnumValueType(UA_EnumValueType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EnumValueType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EnumValueType_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_Int64(*svp);
+		unpack_UA_Int64(&out->value, *svp);
 
 	svp = hv_fetchs(hv, "EnumValueType_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "EnumValueType_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
-
+	return;
 }
 #endif
 
 /* EnumField */
 #ifdef UA_TYPES_ENUMFIELD
-static void XS_pack_UA_EnumField(SV *out, UA_EnumField in)  __attribute__((unused));
-static UA_EnumField XS_unpack_UA_EnumField(SV *in)  __attribute__((unused));
 static void pack_UA_EnumField(SV *out, UA_EnumField *in);
 static void unpack_UA_EnumField(UA_EnumField *out, SV *in);
 
@@ -3732,65 +3557,65 @@ pack_UA_EnumField(SV *out, UA_EnumField *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Int64(sv, in->value);
-	hv_stores(hv, "EnumField_value", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "EnumField_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "EnumField_description", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
-	hv_stores(hv, "EnumField_name", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumField_value", sv);
+	pack_UA_Int64(sv, &in->value);
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumField_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumField_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumField_name", sv);
+	pack_UA_String(sv, &in->name);
+
+	return;
 }
 
 static void
 unpack_UA_EnumField(UA_EnumField *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EnumField_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EnumField_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_Int64(*svp);
+		unpack_UA_Int64(&out->value, *svp);
 
 	svp = hv_fetchs(hv, "EnumField_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "EnumField_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "EnumField_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
-
+	return;
 }
 #endif
 
 /* OptionSet */
 #ifdef UA_TYPES_OPTIONSET
-static void XS_pack_UA_OptionSet(SV *out, UA_OptionSet in)  __attribute__((unused));
-static UA_OptionSet XS_unpack_UA_OptionSet(SV *in)  __attribute__((unused));
 static void pack_UA_OptionSet(SV *out, UA_OptionSet *in);
 static void unpack_UA_OptionSet(UA_OptionSet *out, SV *in);
 
@@ -3799,49 +3624,49 @@ pack_UA_OptionSet(SV *out, UA_OptionSet *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->value);
-	hv_stores(hv, "OptionSet_value", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->validBits);
-	hv_stores(hv, "OptionSet_validBits", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "OptionSet_value", sv);
+	pack_UA_ByteString(sv, &in->value);
+
+	sv = newSV(0);
+	hv_stores(hv, "OptionSet_validBits", sv);
+	pack_UA_ByteString(sv, &in->validBits);
+
+	return;
 }
 
 static void
 unpack_UA_OptionSet(UA_OptionSet *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_OptionSet_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "OptionSet_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->value, *svp);
 
 	svp = hv_fetchs(hv, "OptionSet_validBits", 0);
 	if (svp != NULL)
-		out->validBits = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->validBits, *svp);
 
-
+	return;
 }
 #endif
 
 /* Union */
 #ifdef UA_TYPES_UNION
-static void XS_pack_UA_Union(SV *out, UA_Union in)  __attribute__((unused));
-static UA_Union XS_unpack_UA_Union(SV *in)  __attribute__((unused));
 static void pack_UA_Union(SV *out, UA_Union *in);
 static void unpack_UA_Union(UA_Union *out, SV *in);
 
@@ -3862,8 +3687,6 @@ unpack_UA_Union(UA_Union *out, SV *in)
 
 /* NormalizedString */
 #ifdef UA_TYPES_NORMALIZEDSTRING
-static void XS_pack_UA_NormalizedString(SV *out, UA_NormalizedString in)  __attribute__((unused));
-static UA_NormalizedString XS_unpack_UA_NormalizedString(SV *in)  __attribute__((unused));
 static void pack_UA_NormalizedString(SV *out, UA_NormalizedString *in);
 static void unpack_UA_NormalizedString(UA_NormalizedString *out, SV *in);
 
@@ -3871,21 +3694,19 @@ static void
 pack_UA_NormalizedString(SV *out, UA_NormalizedString *in)
 {
 	dTHX;
-	XS_pack_UA_String(out, *in);
+	pack_UA_String(out, in);
 }
 
 static void
 unpack_UA_NormalizedString(UA_NormalizedString *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_String(in);
+	unpack_UA_String(out, in);
 }
 #endif
 
 /* DecimalString */
 #ifdef UA_TYPES_DECIMALSTRING
-static void XS_pack_UA_DecimalString(SV *out, UA_DecimalString in)  __attribute__((unused));
-static UA_DecimalString XS_unpack_UA_DecimalString(SV *in)  __attribute__((unused));
 static void pack_UA_DecimalString(SV *out, UA_DecimalString *in);
 static void unpack_UA_DecimalString(UA_DecimalString *out, SV *in);
 
@@ -3893,21 +3714,19 @@ static void
 pack_UA_DecimalString(SV *out, UA_DecimalString *in)
 {
 	dTHX;
-	XS_pack_UA_String(out, *in);
+	pack_UA_String(out, in);
 }
 
 static void
 unpack_UA_DecimalString(UA_DecimalString *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_String(in);
+	unpack_UA_String(out, in);
 }
 #endif
 
 /* DurationString */
 #ifdef UA_TYPES_DURATIONSTRING
-static void XS_pack_UA_DurationString(SV *out, UA_DurationString in)  __attribute__((unused));
-static UA_DurationString XS_unpack_UA_DurationString(SV *in)  __attribute__((unused));
 static void pack_UA_DurationString(SV *out, UA_DurationString *in);
 static void unpack_UA_DurationString(UA_DurationString *out, SV *in);
 
@@ -3915,21 +3734,19 @@ static void
 pack_UA_DurationString(SV *out, UA_DurationString *in)
 {
 	dTHX;
-	XS_pack_UA_String(out, *in);
+	pack_UA_String(out, in);
 }
 
 static void
 unpack_UA_DurationString(UA_DurationString *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_String(in);
+	unpack_UA_String(out, in);
 }
 #endif
 
 /* TimeString */
 #ifdef UA_TYPES_TIMESTRING
-static void XS_pack_UA_TimeString(SV *out, UA_TimeString in)  __attribute__((unused));
-static UA_TimeString XS_unpack_UA_TimeString(SV *in)  __attribute__((unused));
 static void pack_UA_TimeString(SV *out, UA_TimeString *in);
 static void unpack_UA_TimeString(UA_TimeString *out, SV *in);
 
@@ -3937,21 +3754,19 @@ static void
 pack_UA_TimeString(SV *out, UA_TimeString *in)
 {
 	dTHX;
-	XS_pack_UA_String(out, *in);
+	pack_UA_String(out, in);
 }
 
 static void
 unpack_UA_TimeString(UA_TimeString *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_String(in);
+	unpack_UA_String(out, in);
 }
 #endif
 
 /* DateString */
 #ifdef UA_TYPES_DATESTRING
-static void XS_pack_UA_DateString(SV *out, UA_DateString in)  __attribute__((unused));
-static UA_DateString XS_unpack_UA_DateString(SV *in)  __attribute__((unused));
 static void pack_UA_DateString(SV *out, UA_DateString *in);
 static void unpack_UA_DateString(UA_DateString *out, SV *in);
 
@@ -3959,21 +3774,19 @@ static void
 pack_UA_DateString(SV *out, UA_DateString *in)
 {
 	dTHX;
-	XS_pack_UA_String(out, *in);
+	pack_UA_String(out, in);
 }
 
 static void
 unpack_UA_DateString(UA_DateString *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_String(in);
+	unpack_UA_String(out, in);
 }
 #endif
 
 /* Duration */
 #ifdef UA_TYPES_DURATION
-static void XS_pack_UA_Duration(SV *out, UA_Duration in)  __attribute__((unused));
-static UA_Duration XS_unpack_UA_Duration(SV *in)  __attribute__((unused));
 static void pack_UA_Duration(SV *out, UA_Duration *in);
 static void unpack_UA_Duration(UA_Duration *out, SV *in);
 
@@ -3981,21 +3794,19 @@ static void
 pack_UA_Duration(SV *out, UA_Duration *in)
 {
 	dTHX;
-	XS_pack_UA_Double(out, *in);
+	pack_UA_Double(out, in);
 }
 
 static void
 unpack_UA_Duration(UA_Duration *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_Double(in);
+	unpack_UA_Double(out, in);
 }
 #endif
 
 /* UtcTime */
 #ifdef UA_TYPES_UTCTIME
-static void XS_pack_UA_UtcTime(SV *out, UA_UtcTime in)  __attribute__((unused));
-static UA_UtcTime XS_unpack_UA_UtcTime(SV *in)  __attribute__((unused));
 static void pack_UA_UtcTime(SV *out, UA_UtcTime *in);
 static void unpack_UA_UtcTime(UA_UtcTime *out, SV *in);
 
@@ -4003,21 +3814,19 @@ static void
 pack_UA_UtcTime(SV *out, UA_UtcTime *in)
 {
 	dTHX;
-	XS_pack_UA_DateTime(out, *in);
+	pack_UA_DateTime(out, in);
 }
 
 static void
 unpack_UA_UtcTime(UA_UtcTime *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_DateTime(in);
+	unpack_UA_DateTime(out, in);
 }
 #endif
 
 /* LocaleId */
 #ifdef UA_TYPES_LOCALEID
-static void XS_pack_UA_LocaleId(SV *out, UA_LocaleId in)  __attribute__((unused));
-static UA_LocaleId XS_unpack_UA_LocaleId(SV *in)  __attribute__((unused));
 static void pack_UA_LocaleId(SV *out, UA_LocaleId *in);
 static void unpack_UA_LocaleId(UA_LocaleId *out, SV *in);
 
@@ -4025,21 +3834,19 @@ static void
 pack_UA_LocaleId(SV *out, UA_LocaleId *in)
 {
 	dTHX;
-	XS_pack_UA_String(out, *in);
+	pack_UA_String(out, in);
 }
 
 static void
 unpack_UA_LocaleId(UA_LocaleId *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_String(in);
+	unpack_UA_String(out, in);
 }
 #endif
 
 /* TimeZoneDataType */
 #ifdef UA_TYPES_TIMEZONEDATATYPE
-static void XS_pack_UA_TimeZoneDataType(SV *out, UA_TimeZoneDataType in)  __attribute__((unused));
-static UA_TimeZoneDataType XS_unpack_UA_TimeZoneDataType(SV *in)  __attribute__((unused));
 static void pack_UA_TimeZoneDataType(SV *out, UA_TimeZoneDataType *in);
 static void unpack_UA_TimeZoneDataType(UA_TimeZoneDataType *out, SV *in);
 
@@ -4048,49 +3855,49 @@ pack_UA_TimeZoneDataType(SV *out, UA_TimeZoneDataType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Int16(sv, in->offset);
-	hv_stores(hv, "TimeZoneDataType_offset", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->daylightSavingInOffset);
-	hv_stores(hv, "TimeZoneDataType_daylightSavingInOffset", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "TimeZoneDataType_offset", sv);
+	pack_UA_Int16(sv, &in->offset);
+
+	sv = newSV(0);
+	hv_stores(hv, "TimeZoneDataType_daylightSavingInOffset", sv);
+	pack_UA_Boolean(sv, &in->daylightSavingInOffset);
+
+	return;
 }
 
 static void
 unpack_UA_TimeZoneDataType(UA_TimeZoneDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_TimeZoneDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "TimeZoneDataType_offset", 0);
 	if (svp != NULL)
-		out->offset = XS_unpack_UA_Int16(*svp);
+		unpack_UA_Int16(&out->offset, *svp);
 
 	svp = hv_fetchs(hv, "TimeZoneDataType_daylightSavingInOffset", 0);
 	if (svp != NULL)
-		out->daylightSavingInOffset = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->daylightSavingInOffset, *svp);
 
-
+	return;
 }
 #endif
 
 /* Index */
 #ifdef UA_TYPES_INDEX
-static void XS_pack_UA_Index(SV *out, UA_Index in)  __attribute__((unused));
-static UA_Index XS_unpack_UA_Index(SV *in)  __attribute__((unused));
 static void pack_UA_Index(SV *out, UA_Index *in);
 static void unpack_UA_Index(UA_Index *out, SV *in);
 
@@ -4098,21 +3905,19 @@ static void
 pack_UA_Index(SV *out, UA_Index *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_Index(UA_Index *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* IntegerId */
 #ifdef UA_TYPES_INTEGERID
-static void XS_pack_UA_IntegerId(SV *out, UA_IntegerId in)  __attribute__((unused));
-static UA_IntegerId XS_unpack_UA_IntegerId(SV *in)  __attribute__((unused));
 static void pack_UA_IntegerId(SV *out, UA_IntegerId *in);
 static void unpack_UA_IntegerId(UA_IntegerId *out, SV *in);
 
@@ -4120,21 +3925,19 @@ static void
 pack_UA_IntegerId(SV *out, UA_IntegerId *in)
 {
 	dTHX;
-	XS_pack_UA_UInt32(out, *in);
+	pack_UA_UInt32(out, in);
 }
 
 static void
 unpack_UA_IntegerId(UA_IntegerId *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_UInt32(in);
+	unpack_UA_UInt32(out, in);
 }
 #endif
 
 /* ApplicationType */
 #ifdef UA_TYPES_APPLICATIONTYPE
-static void XS_pack_UA_ApplicationType(SV *out, UA_ApplicationType in)  __attribute__((unused));
-static UA_ApplicationType XS_unpack_UA_ApplicationType(SV *in)  __attribute__((unused));
 static void pack_UA_ApplicationType(SV *out, UA_ApplicationType *in);
 static void unpack_UA_ApplicationType(UA_ApplicationType *out, SV *in);
 
@@ -4155,8 +3958,6 @@ unpack_UA_ApplicationType(UA_ApplicationType *out, SV *in)
 
 /* ApplicationDescription */
 #ifdef UA_TYPES_APPLICATIONDESCRIPTION
-static void XS_pack_UA_ApplicationDescription(SV *out, UA_ApplicationDescription in)  __attribute__((unused));
-static UA_ApplicationDescription XS_unpack_UA_ApplicationDescription(SV *in)  __attribute__((unused));
 static void pack_UA_ApplicationDescription(SV *out, UA_ApplicationDescription *in);
 static void unpack_UA_ApplicationDescription(UA_ApplicationDescription *out, SV *in);
 
@@ -4167,112 +3968,109 @@ pack_UA_ApplicationDescription(SV *out, UA_ApplicationDescription *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->applicationUri);
 	hv_stores(hv, "ApplicationDescription_applicationUri", sv);
+	pack_UA_String(sv, &in->applicationUri);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->productUri);
 	hv_stores(hv, "ApplicationDescription_productUri", sv);
+	pack_UA_String(sv, &in->productUri);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->applicationName);
 	hv_stores(hv, "ApplicationDescription_applicationName", sv);
+	pack_UA_LocalizedText(sv, &in->applicationName);
 
 	sv = newSV(0);
-	XS_pack_UA_ApplicationType(sv, in->applicationType);
 	hv_stores(hv, "ApplicationDescription_applicationType", sv);
+	pack_UA_ApplicationType(sv, &in->applicationType);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->gatewayServerUri);
 	hv_stores(hv, "ApplicationDescription_gatewayServerUri", sv);
+	pack_UA_String(sv, &in->gatewayServerUri);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->discoveryProfileUri);
 	hv_stores(hv, "ApplicationDescription_discoveryProfileUri", sv);
+	pack_UA_String(sv, &in->discoveryProfileUri);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ApplicationDescription_discoveryUrls", newRV_noinc((SV*)av));
 	av_extend(av, in->discoveryUrlsSize);
 	for (i = 0; i < in->discoveryUrlsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->discoveryUrls[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->discoveryUrls[i]);
 	}
-	hv_stores(hv, "ApplicationDescription_discoveryUrls", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ApplicationDescription(UA_ApplicationDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ApplicationDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ApplicationDescription_applicationUri", 0);
 	if (svp != NULL)
-		out->applicationUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->applicationUri, *svp);
 
 	svp = hv_fetchs(hv, "ApplicationDescription_productUri", 0);
 	if (svp != NULL)
-		out->productUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->productUri, *svp);
 
 	svp = hv_fetchs(hv, "ApplicationDescription_applicationName", 0);
 	if (svp != NULL)
-		out->applicationName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->applicationName, *svp);
 
 	svp = hv_fetchs(hv, "ApplicationDescription_applicationType", 0);
 	if (svp != NULL)
-		out->applicationType = XS_unpack_UA_ApplicationType(*svp);
+		unpack_UA_ApplicationType(&out->applicationType, *svp);
 
 	svp = hv_fetchs(hv, "ApplicationDescription_gatewayServerUri", 0);
 	if (svp != NULL)
-		out->gatewayServerUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->gatewayServerUri, *svp);
 
 	svp = hv_fetchs(hv, "ApplicationDescription_discoveryProfileUri", 0);
 	if (svp != NULL)
-		out->discoveryProfileUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->discoveryProfileUri, *svp);
 
 	svp = hv_fetchs(hv, "ApplicationDescription_discoveryUrls", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ApplicationDescription_discoveryUrls");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->discoveryUrls = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->discoveryUrls == NULL) {
+		if (out->discoveryUrls == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->discoveryUrlsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->discoveryUrls[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->discoveryUrls[i], *svp);
 		}
-		out->discoveryUrlsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* RequestHeader */
 #ifdef UA_TYPES_REQUESTHEADER
-static void XS_pack_UA_RequestHeader(SV *out, UA_RequestHeader in)  __attribute__((unused));
-static UA_RequestHeader XS_unpack_UA_RequestHeader(SV *in)  __attribute__((unused));
 static void pack_UA_RequestHeader(SV *out, UA_RequestHeader *in);
 static void unpack_UA_RequestHeader(UA_RequestHeader *out, SV *in);
 
@@ -4281,89 +4079,89 @@ pack_UA_RequestHeader(SV *out, UA_RequestHeader *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->authenticationToken);
-	hv_stores(hv, "RequestHeader_authenticationToken", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->timestamp);
-	hv_stores(hv, "RequestHeader_timestamp", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->requestHandle);
-	hv_stores(hv, "RequestHeader_requestHandle", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->returnDiagnostics);
-	hv_stores(hv, "RequestHeader_returnDiagnostics", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->auditEntryId);
-	hv_stores(hv, "RequestHeader_auditEntryId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->timeoutHint);
-	hv_stores(hv, "RequestHeader_timeoutHint", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->additionalHeader);
-	hv_stores(hv, "RequestHeader_additionalHeader", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "RequestHeader_authenticationToken", sv);
+	pack_UA_NodeId(sv, &in->authenticationToken);
+
+	sv = newSV(0);
+	hv_stores(hv, "RequestHeader_timestamp", sv);
+	pack_UA_DateTime(sv, &in->timestamp);
+
+	sv = newSV(0);
+	hv_stores(hv, "RequestHeader_requestHandle", sv);
+	pack_UA_UInt32(sv, &in->requestHandle);
+
+	sv = newSV(0);
+	hv_stores(hv, "RequestHeader_returnDiagnostics", sv);
+	pack_UA_UInt32(sv, &in->returnDiagnostics);
+
+	sv = newSV(0);
+	hv_stores(hv, "RequestHeader_auditEntryId", sv);
+	pack_UA_String(sv, &in->auditEntryId);
+
+	sv = newSV(0);
+	hv_stores(hv, "RequestHeader_timeoutHint", sv);
+	pack_UA_UInt32(sv, &in->timeoutHint);
+
+	sv = newSV(0);
+	hv_stores(hv, "RequestHeader_additionalHeader", sv);
+	pack_UA_ExtensionObject(sv, &in->additionalHeader);
+
+	return;
 }
 
 static void
 unpack_UA_RequestHeader(UA_RequestHeader *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RequestHeader_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RequestHeader_authenticationToken", 0);
 	if (svp != NULL)
-		out->authenticationToken = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->authenticationToken, *svp);
 
 	svp = hv_fetchs(hv, "RequestHeader_timestamp", 0);
 	if (svp != NULL)
-		out->timestamp = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->timestamp, *svp);
 
 	svp = hv_fetchs(hv, "RequestHeader_requestHandle", 0);
 	if (svp != NULL)
-		out->requestHandle = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->requestHandle, *svp);
 
 	svp = hv_fetchs(hv, "RequestHeader_returnDiagnostics", 0);
 	if (svp != NULL)
-		out->returnDiagnostics = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->returnDiagnostics, *svp);
 
 	svp = hv_fetchs(hv, "RequestHeader_auditEntryId", 0);
 	if (svp != NULL)
-		out->auditEntryId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->auditEntryId, *svp);
 
 	svp = hv_fetchs(hv, "RequestHeader_timeoutHint", 0);
 	if (svp != NULL)
-		out->timeoutHint = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->timeoutHint, *svp);
 
 	svp = hv_fetchs(hv, "RequestHeader_additionalHeader", 0);
 	if (svp != NULL)
-		out->additionalHeader = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->additionalHeader, *svp);
 
-
+	return;
 }
 #endif
 
 /* ResponseHeader */
 #ifdef UA_TYPES_RESPONSEHEADER
-static void XS_pack_UA_ResponseHeader(SV *out, UA_ResponseHeader in)  __attribute__((unused));
-static UA_ResponseHeader XS_unpack_UA_ResponseHeader(SV *in)  __attribute__((unused));
 static void pack_UA_ResponseHeader(SV *out, UA_ResponseHeader *in);
 static void unpack_UA_ResponseHeader(UA_ResponseHeader *out, SV *in);
 
@@ -4374,104 +4172,101 @@ pack_UA_ResponseHeader(SV *out, UA_ResponseHeader *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->timestamp);
 	hv_stores(hv, "ResponseHeader_timestamp", sv);
+	pack_UA_DateTime(sv, &in->timestamp);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->requestHandle);
 	hv_stores(hv, "ResponseHeader_requestHandle", sv);
+	pack_UA_UInt32(sv, &in->requestHandle);
 
 	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->serviceResult);
 	hv_stores(hv, "ResponseHeader_serviceResult", sv);
+	pack_UA_StatusCode(sv, &in->serviceResult);
 
 	sv = newSV(0);
-	XS_pack_UA_DiagnosticInfo(sv, in->serviceDiagnostics);
 	hv_stores(hv, "ResponseHeader_serviceDiagnostics", sv);
+	pack_UA_DiagnosticInfo(sv, &in->serviceDiagnostics);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ResponseHeader_stringTable", newRV_noinc((SV*)av));
 	av_extend(av, in->stringTableSize);
 	for (i = 0; i < in->stringTableSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->stringTable[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->stringTable[i]);
 	}
-	hv_stores(hv, "ResponseHeader_stringTable", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->additionalHeader);
 	hv_stores(hv, "ResponseHeader_additionalHeader", sv);
+	pack_UA_ExtensionObject(sv, &in->additionalHeader);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ResponseHeader(UA_ResponseHeader *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ResponseHeader_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ResponseHeader_timestamp", 0);
 	if (svp != NULL)
-		out->timestamp = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->timestamp, *svp);
 
 	svp = hv_fetchs(hv, "ResponseHeader_requestHandle", 0);
 	if (svp != NULL)
-		out->requestHandle = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->requestHandle, *svp);
 
 	svp = hv_fetchs(hv, "ResponseHeader_serviceResult", 0);
 	if (svp != NULL)
-		out->serviceResult = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->serviceResult, *svp);
 
 	svp = hv_fetchs(hv, "ResponseHeader_serviceDiagnostics", 0);
 	if (svp != NULL)
-		out->serviceDiagnostics = XS_unpack_UA_DiagnosticInfo(*svp);
+		unpack_UA_DiagnosticInfo(&out->serviceDiagnostics, *svp);
 
 	svp = hv_fetchs(hv, "ResponseHeader_stringTable", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ResponseHeader_stringTable");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->stringTable = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->stringTable == NULL) {
+		if (out->stringTable == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->stringTableSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->stringTable[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->stringTable[i], *svp);
 		}
-		out->stringTableSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ResponseHeader_additionalHeader", 0);
 	if (svp != NULL)
-		out->additionalHeader = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->additionalHeader, *svp);
 
-
+	return;
 }
 #endif
 
 /* VersionTime */
 #ifdef UA_TYPES_VERSIONTIME
-static void XS_pack_UA_VersionTime(SV *out, UA_VersionTime in)  __attribute__((unused));
-static UA_VersionTime XS_unpack_UA_VersionTime(SV *in)  __attribute__((unused));
 static void pack_UA_VersionTime(SV *out, UA_VersionTime *in);
 static void unpack_UA_VersionTime(UA_VersionTime *out, SV *in);
 
@@ -4479,21 +4274,19 @@ static void
 pack_UA_VersionTime(SV *out, UA_VersionTime *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_VersionTime(UA_VersionTime *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* ServiceFault */
 #ifdef UA_TYPES_SERVICEFAULT
-static void XS_pack_UA_ServiceFault(SV *out, UA_ServiceFault in)  __attribute__((unused));
-static UA_ServiceFault XS_unpack_UA_ServiceFault(SV *in)  __attribute__((unused));
 static void pack_UA_ServiceFault(SV *out, UA_ServiceFault *in);
 static void unpack_UA_ServiceFault(UA_ServiceFault *out, SV *in);
 
@@ -4502,41 +4295,41 @@ pack_UA_ServiceFault(SV *out, UA_ServiceFault *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "ServiceFault_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ServiceFault(UA_ServiceFault *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ServiceFault_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ServiceFault_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
-
+	return;
 }
 #endif
 
 /* SessionlessInvokeRequestType */
 #ifdef UA_TYPES_SESSIONLESSINVOKEREQUESTTYPE
-static void XS_pack_UA_SessionlessInvokeRequestType(SV *out, UA_SessionlessInvokeRequestType in)  __attribute__((unused));
-static UA_SessionlessInvokeRequestType XS_unpack_UA_SessionlessInvokeRequestType(SV *in)  __attribute__((unused));
 static void pack_UA_SessionlessInvokeRequestType(SV *out, UA_SessionlessInvokeRequestType *in);
 static void unpack_UA_SessionlessInvokeRequestType(UA_SessionlessInvokeRequestType *out, SV *in);
 
@@ -4547,171 +4340,159 @@ pack_UA_SessionlessInvokeRequestType(SV *out, UA_SessionlessInvokeRequestType *i
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 #ifdef HAVE_UA_SESSIONLESSINVOKEREQUESTTYPE_URISVERSIONSIZE
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SessionlessInvokeRequestType_urisVersion", newRV_noinc((SV*)av));
 	av_extend(av, in->urisVersionSize);
 	for (i = 0; i < in->urisVersionSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->urisVersion[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->urisVersion[i]);
 	}
-	hv_stores(hv, "SessionlessInvokeRequestType_urisVersion", newRV_inc((SV*)av));
 #else
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->urisVersion);
 	hv_stores(hv, "SessionlessInvokeRequestType_urisVersion", sv);
+	pack_UA_UInt32(sv, &in->urisVersion);
 #endif
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SessionlessInvokeRequestType_namespaceUris", newRV_noinc((SV*)av));
 	av_extend(av, in->namespaceUrisSize);
 	for (i = 0; i < in->namespaceUrisSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->namespaceUris[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->namespaceUris[i]);
 	}
-	hv_stores(hv, "SessionlessInvokeRequestType_namespaceUris", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SessionlessInvokeRequestType_serverUris", newRV_noinc((SV*)av));
 	av_extend(av, in->serverUrisSize);
 	for (i = 0; i < in->serverUrisSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->serverUris[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->serverUris[i]);
 	}
-	hv_stores(hv, "SessionlessInvokeRequestType_serverUris", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SessionlessInvokeRequestType_localeIds", newRV_noinc((SV*)av));
 	av_extend(av, in->localeIdsSize);
 	for (i = 0; i < in->localeIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->localeIds[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->localeIds[i]);
 	}
-	hv_stores(hv, "SessionlessInvokeRequestType_localeIds", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->serviceId);
 	hv_stores(hv, "SessionlessInvokeRequestType_serviceId", sv);
+	pack_UA_UInt32(sv, &in->serviceId);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SessionlessInvokeRequestType(UA_SessionlessInvokeRequestType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SessionlessInvokeRequestType_init(out);
 	hv = (HV*)SvRV(in);
 
 #ifdef HAVE_UA_SESSIONLESSINVOKEREQUESTTYPE_URISVERSIONSIZE
 	svp = hv_fetchs(hv, "SessionlessInvokeRequestType_urisVersion", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SessionlessInvokeRequestType_urisVersion");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->urisVersion = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->urisVersion == NULL) {
+		if (out->urisVersion == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->urisVersionSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->urisVersion[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->urisVersion[i], *svp);
 		}
-		out->urisVersionSize = i;
 	}
 #else
 	svp = hv_fetchs(hv, "SessionlessInvokeRequestType_urisVersion", 0);
 	if (svp != NULL)
-		out->urisVersion = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->urisVersion, *svp);
 #endif
 
 	svp = hv_fetchs(hv, "SessionlessInvokeRequestType_namespaceUris", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SessionlessInvokeRequestType_namespaceUris");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->namespaceUris = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->namespaceUris == NULL) {
+		if (out->namespaceUris == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->namespaceUrisSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->namespaceUris[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->namespaceUris[i], *svp);
 		}
-		out->namespaceUrisSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SessionlessInvokeRequestType_serverUris", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SessionlessInvokeRequestType_serverUris");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->serverUris = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->serverUris == NULL) {
+		if (out->serverUris == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serverUrisSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->serverUris[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->serverUris[i], *svp);
 		}
-		out->serverUrisSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SessionlessInvokeRequestType_localeIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SessionlessInvokeRequestType_localeIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->localeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->localeIds == NULL) {
+		if (out->localeIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->localeIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->localeIds[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->localeIds[i], *svp);
 		}
-		out->localeIdsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SessionlessInvokeRequestType_serviceId", 0);
 	if (svp != NULL)
-		out->serviceId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->serviceId, *svp);
 
-
+	return;
 }
 #endif
 
 /* SessionlessInvokeResponseType */
 #ifdef UA_TYPES_SESSIONLESSINVOKERESPONSETYPE
-static void XS_pack_UA_SessionlessInvokeResponseType(SV *out, UA_SessionlessInvokeResponseType in)  __attribute__((unused));
-static UA_SessionlessInvokeResponseType XS_unpack_UA_SessionlessInvokeResponseType(SV *in)  __attribute__((unused));
 static void pack_UA_SessionlessInvokeResponseType(SV *out, UA_SessionlessInvokeResponseType *in);
 static void unpack_UA_SessionlessInvokeResponseType(UA_SessionlessInvokeResponseType *out, SV *in);
 
@@ -4722,101 +4503,95 @@ pack_UA_SessionlessInvokeResponseType(SV *out, UA_SessionlessInvokeResponseType 
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "SessionlessInvokeResponseType_namespaceUris", newRV_noinc((SV*)av));
 	av_extend(av, in->namespaceUrisSize);
 	for (i = 0; i < in->namespaceUrisSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->namespaceUris[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->namespaceUris[i]);
 	}
-	hv_stores(hv, "SessionlessInvokeResponseType_namespaceUris", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SessionlessInvokeResponseType_serverUris", newRV_noinc((SV*)av));
 	av_extend(av, in->serverUrisSize);
 	for (i = 0; i < in->serverUrisSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->serverUris[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->serverUris[i]);
 	}
-	hv_stores(hv, "SessionlessInvokeResponseType_serverUris", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->serviceId);
 	hv_stores(hv, "SessionlessInvokeResponseType_serviceId", sv);
+	pack_UA_UInt32(sv, &in->serviceId);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SessionlessInvokeResponseType(UA_SessionlessInvokeResponseType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SessionlessInvokeResponseType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SessionlessInvokeResponseType_namespaceUris", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SessionlessInvokeResponseType_namespaceUris");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->namespaceUris = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->namespaceUris == NULL) {
+		if (out->namespaceUris == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->namespaceUrisSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->namespaceUris[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->namespaceUris[i], *svp);
 		}
-		out->namespaceUrisSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SessionlessInvokeResponseType_serverUris", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SessionlessInvokeResponseType_serverUris");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->serverUris = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->serverUris == NULL) {
+		if (out->serverUris == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serverUrisSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->serverUris[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->serverUris[i], *svp);
 		}
-		out->serverUrisSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SessionlessInvokeResponseType_serviceId", 0);
 	if (svp != NULL)
-		out->serviceId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->serviceId, *svp);
 
-
+	return;
 }
 #endif
 
 /* FindServersRequest */
 #ifdef UA_TYPES_FINDSERVERSREQUEST
-static void XS_pack_UA_FindServersRequest(SV *out, UA_FindServersRequest in)  __attribute__((unused));
-static UA_FindServersRequest XS_unpack_UA_FindServersRequest(SV *in)  __attribute__((unused));
 static void pack_UA_FindServersRequest(SV *out, UA_FindServersRequest *in);
 static void unpack_UA_FindServersRequest(UA_FindServersRequest *out, SV *in);
 
@@ -4827,109 +4602,103 @@ pack_UA_FindServersRequest(SV *out, UA_FindServersRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "FindServersRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->endpointUrl);
 	hv_stores(hv, "FindServersRequest_endpointUrl", sv);
+	pack_UA_String(sv, &in->endpointUrl);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "FindServersRequest_localeIds", newRV_noinc((SV*)av));
 	av_extend(av, in->localeIdsSize);
 	for (i = 0; i < in->localeIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->localeIds[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->localeIds[i]);
 	}
-	hv_stores(hv, "FindServersRequest_localeIds", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "FindServersRequest_serverUris", newRV_noinc((SV*)av));
 	av_extend(av, in->serverUrisSize);
 	for (i = 0; i < in->serverUrisSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->serverUris[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->serverUris[i]);
 	}
-	hv_stores(hv, "FindServersRequest_serverUris", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_FindServersRequest(UA_FindServersRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_FindServersRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "FindServersRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "FindServersRequest_endpointUrl", 0);
 	if (svp != NULL)
-		out->endpointUrl = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->endpointUrl, *svp);
 
 	svp = hv_fetchs(hv, "FindServersRequest_localeIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for FindServersRequest_localeIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->localeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->localeIds == NULL) {
+		if (out->localeIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->localeIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->localeIds[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->localeIds[i], *svp);
 		}
-		out->localeIdsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "FindServersRequest_serverUris", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for FindServersRequest_serverUris");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->serverUris = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->serverUris == NULL) {
+		if (out->serverUris == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serverUrisSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->serverUris[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->serverUris[i], *svp);
 		}
-		out->serverUrisSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* FindServersResponse */
 #ifdef UA_TYPES_FINDSERVERSRESPONSE
-static void XS_pack_UA_FindServersResponse(SV *out, UA_FindServersResponse in)  __attribute__((unused));
-static UA_FindServersResponse XS_unpack_UA_FindServersResponse(SV *in)  __attribute__((unused));
 static void pack_UA_FindServersResponse(SV *out, UA_FindServersResponse *in);
 static void unpack_UA_FindServersResponse(UA_FindServersResponse *out, SV *in);
 
@@ -4940,72 +4709,69 @@ pack_UA_FindServersResponse(SV *out, UA_FindServersResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "FindServersResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "FindServersResponse_servers", newRV_noinc((SV*)av));
 	av_extend(av, in->serversSize);
 	for (i = 0; i < in->serversSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ApplicationDescription(sv, in->servers[i]);
 		av_push(av, sv);
+		pack_UA_ApplicationDescription(sv, &in->servers[i]);
 	}
-	hv_stores(hv, "FindServersResponse_servers", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_FindServersResponse(UA_FindServersResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_FindServersResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "FindServersResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "FindServersResponse_servers", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for FindServersResponse_servers");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->servers = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION]);
-		if (out->servers == NULL) {
+		if (out->servers == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serversSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->servers[i] = XS_unpack_UA_ApplicationDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ApplicationDescription(&out->servers[i], *svp);
 		}
-		out->serversSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ServerOnNetwork */
 #ifdef UA_TYPES_SERVERONNETWORK
-static void XS_pack_UA_ServerOnNetwork(SV *out, UA_ServerOnNetwork in)  __attribute__((unused));
-static UA_ServerOnNetwork XS_unpack_UA_ServerOnNetwork(SV *in)  __attribute__((unused));
 static void pack_UA_ServerOnNetwork(SV *out, UA_ServerOnNetwork *in);
 static void unpack_UA_ServerOnNetwork(UA_ServerOnNetwork *out, SV *in);
 
@@ -5016,88 +4782,85 @@ pack_UA_ServerOnNetwork(SV *out, UA_ServerOnNetwork *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->recordId);
 	hv_stores(hv, "ServerOnNetwork_recordId", sv);
+	pack_UA_UInt32(sv, &in->recordId);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->serverName);
 	hv_stores(hv, "ServerOnNetwork_serverName", sv);
+	pack_UA_String(sv, &in->serverName);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->discoveryUrl);
 	hv_stores(hv, "ServerOnNetwork_discoveryUrl", sv);
+	pack_UA_String(sv, &in->discoveryUrl);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ServerOnNetwork_serverCapabilities", newRV_noinc((SV*)av));
 	av_extend(av, in->serverCapabilitiesSize);
 	for (i = 0; i < in->serverCapabilitiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->serverCapabilities[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->serverCapabilities[i]);
 	}
-	hv_stores(hv, "ServerOnNetwork_serverCapabilities", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ServerOnNetwork(UA_ServerOnNetwork *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ServerOnNetwork_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ServerOnNetwork_recordId", 0);
 	if (svp != NULL)
-		out->recordId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->recordId, *svp);
 
 	svp = hv_fetchs(hv, "ServerOnNetwork_serverName", 0);
 	if (svp != NULL)
-		out->serverName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->serverName, *svp);
 
 	svp = hv_fetchs(hv, "ServerOnNetwork_discoveryUrl", 0);
 	if (svp != NULL)
-		out->discoveryUrl = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->discoveryUrl, *svp);
 
 	svp = hv_fetchs(hv, "ServerOnNetwork_serverCapabilities", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ServerOnNetwork_serverCapabilities");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->serverCapabilities = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->serverCapabilities == NULL) {
+		if (out->serverCapabilities == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serverCapabilitiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->serverCapabilities[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->serverCapabilities[i], *svp);
 		}
-		out->serverCapabilitiesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* FindServersOnNetworkRequest */
 #ifdef UA_TYPES_FINDSERVERSONNETWORKREQUEST
-static void XS_pack_UA_FindServersOnNetworkRequest(SV *out, UA_FindServersOnNetworkRequest in)  __attribute__((unused));
-static UA_FindServersOnNetworkRequest XS_unpack_UA_FindServersOnNetworkRequest(SV *in)  __attribute__((unused));
 static void pack_UA_FindServersOnNetworkRequest(SV *out, UA_FindServersOnNetworkRequest *in);
 static void unpack_UA_FindServersOnNetworkRequest(UA_FindServersOnNetworkRequest *out, SV *in);
 
@@ -5108,88 +4871,85 @@ pack_UA_FindServersOnNetworkRequest(SV *out, UA_FindServersOnNetworkRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "FindServersOnNetworkRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->startingRecordId);
 	hv_stores(hv, "FindServersOnNetworkRequest_startingRecordId", sv);
+	pack_UA_UInt32(sv, &in->startingRecordId);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxRecordsToReturn);
 	hv_stores(hv, "FindServersOnNetworkRequest_maxRecordsToReturn", sv);
+	pack_UA_UInt32(sv, &in->maxRecordsToReturn);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "FindServersOnNetworkRequest_serverCapabilityFilter", newRV_noinc((SV*)av));
 	av_extend(av, in->serverCapabilityFilterSize);
 	for (i = 0; i < in->serverCapabilityFilterSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->serverCapabilityFilter[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->serverCapabilityFilter[i]);
 	}
-	hv_stores(hv, "FindServersOnNetworkRequest_serverCapabilityFilter", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_FindServersOnNetworkRequest(UA_FindServersOnNetworkRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_FindServersOnNetworkRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "FindServersOnNetworkRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "FindServersOnNetworkRequest_startingRecordId", 0);
 	if (svp != NULL)
-		out->startingRecordId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->startingRecordId, *svp);
 
 	svp = hv_fetchs(hv, "FindServersOnNetworkRequest_maxRecordsToReturn", 0);
 	if (svp != NULL)
-		out->maxRecordsToReturn = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxRecordsToReturn, *svp);
 
 	svp = hv_fetchs(hv, "FindServersOnNetworkRequest_serverCapabilityFilter", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for FindServersOnNetworkRequest_serverCapabilityFilter");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->serverCapabilityFilter = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->serverCapabilityFilter == NULL) {
+		if (out->serverCapabilityFilter == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serverCapabilityFilterSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->serverCapabilityFilter[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->serverCapabilityFilter[i], *svp);
 		}
-		out->serverCapabilityFilterSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* FindServersOnNetworkResponse */
 #ifdef UA_TYPES_FINDSERVERSONNETWORKRESPONSE
-static void XS_pack_UA_FindServersOnNetworkResponse(SV *out, UA_FindServersOnNetworkResponse in)  __attribute__((unused));
-static UA_FindServersOnNetworkResponse XS_unpack_UA_FindServersOnNetworkResponse(SV *in)  __attribute__((unused));
 static void pack_UA_FindServersOnNetworkResponse(SV *out, UA_FindServersOnNetworkResponse *in);
 static void unpack_UA_FindServersOnNetworkResponse(UA_FindServersOnNetworkResponse *out, SV *in);
 
@@ -5200,80 +4960,77 @@ pack_UA_FindServersOnNetworkResponse(SV *out, UA_FindServersOnNetworkResponse *i
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "FindServersOnNetworkResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->lastCounterResetTime);
 	hv_stores(hv, "FindServersOnNetworkResponse_lastCounterResetTime", sv);
+	pack_UA_DateTime(sv, &in->lastCounterResetTime);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "FindServersOnNetworkResponse_servers", newRV_noinc((SV*)av));
 	av_extend(av, in->serversSize);
 	for (i = 0; i < in->serversSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ServerOnNetwork(sv, in->servers[i]);
 		av_push(av, sv);
+		pack_UA_ServerOnNetwork(sv, &in->servers[i]);
 	}
-	hv_stores(hv, "FindServersOnNetworkResponse_servers", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_FindServersOnNetworkResponse(UA_FindServersOnNetworkResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_FindServersOnNetworkResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "FindServersOnNetworkResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "FindServersOnNetworkResponse_lastCounterResetTime", 0);
 	if (svp != NULL)
-		out->lastCounterResetTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->lastCounterResetTime, *svp);
 
 	svp = hv_fetchs(hv, "FindServersOnNetworkResponse_servers", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for FindServersOnNetworkResponse_servers");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->servers = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SERVERONNETWORK]);
-		if (out->servers == NULL) {
+		if (out->servers == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serversSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->servers[i] = XS_unpack_UA_ServerOnNetwork(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ServerOnNetwork(&out->servers[i], *svp);
 		}
-		out->serversSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ApplicationInstanceCertificate */
 #ifdef UA_TYPES_APPLICATIONINSTANCECERTIFICATE
-static void XS_pack_UA_ApplicationInstanceCertificate(SV *out, UA_ApplicationInstanceCertificate in)  __attribute__((unused));
-static UA_ApplicationInstanceCertificate XS_unpack_UA_ApplicationInstanceCertificate(SV *in)  __attribute__((unused));
 static void pack_UA_ApplicationInstanceCertificate(SV *out, UA_ApplicationInstanceCertificate *in);
 static void unpack_UA_ApplicationInstanceCertificate(UA_ApplicationInstanceCertificate *out, SV *in);
 
@@ -5281,21 +5038,19 @@ static void
 pack_UA_ApplicationInstanceCertificate(SV *out, UA_ApplicationInstanceCertificate *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_ApplicationInstanceCertificate(UA_ApplicationInstanceCertificate *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* MessageSecurityMode */
 #ifdef UA_TYPES_MESSAGESECURITYMODE
-static void XS_pack_UA_MessageSecurityMode(SV *out, UA_MessageSecurityMode in)  __attribute__((unused));
-static UA_MessageSecurityMode XS_unpack_UA_MessageSecurityMode(SV *in)  __attribute__((unused));
 static void pack_UA_MessageSecurityMode(SV *out, UA_MessageSecurityMode *in);
 static void unpack_UA_MessageSecurityMode(UA_MessageSecurityMode *out, SV *in);
 
@@ -5316,8 +5071,6 @@ unpack_UA_MessageSecurityMode(UA_MessageSecurityMode *out, SV *in)
 
 /* UserTokenType */
 #ifdef UA_TYPES_USERTOKENTYPE
-static void XS_pack_UA_UserTokenType(SV *out, UA_UserTokenType in)  __attribute__((unused));
-static UA_UserTokenType XS_unpack_UA_UserTokenType(SV *in)  __attribute__((unused));
 static void pack_UA_UserTokenType(SV *out, UA_UserTokenType *in);
 static void unpack_UA_UserTokenType(UA_UserTokenType *out, SV *in);
 
@@ -5338,8 +5091,6 @@ unpack_UA_UserTokenType(UA_UserTokenType *out, SV *in)
 
 /* UserTokenPolicy */
 #ifdef UA_TYPES_USERTOKENPOLICY
-static void XS_pack_UA_UserTokenPolicy(SV *out, UA_UserTokenPolicy in)  __attribute__((unused));
-static UA_UserTokenPolicy XS_unpack_UA_UserTokenPolicy(SV *in)  __attribute__((unused));
 static void pack_UA_UserTokenPolicy(SV *out, UA_UserTokenPolicy *in);
 static void unpack_UA_UserTokenPolicy(UA_UserTokenPolicy *out, SV *in);
 
@@ -5348,73 +5099,73 @@ pack_UA_UserTokenPolicy(SV *out, UA_UserTokenPolicy *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->policyId);
-	hv_stores(hv, "UserTokenPolicy_policyId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UserTokenType(sv, in->tokenType);
-	hv_stores(hv, "UserTokenPolicy_tokenType", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->issuedTokenType);
-	hv_stores(hv, "UserTokenPolicy_issuedTokenType", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->issuerEndpointUrl);
-	hv_stores(hv, "UserTokenPolicy_issuerEndpointUrl", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->securityPolicyUri);
-	hv_stores(hv, "UserTokenPolicy_securityPolicyUri", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "UserTokenPolicy_policyId", sv);
+	pack_UA_String(sv, &in->policyId);
+
+	sv = newSV(0);
+	hv_stores(hv, "UserTokenPolicy_tokenType", sv);
+	pack_UA_UserTokenType(sv, &in->tokenType);
+
+	sv = newSV(0);
+	hv_stores(hv, "UserTokenPolicy_issuedTokenType", sv);
+	pack_UA_String(sv, &in->issuedTokenType);
+
+	sv = newSV(0);
+	hv_stores(hv, "UserTokenPolicy_issuerEndpointUrl", sv);
+	pack_UA_String(sv, &in->issuerEndpointUrl);
+
+	sv = newSV(0);
+	hv_stores(hv, "UserTokenPolicy_securityPolicyUri", sv);
+	pack_UA_String(sv, &in->securityPolicyUri);
+
+	return;
 }
 
 static void
 unpack_UA_UserTokenPolicy(UA_UserTokenPolicy *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UserTokenPolicy_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UserTokenPolicy_policyId", 0);
 	if (svp != NULL)
-		out->policyId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->policyId, *svp);
 
 	svp = hv_fetchs(hv, "UserTokenPolicy_tokenType", 0);
 	if (svp != NULL)
-		out->tokenType = XS_unpack_UA_UserTokenType(*svp);
+		unpack_UA_UserTokenType(&out->tokenType, *svp);
 
 	svp = hv_fetchs(hv, "UserTokenPolicy_issuedTokenType", 0);
 	if (svp != NULL)
-		out->issuedTokenType = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->issuedTokenType, *svp);
 
 	svp = hv_fetchs(hv, "UserTokenPolicy_issuerEndpointUrl", 0);
 	if (svp != NULL)
-		out->issuerEndpointUrl = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->issuerEndpointUrl, *svp);
 
 	svp = hv_fetchs(hv, "UserTokenPolicy_securityPolicyUri", 0);
 	if (svp != NULL)
-		out->securityPolicyUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->securityPolicyUri, *svp);
 
-
+	return;
 }
 #endif
 
 /* EndpointDescription */
 #ifdef UA_TYPES_ENDPOINTDESCRIPTION
-static void XS_pack_UA_EndpointDescription(SV *out, UA_EndpointDescription in)  __attribute__((unused));
-static UA_EndpointDescription XS_unpack_UA_EndpointDescription(SV *in)  __attribute__((unused));
 static void pack_UA_EndpointDescription(SV *out, UA_EndpointDescription *in);
 static void unpack_UA_EndpointDescription(UA_EndpointDescription *out, SV *in);
 
@@ -5425,120 +5176,117 @@ pack_UA_EndpointDescription(SV *out, UA_EndpointDescription *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->endpointUrl);
 	hv_stores(hv, "EndpointDescription_endpointUrl", sv);
+	pack_UA_String(sv, &in->endpointUrl);
 
 	sv = newSV(0);
-	XS_pack_UA_ApplicationDescription(sv, in->server);
 	hv_stores(hv, "EndpointDescription_server", sv);
+	pack_UA_ApplicationDescription(sv, &in->server);
 
 	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->serverCertificate);
 	hv_stores(hv, "EndpointDescription_serverCertificate", sv);
+	pack_UA_ByteString(sv, &in->serverCertificate);
 
 	sv = newSV(0);
-	XS_pack_UA_MessageSecurityMode(sv, in->securityMode);
 	hv_stores(hv, "EndpointDescription_securityMode", sv);
+	pack_UA_MessageSecurityMode(sv, &in->securityMode);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->securityPolicyUri);
 	hv_stores(hv, "EndpointDescription_securityPolicyUri", sv);
+	pack_UA_String(sv, &in->securityPolicyUri);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "EndpointDescription_userIdentityTokens", newRV_noinc((SV*)av));
 	av_extend(av, in->userIdentityTokensSize);
 	for (i = 0; i < in->userIdentityTokensSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UserTokenPolicy(sv, in->userIdentityTokens[i]);
 		av_push(av, sv);
+		pack_UA_UserTokenPolicy(sv, &in->userIdentityTokens[i]);
 	}
-	hv_stores(hv, "EndpointDescription_userIdentityTokens", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->transportProfileUri);
 	hv_stores(hv, "EndpointDescription_transportProfileUri", sv);
+	pack_UA_String(sv, &in->transportProfileUri);
 
 	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->securityLevel);
 	hv_stores(hv, "EndpointDescription_securityLevel", sv);
+	pack_UA_Byte(sv, &in->securityLevel);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_EndpointDescription(UA_EndpointDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EndpointDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EndpointDescription_endpointUrl", 0);
 	if (svp != NULL)
-		out->endpointUrl = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->endpointUrl, *svp);
 
 	svp = hv_fetchs(hv, "EndpointDescription_server", 0);
 	if (svp != NULL)
-		out->server = XS_unpack_UA_ApplicationDescription(*svp);
+		unpack_UA_ApplicationDescription(&out->server, *svp);
 
 	svp = hv_fetchs(hv, "EndpointDescription_serverCertificate", 0);
 	if (svp != NULL)
-		out->serverCertificate = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->serverCertificate, *svp);
 
 	svp = hv_fetchs(hv, "EndpointDescription_securityMode", 0);
 	if (svp != NULL)
-		out->securityMode = XS_unpack_UA_MessageSecurityMode(*svp);
+		unpack_UA_MessageSecurityMode(&out->securityMode, *svp);
 
 	svp = hv_fetchs(hv, "EndpointDescription_securityPolicyUri", 0);
 	if (svp != NULL)
-		out->securityPolicyUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->securityPolicyUri, *svp);
 
 	svp = hv_fetchs(hv, "EndpointDescription_userIdentityTokens", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for EndpointDescription_userIdentityTokens");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->userIdentityTokens = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_USERTOKENPOLICY]);
-		if (out->userIdentityTokens == NULL) {
+		if (out->userIdentityTokens == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->userIdentityTokensSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->userIdentityTokens[i] = XS_unpack_UA_UserTokenPolicy(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UserTokenPolicy(&out->userIdentityTokens[i], *svp);
 		}
-		out->userIdentityTokensSize = i;
 	}
 
 	svp = hv_fetchs(hv, "EndpointDescription_transportProfileUri", 0);
 	if (svp != NULL)
-		out->transportProfileUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->transportProfileUri, *svp);
 
 	svp = hv_fetchs(hv, "EndpointDescription_securityLevel", 0);
 	if (svp != NULL)
-		out->securityLevel = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->securityLevel, *svp);
 
-
+	return;
 }
 #endif
 
 /* GetEndpointsRequest */
 #ifdef UA_TYPES_GETENDPOINTSREQUEST
-static void XS_pack_UA_GetEndpointsRequest(SV *out, UA_GetEndpointsRequest in)  __attribute__((unused));
-static UA_GetEndpointsRequest XS_unpack_UA_GetEndpointsRequest(SV *in)  __attribute__((unused));
 static void pack_UA_GetEndpointsRequest(SV *out, UA_GetEndpointsRequest *in);
 static void unpack_UA_GetEndpointsRequest(UA_GetEndpointsRequest *out, SV *in);
 
@@ -5549,109 +5297,103 @@ pack_UA_GetEndpointsRequest(SV *out, UA_GetEndpointsRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "GetEndpointsRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->endpointUrl);
 	hv_stores(hv, "GetEndpointsRequest_endpointUrl", sv);
+	pack_UA_String(sv, &in->endpointUrl);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "GetEndpointsRequest_localeIds", newRV_noinc((SV*)av));
 	av_extend(av, in->localeIdsSize);
 	for (i = 0; i < in->localeIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->localeIds[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->localeIds[i]);
 	}
-	hv_stores(hv, "GetEndpointsRequest_localeIds", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "GetEndpointsRequest_profileUris", newRV_noinc((SV*)av));
 	av_extend(av, in->profileUrisSize);
 	for (i = 0; i < in->profileUrisSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->profileUris[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->profileUris[i]);
 	}
-	hv_stores(hv, "GetEndpointsRequest_profileUris", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_GetEndpointsRequest(UA_GetEndpointsRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_GetEndpointsRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "GetEndpointsRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "GetEndpointsRequest_endpointUrl", 0);
 	if (svp != NULL)
-		out->endpointUrl = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->endpointUrl, *svp);
 
 	svp = hv_fetchs(hv, "GetEndpointsRequest_localeIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for GetEndpointsRequest_localeIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->localeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->localeIds == NULL) {
+		if (out->localeIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->localeIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->localeIds[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->localeIds[i], *svp);
 		}
-		out->localeIdsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "GetEndpointsRequest_profileUris", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for GetEndpointsRequest_profileUris");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->profileUris = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->profileUris == NULL) {
+		if (out->profileUris == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->profileUrisSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->profileUris[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->profileUris[i], *svp);
 		}
-		out->profileUrisSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* GetEndpointsResponse */
 #ifdef UA_TYPES_GETENDPOINTSRESPONSE
-static void XS_pack_UA_GetEndpointsResponse(SV *out, UA_GetEndpointsResponse in)  __attribute__((unused));
-static UA_GetEndpointsResponse XS_unpack_UA_GetEndpointsResponse(SV *in)  __attribute__((unused));
 static void pack_UA_GetEndpointsResponse(SV *out, UA_GetEndpointsResponse *in);
 static void unpack_UA_GetEndpointsResponse(UA_GetEndpointsResponse *out, SV *in);
 
@@ -5662,72 +5404,69 @@ pack_UA_GetEndpointsResponse(SV *out, UA_GetEndpointsResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "GetEndpointsResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "GetEndpointsResponse_endpoints", newRV_noinc((SV*)av));
 	av_extend(av, in->endpointsSize);
 	for (i = 0; i < in->endpointsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EndpointDescription(sv, in->endpoints[i]);
 		av_push(av, sv);
+		pack_UA_EndpointDescription(sv, &in->endpoints[i]);
 	}
-	hv_stores(hv, "GetEndpointsResponse_endpoints", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_GetEndpointsResponse(UA_GetEndpointsResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_GetEndpointsResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "GetEndpointsResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "GetEndpointsResponse_endpoints", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for GetEndpointsResponse_endpoints");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->endpoints = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
-		if (out->endpoints == NULL) {
+		if (out->endpoints == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->endpointsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->endpoints[i] = XS_unpack_UA_EndpointDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EndpointDescription(&out->endpoints[i], *svp);
 		}
-		out->endpointsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* RegisteredServer */
 #ifdef UA_TYPES_REGISTEREDSERVER
-static void XS_pack_UA_RegisteredServer(SV *out, UA_RegisteredServer in)  __attribute__((unused));
-static UA_RegisteredServer XS_unpack_UA_RegisteredServer(SV *in)  __attribute__((unused));
 static void pack_UA_RegisteredServer(SV *out, UA_RegisteredServer *in);
 static void unpack_UA_RegisteredServer(UA_RegisteredServer *out, SV *in);
 
@@ -5738,141 +5477,135 @@ pack_UA_RegisteredServer(SV *out, UA_RegisteredServer *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->serverUri);
 	hv_stores(hv, "RegisteredServer_serverUri", sv);
+	pack_UA_String(sv, &in->serverUri);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->productUri);
 	hv_stores(hv, "RegisteredServer_productUri", sv);
+	pack_UA_String(sv, &in->productUri);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "RegisteredServer_serverNames", newRV_noinc((SV*)av));
 	av_extend(av, in->serverNamesSize);
 	for (i = 0; i < in->serverNamesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_LocalizedText(sv, in->serverNames[i]);
 		av_push(av, sv);
+		pack_UA_LocalizedText(sv, &in->serverNames[i]);
 	}
-	hv_stores(hv, "RegisteredServer_serverNames", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ApplicationType(sv, in->serverType);
 	hv_stores(hv, "RegisteredServer_serverType", sv);
+	pack_UA_ApplicationType(sv, &in->serverType);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->gatewayServerUri);
 	hv_stores(hv, "RegisteredServer_gatewayServerUri", sv);
+	pack_UA_String(sv, &in->gatewayServerUri);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "RegisteredServer_discoveryUrls", newRV_noinc((SV*)av));
 	av_extend(av, in->discoveryUrlsSize);
 	for (i = 0; i < in->discoveryUrlsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->discoveryUrls[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->discoveryUrls[i]);
 	}
-	hv_stores(hv, "RegisteredServer_discoveryUrls", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->semaphoreFilePath);
 	hv_stores(hv, "RegisteredServer_semaphoreFilePath", sv);
+	pack_UA_String(sv, &in->semaphoreFilePath);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isOnline);
 	hv_stores(hv, "RegisteredServer_isOnline", sv);
+	pack_UA_Boolean(sv, &in->isOnline);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_RegisteredServer(UA_RegisteredServer *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RegisteredServer_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RegisteredServer_serverUri", 0);
 	if (svp != NULL)
-		out->serverUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->serverUri, *svp);
 
 	svp = hv_fetchs(hv, "RegisteredServer_productUri", 0);
 	if (svp != NULL)
-		out->productUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->productUri, *svp);
 
 	svp = hv_fetchs(hv, "RegisteredServer_serverNames", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for RegisteredServer_serverNames");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->serverNames = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_LOCALIZEDTEXT]);
-		if (out->serverNames == NULL) {
+		if (out->serverNames == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serverNamesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->serverNames[i] = XS_unpack_UA_LocalizedText(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_LocalizedText(&out->serverNames[i], *svp);
 		}
-		out->serverNamesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "RegisteredServer_serverType", 0);
 	if (svp != NULL)
-		out->serverType = XS_unpack_UA_ApplicationType(*svp);
+		unpack_UA_ApplicationType(&out->serverType, *svp);
 
 	svp = hv_fetchs(hv, "RegisteredServer_gatewayServerUri", 0);
 	if (svp != NULL)
-		out->gatewayServerUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->gatewayServerUri, *svp);
 
 	svp = hv_fetchs(hv, "RegisteredServer_discoveryUrls", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for RegisteredServer_discoveryUrls");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->discoveryUrls = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->discoveryUrls == NULL) {
+		if (out->discoveryUrls == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->discoveryUrlsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->discoveryUrls[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->discoveryUrls[i], *svp);
 		}
-		out->discoveryUrlsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "RegisteredServer_semaphoreFilePath", 0);
 	if (svp != NULL)
-		out->semaphoreFilePath = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->semaphoreFilePath, *svp);
 
 	svp = hv_fetchs(hv, "RegisteredServer_isOnline", 0);
 	if (svp != NULL)
-		out->isOnline = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isOnline, *svp);
 
-
+	return;
 }
 #endif
 
 /* RegisterServerRequest */
 #ifdef UA_TYPES_REGISTERSERVERREQUEST
-static void XS_pack_UA_RegisterServerRequest(SV *out, UA_RegisterServerRequest in)  __attribute__((unused));
-static UA_RegisterServerRequest XS_unpack_UA_RegisterServerRequest(SV *in)  __attribute__((unused));
 static void pack_UA_RegisterServerRequest(SV *out, UA_RegisterServerRequest *in);
 static void unpack_UA_RegisterServerRequest(UA_RegisterServerRequest *out, SV *in);
 
@@ -5881,49 +5614,49 @@ pack_UA_RegisterServerRequest(SV *out, UA_RegisterServerRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
-	hv_stores(hv, "RegisterServerRequest_requestHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_RegisteredServer(sv, in->server);
-	hv_stores(hv, "RegisterServerRequest_server", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "RegisterServerRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "RegisterServerRequest_server", sv);
+	pack_UA_RegisteredServer(sv, &in->server);
+
+	return;
 }
 
 static void
 unpack_UA_RegisterServerRequest(UA_RegisterServerRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RegisterServerRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RegisterServerRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "RegisterServerRequest_server", 0);
 	if (svp != NULL)
-		out->server = XS_unpack_UA_RegisteredServer(*svp);
+		unpack_UA_RegisteredServer(&out->server, *svp);
 
-
+	return;
 }
 #endif
 
 /* RegisterServerResponse */
 #ifdef UA_TYPES_REGISTERSERVERRESPONSE
-static void XS_pack_UA_RegisterServerResponse(SV *out, UA_RegisterServerResponse in)  __attribute__((unused));
-static UA_RegisterServerResponse XS_unpack_UA_RegisterServerResponse(SV *in)  __attribute__((unused));
 static void pack_UA_RegisterServerResponse(SV *out, UA_RegisterServerResponse *in);
 static void unpack_UA_RegisterServerResponse(UA_RegisterServerResponse *out, SV *in);
 
@@ -5932,41 +5665,41 @@ pack_UA_RegisterServerResponse(SV *out, UA_RegisterServerResponse *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "RegisterServerResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_RegisterServerResponse(UA_RegisterServerResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RegisterServerResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RegisterServerResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
-
+	return;
 }
 #endif
 
 /* DiscoveryConfiguration */
 #ifdef UA_TYPES_DISCOVERYCONFIGURATION
-static void XS_pack_UA_DiscoveryConfiguration(SV *out, UA_DiscoveryConfiguration in)  __attribute__((unused));
-static UA_DiscoveryConfiguration XS_unpack_UA_DiscoveryConfiguration(SV *in)  __attribute__((unused));
 static void pack_UA_DiscoveryConfiguration(SV *out, UA_DiscoveryConfiguration *in);
 static void unpack_UA_DiscoveryConfiguration(UA_DiscoveryConfiguration *out, SV *in);
 
@@ -5987,8 +5720,6 @@ unpack_UA_DiscoveryConfiguration(UA_DiscoveryConfiguration *out, SV *in)
 
 /* MdnsDiscoveryConfiguration */
 #ifdef UA_TYPES_MDNSDISCOVERYCONFIGURATION
-static void XS_pack_UA_MdnsDiscoveryConfiguration(SV *out, UA_MdnsDiscoveryConfiguration in)  __attribute__((unused));
-static UA_MdnsDiscoveryConfiguration XS_unpack_UA_MdnsDiscoveryConfiguration(SV *in)  __attribute__((unused));
 static void pack_UA_MdnsDiscoveryConfiguration(SV *out, UA_MdnsDiscoveryConfiguration *in);
 static void unpack_UA_MdnsDiscoveryConfiguration(UA_MdnsDiscoveryConfiguration *out, SV *in);
 
@@ -5999,72 +5730,69 @@ pack_UA_MdnsDiscoveryConfiguration(SV *out, UA_MdnsDiscoveryConfiguration *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->mdnsServerName);
 	hv_stores(hv, "MdnsDiscoveryConfiguration_mdnsServerName", sv);
+	pack_UA_String(sv, &in->mdnsServerName);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "MdnsDiscoveryConfiguration_serverCapabilities", newRV_noinc((SV*)av));
 	av_extend(av, in->serverCapabilitiesSize);
 	for (i = 0; i < in->serverCapabilitiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->serverCapabilities[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->serverCapabilities[i]);
 	}
-	hv_stores(hv, "MdnsDiscoveryConfiguration_serverCapabilities", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_MdnsDiscoveryConfiguration(UA_MdnsDiscoveryConfiguration *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_MdnsDiscoveryConfiguration_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "MdnsDiscoveryConfiguration_mdnsServerName", 0);
 	if (svp != NULL)
-		out->mdnsServerName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->mdnsServerName, *svp);
 
 	svp = hv_fetchs(hv, "MdnsDiscoveryConfiguration_serverCapabilities", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for MdnsDiscoveryConfiguration_serverCapabilities");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->serverCapabilities = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->serverCapabilities == NULL) {
+		if (out->serverCapabilities == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serverCapabilitiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->serverCapabilities[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->serverCapabilities[i], *svp);
 		}
-		out->serverCapabilitiesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* RegisterServer2Request */
 #ifdef UA_TYPES_REGISTERSERVER2REQUEST
-static void XS_pack_UA_RegisterServer2Request(SV *out, UA_RegisterServer2Request in)  __attribute__((unused));
-static UA_RegisterServer2Request XS_unpack_UA_RegisterServer2Request(SV *in)  __attribute__((unused));
 static void pack_UA_RegisterServer2Request(SV *out, UA_RegisterServer2Request *in);
 static void unpack_UA_RegisterServer2Request(UA_RegisterServer2Request *out, SV *in);
 
@@ -6075,80 +5803,77 @@ pack_UA_RegisterServer2Request(SV *out, UA_RegisterServer2Request *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "RegisterServer2Request_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_RegisteredServer(sv, in->server);
 	hv_stores(hv, "RegisterServer2Request_server", sv);
+	pack_UA_RegisteredServer(sv, &in->server);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "RegisterServer2Request_discoveryConfiguration", newRV_noinc((SV*)av));
 	av_extend(av, in->discoveryConfigurationSize);
 	for (i = 0; i < in->discoveryConfigurationSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ExtensionObject(sv, in->discoveryConfiguration[i]);
 		av_push(av, sv);
+		pack_UA_ExtensionObject(sv, &in->discoveryConfiguration[i]);
 	}
-	hv_stores(hv, "RegisterServer2Request_discoveryConfiguration", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_RegisterServer2Request(UA_RegisterServer2Request *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RegisterServer2Request_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RegisterServer2Request_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "RegisterServer2Request_server", 0);
 	if (svp != NULL)
-		out->server = XS_unpack_UA_RegisteredServer(*svp);
+		unpack_UA_RegisteredServer(&out->server, *svp);
 
 	svp = hv_fetchs(hv, "RegisterServer2Request_discoveryConfiguration", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for RegisterServer2Request_discoveryConfiguration");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->discoveryConfiguration = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
-		if (out->discoveryConfiguration == NULL) {
+		if (out->discoveryConfiguration == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->discoveryConfigurationSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->discoveryConfiguration[i] = XS_unpack_UA_ExtensionObject(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ExtensionObject(&out->discoveryConfiguration[i], *svp);
 		}
-		out->discoveryConfigurationSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* RegisterServer2Response */
 #ifdef UA_TYPES_REGISTERSERVER2RESPONSE
-static void XS_pack_UA_RegisterServer2Response(SV *out, UA_RegisterServer2Response in)  __attribute__((unused));
-static UA_RegisterServer2Response XS_unpack_UA_RegisterServer2Response(SV *in)  __attribute__((unused));
 static void pack_UA_RegisterServer2Response(SV *out, UA_RegisterServer2Response *in);
 static void unpack_UA_RegisterServer2Response(UA_RegisterServer2Response *out, SV *in);
 
@@ -6159,101 +5884,95 @@ pack_UA_RegisterServer2Response(SV *out, UA_RegisterServer2Response *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "RegisterServer2Response_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "RegisterServer2Response_configurationResults", newRV_noinc((SV*)av));
 	av_extend(av, in->configurationResultsSize);
 	for (i = 0; i < in->configurationResultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->configurationResults[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->configurationResults[i]);
 	}
-	hv_stores(hv, "RegisterServer2Response_configurationResults", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "RegisterServer2Response_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "RegisterServer2Response_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_RegisterServer2Response(UA_RegisterServer2Response *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RegisterServer2Response_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RegisterServer2Response_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "RegisterServer2Response_configurationResults", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for RegisterServer2Response_configurationResults");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->configurationResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->configurationResults == NULL) {
+		if (out->configurationResults == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->configurationResultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->configurationResults[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->configurationResults[i], *svp);
 		}
-		out->configurationResultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "RegisterServer2Response_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for RegisterServer2Response_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* SecurityTokenRequestType */
 #ifdef UA_TYPES_SECURITYTOKENREQUESTTYPE
-static void XS_pack_UA_SecurityTokenRequestType(SV *out, UA_SecurityTokenRequestType in)  __attribute__((unused));
-static UA_SecurityTokenRequestType XS_unpack_UA_SecurityTokenRequestType(SV *in)  __attribute__((unused));
 static void pack_UA_SecurityTokenRequestType(SV *out, UA_SecurityTokenRequestType *in);
 static void unpack_UA_SecurityTokenRequestType(UA_SecurityTokenRequestType *out, SV *in);
 
@@ -6274,8 +5993,6 @@ unpack_UA_SecurityTokenRequestType(UA_SecurityTokenRequestType *out, SV *in)
 
 /* ChannelSecurityToken */
 #ifdef UA_TYPES_CHANNELSECURITYTOKEN
-static void XS_pack_UA_ChannelSecurityToken(SV *out, UA_ChannelSecurityToken in)  __attribute__((unused));
-static UA_ChannelSecurityToken XS_unpack_UA_ChannelSecurityToken(SV *in)  __attribute__((unused));
 static void pack_UA_ChannelSecurityToken(SV *out, UA_ChannelSecurityToken *in);
 static void unpack_UA_ChannelSecurityToken(UA_ChannelSecurityToken *out, SV *in);
 
@@ -6284,65 +6001,65 @@ pack_UA_ChannelSecurityToken(SV *out, UA_ChannelSecurityToken *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->channelId);
-	hv_stores(hv, "ChannelSecurityToken_channelId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->tokenId);
-	hv_stores(hv, "ChannelSecurityToken_tokenId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->createdAt);
-	hv_stores(hv, "ChannelSecurityToken_createdAt", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->revisedLifetime);
-	hv_stores(hv, "ChannelSecurityToken_revisedLifetime", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ChannelSecurityToken_channelId", sv);
+	pack_UA_UInt32(sv, &in->channelId);
+
+	sv = newSV(0);
+	hv_stores(hv, "ChannelSecurityToken_tokenId", sv);
+	pack_UA_UInt32(sv, &in->tokenId);
+
+	sv = newSV(0);
+	hv_stores(hv, "ChannelSecurityToken_createdAt", sv);
+	pack_UA_DateTime(sv, &in->createdAt);
+
+	sv = newSV(0);
+	hv_stores(hv, "ChannelSecurityToken_revisedLifetime", sv);
+	pack_UA_UInt32(sv, &in->revisedLifetime);
+
+	return;
 }
 
 static void
 unpack_UA_ChannelSecurityToken(UA_ChannelSecurityToken *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ChannelSecurityToken_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ChannelSecurityToken_channelId", 0);
 	if (svp != NULL)
-		out->channelId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->channelId, *svp);
 
 	svp = hv_fetchs(hv, "ChannelSecurityToken_tokenId", 0);
 	if (svp != NULL)
-		out->tokenId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->tokenId, *svp);
 
 	svp = hv_fetchs(hv, "ChannelSecurityToken_createdAt", 0);
 	if (svp != NULL)
-		out->createdAt = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->createdAt, *svp);
 
 	svp = hv_fetchs(hv, "ChannelSecurityToken_revisedLifetime", 0);
 	if (svp != NULL)
-		out->revisedLifetime = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->revisedLifetime, *svp);
 
-
+	return;
 }
 #endif
 
 /* OpenSecureChannelRequest */
 #ifdef UA_TYPES_OPENSECURECHANNELREQUEST
-static void XS_pack_UA_OpenSecureChannelRequest(SV *out, UA_OpenSecureChannelRequest in)  __attribute__((unused));
-static UA_OpenSecureChannelRequest XS_unpack_UA_OpenSecureChannelRequest(SV *in)  __attribute__((unused));
 static void pack_UA_OpenSecureChannelRequest(SV *out, UA_OpenSecureChannelRequest *in);
 static void unpack_UA_OpenSecureChannelRequest(UA_OpenSecureChannelRequest *out, SV *in);
 
@@ -6351,81 +6068,81 @@ pack_UA_OpenSecureChannelRequest(SV *out, UA_OpenSecureChannelRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
-	hv_stores(hv, "OpenSecureChannelRequest_requestHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->clientProtocolVersion);
-	hv_stores(hv, "OpenSecureChannelRequest_clientProtocolVersion", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_SecurityTokenRequestType(sv, in->requestType);
-	hv_stores(hv, "OpenSecureChannelRequest_requestType", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_MessageSecurityMode(sv, in->securityMode);
-	hv_stores(hv, "OpenSecureChannelRequest_securityMode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->clientNonce);
-	hv_stores(hv, "OpenSecureChannelRequest_clientNonce", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->requestedLifetime);
-	hv_stores(hv, "OpenSecureChannelRequest_requestedLifetime", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelRequest_clientProtocolVersion", sv);
+	pack_UA_UInt32(sv, &in->clientProtocolVersion);
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelRequest_requestType", sv);
+	pack_UA_SecurityTokenRequestType(sv, &in->requestType);
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelRequest_securityMode", sv);
+	pack_UA_MessageSecurityMode(sv, &in->securityMode);
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelRequest_clientNonce", sv);
+	pack_UA_ByteString(sv, &in->clientNonce);
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelRequest_requestedLifetime", sv);
+	pack_UA_UInt32(sv, &in->requestedLifetime);
+
+	return;
 }
 
 static void
 unpack_UA_OpenSecureChannelRequest(UA_OpenSecureChannelRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_OpenSecureChannelRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelRequest_clientProtocolVersion", 0);
 	if (svp != NULL)
-		out->clientProtocolVersion = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->clientProtocolVersion, *svp);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelRequest_requestType", 0);
 	if (svp != NULL)
-		out->requestType = XS_unpack_UA_SecurityTokenRequestType(*svp);
+		unpack_UA_SecurityTokenRequestType(&out->requestType, *svp);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelRequest_securityMode", 0);
 	if (svp != NULL)
-		out->securityMode = XS_unpack_UA_MessageSecurityMode(*svp);
+		unpack_UA_MessageSecurityMode(&out->securityMode, *svp);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelRequest_clientNonce", 0);
 	if (svp != NULL)
-		out->clientNonce = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->clientNonce, *svp);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelRequest_requestedLifetime", 0);
 	if (svp != NULL)
-		out->requestedLifetime = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->requestedLifetime, *svp);
 
-
+	return;
 }
 #endif
 
 /* OpenSecureChannelResponse */
 #ifdef UA_TYPES_OPENSECURECHANNELRESPONSE
-static void XS_pack_UA_OpenSecureChannelResponse(SV *out, UA_OpenSecureChannelResponse in)  __attribute__((unused));
-static UA_OpenSecureChannelResponse XS_unpack_UA_OpenSecureChannelResponse(SV *in)  __attribute__((unused));
 static void pack_UA_OpenSecureChannelResponse(SV *out, UA_OpenSecureChannelResponse *in);
 static void unpack_UA_OpenSecureChannelResponse(UA_OpenSecureChannelResponse *out, SV *in);
 
@@ -6434,65 +6151,65 @@ pack_UA_OpenSecureChannelResponse(SV *out, UA_OpenSecureChannelResponse *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
-	hv_stores(hv, "OpenSecureChannelResponse_responseHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->serverProtocolVersion);
-	hv_stores(hv, "OpenSecureChannelResponse_serverProtocolVersion", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ChannelSecurityToken(sv, in->securityToken);
-	hv_stores(hv, "OpenSecureChannelResponse_securityToken", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->serverNonce);
-	hv_stores(hv, "OpenSecureChannelResponse_serverNonce", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelResponse_serverProtocolVersion", sv);
+	pack_UA_UInt32(sv, &in->serverProtocolVersion);
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelResponse_securityToken", sv);
+	pack_UA_ChannelSecurityToken(sv, &in->securityToken);
+
+	sv = newSV(0);
+	hv_stores(hv, "OpenSecureChannelResponse_serverNonce", sv);
+	pack_UA_ByteString(sv, &in->serverNonce);
+
+	return;
 }
 
 static void
 unpack_UA_OpenSecureChannelResponse(UA_OpenSecureChannelResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_OpenSecureChannelResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelResponse_serverProtocolVersion", 0);
 	if (svp != NULL)
-		out->serverProtocolVersion = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->serverProtocolVersion, *svp);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelResponse_securityToken", 0);
 	if (svp != NULL)
-		out->securityToken = XS_unpack_UA_ChannelSecurityToken(*svp);
+		unpack_UA_ChannelSecurityToken(&out->securityToken, *svp);
 
 	svp = hv_fetchs(hv, "OpenSecureChannelResponse_serverNonce", 0);
 	if (svp != NULL)
-		out->serverNonce = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->serverNonce, *svp);
 
-
+	return;
 }
 #endif
 
 /* CloseSecureChannelRequest */
 #ifdef UA_TYPES_CLOSESECURECHANNELREQUEST
-static void XS_pack_UA_CloseSecureChannelRequest(SV *out, UA_CloseSecureChannelRequest in)  __attribute__((unused));
-static UA_CloseSecureChannelRequest XS_unpack_UA_CloseSecureChannelRequest(SV *in)  __attribute__((unused));
 static void pack_UA_CloseSecureChannelRequest(SV *out, UA_CloseSecureChannelRequest *in);
 static void unpack_UA_CloseSecureChannelRequest(UA_CloseSecureChannelRequest *out, SV *in);
 
@@ -6501,41 +6218,41 @@ pack_UA_CloseSecureChannelRequest(SV *out, UA_CloseSecureChannelRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "CloseSecureChannelRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CloseSecureChannelRequest(UA_CloseSecureChannelRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CloseSecureChannelRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CloseSecureChannelRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
-
+	return;
 }
 #endif
 
 /* CloseSecureChannelResponse */
 #ifdef UA_TYPES_CLOSESECURECHANNELRESPONSE
-static void XS_pack_UA_CloseSecureChannelResponse(SV *out, UA_CloseSecureChannelResponse in)  __attribute__((unused));
-static UA_CloseSecureChannelResponse XS_unpack_UA_CloseSecureChannelResponse(SV *in)  __attribute__((unused));
 static void pack_UA_CloseSecureChannelResponse(SV *out, UA_CloseSecureChannelResponse *in);
 static void unpack_UA_CloseSecureChannelResponse(UA_CloseSecureChannelResponse *out, SV *in);
 
@@ -6544,41 +6261,41 @@ pack_UA_CloseSecureChannelResponse(SV *out, UA_CloseSecureChannelResponse *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "CloseSecureChannelResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CloseSecureChannelResponse(UA_CloseSecureChannelResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CloseSecureChannelResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CloseSecureChannelResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
-
+	return;
 }
 #endif
 
 /* SignedSoftwareCertificate */
 #ifdef UA_TYPES_SIGNEDSOFTWARECERTIFICATE
-static void XS_pack_UA_SignedSoftwareCertificate(SV *out, UA_SignedSoftwareCertificate in)  __attribute__((unused));
-static UA_SignedSoftwareCertificate XS_unpack_UA_SignedSoftwareCertificate(SV *in)  __attribute__((unused));
 static void pack_UA_SignedSoftwareCertificate(SV *out, UA_SignedSoftwareCertificate *in);
 static void unpack_UA_SignedSoftwareCertificate(UA_SignedSoftwareCertificate *out, SV *in);
 
@@ -6587,49 +6304,49 @@ pack_UA_SignedSoftwareCertificate(SV *out, UA_SignedSoftwareCertificate *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->certificateData);
-	hv_stores(hv, "SignedSoftwareCertificate_certificateData", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->signature);
-	hv_stores(hv, "SignedSoftwareCertificate_signature", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "SignedSoftwareCertificate_certificateData", sv);
+	pack_UA_ByteString(sv, &in->certificateData);
+
+	sv = newSV(0);
+	hv_stores(hv, "SignedSoftwareCertificate_signature", sv);
+	pack_UA_ByteString(sv, &in->signature);
+
+	return;
 }
 
 static void
 unpack_UA_SignedSoftwareCertificate(UA_SignedSoftwareCertificate *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SignedSoftwareCertificate_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SignedSoftwareCertificate_certificateData", 0);
 	if (svp != NULL)
-		out->certificateData = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->certificateData, *svp);
 
 	svp = hv_fetchs(hv, "SignedSoftwareCertificate_signature", 0);
 	if (svp != NULL)
-		out->signature = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->signature, *svp);
 
-
+	return;
 }
 #endif
 
 /* SessionAuthenticationToken */
 #ifdef UA_TYPES_SESSIONAUTHENTICATIONTOKEN
-static void XS_pack_UA_SessionAuthenticationToken(SV *out, UA_SessionAuthenticationToken in)  __attribute__((unused));
-static UA_SessionAuthenticationToken XS_unpack_UA_SessionAuthenticationToken(SV *in)  __attribute__((unused));
 static void pack_UA_SessionAuthenticationToken(SV *out, UA_SessionAuthenticationToken *in);
 static void unpack_UA_SessionAuthenticationToken(UA_SessionAuthenticationToken *out, SV *in);
 
@@ -6637,21 +6354,19 @@ static void
 pack_UA_SessionAuthenticationToken(SV *out, UA_SessionAuthenticationToken *in)
 {
 	dTHX;
-	XS_pack_UA_NodeId(out, *in);
+	pack_UA_NodeId(out, in);
 }
 
 static void
 unpack_UA_SessionAuthenticationToken(UA_SessionAuthenticationToken *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_NodeId(in);
+	unpack_UA_NodeId(out, in);
 }
 #endif
 
 /* SignatureData */
 #ifdef UA_TYPES_SIGNATUREDATA
-static void XS_pack_UA_SignatureData(SV *out, UA_SignatureData in)  __attribute__((unused));
-static UA_SignatureData XS_unpack_UA_SignatureData(SV *in)  __attribute__((unused));
 static void pack_UA_SignatureData(SV *out, UA_SignatureData *in);
 static void unpack_UA_SignatureData(UA_SignatureData *out, SV *in);
 
@@ -6660,49 +6375,49 @@ pack_UA_SignatureData(SV *out, UA_SignatureData *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->algorithm);
-	hv_stores(hv, "SignatureData_algorithm", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->signature);
-	hv_stores(hv, "SignatureData_signature", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "SignatureData_algorithm", sv);
+	pack_UA_String(sv, &in->algorithm);
+
+	sv = newSV(0);
+	hv_stores(hv, "SignatureData_signature", sv);
+	pack_UA_ByteString(sv, &in->signature);
+
+	return;
 }
 
 static void
 unpack_UA_SignatureData(UA_SignatureData *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SignatureData_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SignatureData_algorithm", 0);
 	if (svp != NULL)
-		out->algorithm = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->algorithm, *svp);
 
 	svp = hv_fetchs(hv, "SignatureData_signature", 0);
 	if (svp != NULL)
-		out->signature = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->signature, *svp);
 
-
+	return;
 }
 #endif
 
 /* CreateSessionRequest */
 #ifdef UA_TYPES_CREATESESSIONREQUEST
-static void XS_pack_UA_CreateSessionRequest(SV *out, UA_CreateSessionRequest in)  __attribute__((unused));
-static UA_CreateSessionRequest XS_unpack_UA_CreateSessionRequest(SV *in)  __attribute__((unused));
 static void pack_UA_CreateSessionRequest(SV *out, UA_CreateSessionRequest *in);
 static void unpack_UA_CreateSessionRequest(UA_CreateSessionRequest *out, SV *in);
 
@@ -6711,105 +6426,105 @@ pack_UA_CreateSessionRequest(SV *out, UA_CreateSessionRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
-	hv_stores(hv, "CreateSessionRequest_requestHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ApplicationDescription(sv, in->clientDescription);
-	hv_stores(hv, "CreateSessionRequest_clientDescription", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->serverUri);
-	hv_stores(hv, "CreateSessionRequest_serverUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->endpointUrl);
-	hv_stores(hv, "CreateSessionRequest_endpointUrl", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->sessionName);
-	hv_stores(hv, "CreateSessionRequest_sessionName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->clientNonce);
-	hv_stores(hv, "CreateSessionRequest_clientNonce", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->clientCertificate);
-	hv_stores(hv, "CreateSessionRequest_clientCertificate", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->requestedSessionTimeout);
-	hv_stores(hv, "CreateSessionRequest_requestedSessionTimeout", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxResponseMessageSize);
-	hv_stores(hv, "CreateSessionRequest_maxResponseMessageSize", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSessionRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSessionRequest_clientDescription", sv);
+	pack_UA_ApplicationDescription(sv, &in->clientDescription);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSessionRequest_serverUri", sv);
+	pack_UA_String(sv, &in->serverUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSessionRequest_endpointUrl", sv);
+	pack_UA_String(sv, &in->endpointUrl);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSessionRequest_sessionName", sv);
+	pack_UA_String(sv, &in->sessionName);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSessionRequest_clientNonce", sv);
+	pack_UA_ByteString(sv, &in->clientNonce);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSessionRequest_clientCertificate", sv);
+	pack_UA_ByteString(sv, &in->clientCertificate);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSessionRequest_requestedSessionTimeout", sv);
+	pack_UA_Double(sv, &in->requestedSessionTimeout);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSessionRequest_maxResponseMessageSize", sv);
+	pack_UA_UInt32(sv, &in->maxResponseMessageSize);
+
+	return;
 }
 
 static void
 unpack_UA_CreateSessionRequest(UA_CreateSessionRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CreateSessionRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CreateSessionRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionRequest_clientDescription", 0);
 	if (svp != NULL)
-		out->clientDescription = XS_unpack_UA_ApplicationDescription(*svp);
+		unpack_UA_ApplicationDescription(&out->clientDescription, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionRequest_serverUri", 0);
 	if (svp != NULL)
-		out->serverUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->serverUri, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionRequest_endpointUrl", 0);
 	if (svp != NULL)
-		out->endpointUrl = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->endpointUrl, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionRequest_sessionName", 0);
 	if (svp != NULL)
-		out->sessionName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->sessionName, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionRequest_clientNonce", 0);
 	if (svp != NULL)
-		out->clientNonce = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->clientNonce, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionRequest_clientCertificate", 0);
 	if (svp != NULL)
-		out->clientCertificate = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->clientCertificate, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionRequest_requestedSessionTimeout", 0);
 	if (svp != NULL)
-		out->requestedSessionTimeout = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->requestedSessionTimeout, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionRequest_maxResponseMessageSize", 0);
 	if (svp != NULL)
-		out->maxResponseMessageSize = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxResponseMessageSize, *svp);
 
-
+	return;
 }
 #endif
 
 /* CreateSessionResponse */
 #ifdef UA_TYPES_CREATESESSIONRESPONSE
-static void XS_pack_UA_CreateSessionResponse(SV *out, UA_CreateSessionResponse in)  __attribute__((unused));
-static UA_CreateSessionResponse XS_unpack_UA_CreateSessionResponse(SV *in)  __attribute__((unused));
 static void pack_UA_CreateSessionResponse(SV *out, UA_CreateSessionResponse *in);
 static void unpack_UA_CreateSessionResponse(UA_CreateSessionResponse *out, SV *in);
 
@@ -6820,157 +6535,151 @@ pack_UA_CreateSessionResponse(SV *out, UA_CreateSessionResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "CreateSessionResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->sessionId);
 	hv_stores(hv, "CreateSessionResponse_sessionId", sv);
+	pack_UA_NodeId(sv, &in->sessionId);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->authenticationToken);
 	hv_stores(hv, "CreateSessionResponse_authenticationToken", sv);
+	pack_UA_NodeId(sv, &in->authenticationToken);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->revisedSessionTimeout);
 	hv_stores(hv, "CreateSessionResponse_revisedSessionTimeout", sv);
+	pack_UA_Double(sv, &in->revisedSessionTimeout);
 
 	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->serverNonce);
 	hv_stores(hv, "CreateSessionResponse_serverNonce", sv);
+	pack_UA_ByteString(sv, &in->serverNonce);
 
 	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->serverCertificate);
 	hv_stores(hv, "CreateSessionResponse_serverCertificate", sv);
+	pack_UA_ByteString(sv, &in->serverCertificate);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CreateSessionResponse_serverEndpoints", newRV_noinc((SV*)av));
 	av_extend(av, in->serverEndpointsSize);
 	for (i = 0; i < in->serverEndpointsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EndpointDescription(sv, in->serverEndpoints[i]);
 		av_push(av, sv);
+		pack_UA_EndpointDescription(sv, &in->serverEndpoints[i]);
 	}
-	hv_stores(hv, "CreateSessionResponse_serverEndpoints", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CreateSessionResponse_serverSoftwareCertificates", newRV_noinc((SV*)av));
 	av_extend(av, in->serverSoftwareCertificatesSize);
 	for (i = 0; i < in->serverSoftwareCertificatesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_SignedSoftwareCertificate(sv, in->serverSoftwareCertificates[i]);
 		av_push(av, sv);
+		pack_UA_SignedSoftwareCertificate(sv, &in->serverSoftwareCertificates[i]);
 	}
-	hv_stores(hv, "CreateSessionResponse_serverSoftwareCertificates", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_SignatureData(sv, in->serverSignature);
 	hv_stores(hv, "CreateSessionResponse_serverSignature", sv);
+	pack_UA_SignatureData(sv, &in->serverSignature);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxRequestMessageSize);
 	hv_stores(hv, "CreateSessionResponse_maxRequestMessageSize", sv);
+	pack_UA_UInt32(sv, &in->maxRequestMessageSize);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CreateSessionResponse(UA_CreateSessionResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CreateSessionResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_sessionId", 0);
 	if (svp != NULL)
-		out->sessionId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->sessionId, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_authenticationToken", 0);
 	if (svp != NULL)
-		out->authenticationToken = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->authenticationToken, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_revisedSessionTimeout", 0);
 	if (svp != NULL)
-		out->revisedSessionTimeout = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->revisedSessionTimeout, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_serverNonce", 0);
 	if (svp != NULL)
-		out->serverNonce = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->serverNonce, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_serverCertificate", 0);
 	if (svp != NULL)
-		out->serverCertificate = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->serverCertificate, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_serverEndpoints", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CreateSessionResponse_serverEndpoints");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->serverEndpoints = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
-		if (out->serverEndpoints == NULL) {
+		if (out->serverEndpoints == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serverEndpointsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->serverEndpoints[i] = XS_unpack_UA_EndpointDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EndpointDescription(&out->serverEndpoints[i], *svp);
 		}
-		out->serverEndpointsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_serverSoftwareCertificates", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CreateSessionResponse_serverSoftwareCertificates");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->serverSoftwareCertificates = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIGNEDSOFTWARECERTIFICATE]);
-		if (out->serverSoftwareCertificates == NULL) {
+		if (out->serverSoftwareCertificates == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->serverSoftwareCertificatesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->serverSoftwareCertificates[i] = XS_unpack_UA_SignedSoftwareCertificate(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_SignedSoftwareCertificate(&out->serverSoftwareCertificates[i], *svp);
 		}
-		out->serverSoftwareCertificatesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_serverSignature", 0);
 	if (svp != NULL)
-		out->serverSignature = XS_unpack_UA_SignatureData(*svp);
+		unpack_UA_SignatureData(&out->serverSignature, *svp);
 
 	svp = hv_fetchs(hv, "CreateSessionResponse_maxRequestMessageSize", 0);
 	if (svp != NULL)
-		out->maxRequestMessageSize = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxRequestMessageSize, *svp);
 
-
+	return;
 }
 #endif
 
 /* UserIdentityToken */
 #ifdef UA_TYPES_USERIDENTITYTOKEN
-static void XS_pack_UA_UserIdentityToken(SV *out, UA_UserIdentityToken in)  __attribute__((unused));
-static UA_UserIdentityToken XS_unpack_UA_UserIdentityToken(SV *in)  __attribute__((unused));
 static void pack_UA_UserIdentityToken(SV *out, UA_UserIdentityToken *in);
 static void unpack_UA_UserIdentityToken(UA_UserIdentityToken *out, SV *in);
 
@@ -6979,41 +6688,41 @@ pack_UA_UserIdentityToken(SV *out, UA_UserIdentityToken *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->policyId);
 	hv_stores(hv, "UserIdentityToken_policyId", sv);
+	pack_UA_String(sv, &in->policyId);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_UserIdentityToken(UA_UserIdentityToken *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UserIdentityToken_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UserIdentityToken_policyId", 0);
 	if (svp != NULL)
-		out->policyId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->policyId, *svp);
 
-
+	return;
 }
 #endif
 
 /* AnonymousIdentityToken */
 #ifdef UA_TYPES_ANONYMOUSIDENTITYTOKEN
-static void XS_pack_UA_AnonymousIdentityToken(SV *out, UA_AnonymousIdentityToken in)  __attribute__((unused));
-static UA_AnonymousIdentityToken XS_unpack_UA_AnonymousIdentityToken(SV *in)  __attribute__((unused));
 static void pack_UA_AnonymousIdentityToken(SV *out, UA_AnonymousIdentityToken *in);
 static void unpack_UA_AnonymousIdentityToken(UA_AnonymousIdentityToken *out, SV *in);
 
@@ -7022,41 +6731,41 @@ pack_UA_AnonymousIdentityToken(SV *out, UA_AnonymousIdentityToken *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->policyId);
 	hv_stores(hv, "AnonymousIdentityToken_policyId", sv);
+	pack_UA_String(sv, &in->policyId);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_AnonymousIdentityToken(UA_AnonymousIdentityToken *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AnonymousIdentityToken_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AnonymousIdentityToken_policyId", 0);
 	if (svp != NULL)
-		out->policyId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->policyId, *svp);
 
-
+	return;
 }
 #endif
 
 /* UserNameIdentityToken */
 #ifdef UA_TYPES_USERNAMEIDENTITYTOKEN
-static void XS_pack_UA_UserNameIdentityToken(SV *out, UA_UserNameIdentityToken in)  __attribute__((unused));
-static UA_UserNameIdentityToken XS_unpack_UA_UserNameIdentityToken(SV *in)  __attribute__((unused));
 static void pack_UA_UserNameIdentityToken(SV *out, UA_UserNameIdentityToken *in);
 static void unpack_UA_UserNameIdentityToken(UA_UserNameIdentityToken *out, SV *in);
 
@@ -7065,65 +6774,65 @@ pack_UA_UserNameIdentityToken(SV *out, UA_UserNameIdentityToken *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->policyId);
-	hv_stores(hv, "UserNameIdentityToken_policyId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->userName);
-	hv_stores(hv, "UserNameIdentityToken_userName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->password);
-	hv_stores(hv, "UserNameIdentityToken_password", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->encryptionAlgorithm);
-	hv_stores(hv, "UserNameIdentityToken_encryptionAlgorithm", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "UserNameIdentityToken_policyId", sv);
+	pack_UA_String(sv, &in->policyId);
+
+	sv = newSV(0);
+	hv_stores(hv, "UserNameIdentityToken_userName", sv);
+	pack_UA_String(sv, &in->userName);
+
+	sv = newSV(0);
+	hv_stores(hv, "UserNameIdentityToken_password", sv);
+	pack_UA_ByteString(sv, &in->password);
+
+	sv = newSV(0);
+	hv_stores(hv, "UserNameIdentityToken_encryptionAlgorithm", sv);
+	pack_UA_String(sv, &in->encryptionAlgorithm);
+
+	return;
 }
 
 static void
 unpack_UA_UserNameIdentityToken(UA_UserNameIdentityToken *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UserNameIdentityToken_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UserNameIdentityToken_policyId", 0);
 	if (svp != NULL)
-		out->policyId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->policyId, *svp);
 
 	svp = hv_fetchs(hv, "UserNameIdentityToken_userName", 0);
 	if (svp != NULL)
-		out->userName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->userName, *svp);
 
 	svp = hv_fetchs(hv, "UserNameIdentityToken_password", 0);
 	if (svp != NULL)
-		out->password = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->password, *svp);
 
 	svp = hv_fetchs(hv, "UserNameIdentityToken_encryptionAlgorithm", 0);
 	if (svp != NULL)
-		out->encryptionAlgorithm = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->encryptionAlgorithm, *svp);
 
-
+	return;
 }
 #endif
 
 /* X509IdentityToken */
 #ifdef UA_TYPES_X509IDENTITYTOKEN
-static void XS_pack_UA_X509IdentityToken(SV *out, UA_X509IdentityToken in)  __attribute__((unused));
-static UA_X509IdentityToken XS_unpack_UA_X509IdentityToken(SV *in)  __attribute__((unused));
 static void pack_UA_X509IdentityToken(SV *out, UA_X509IdentityToken *in);
 static void unpack_UA_X509IdentityToken(UA_X509IdentityToken *out, SV *in);
 
@@ -7132,49 +6841,49 @@ pack_UA_X509IdentityToken(SV *out, UA_X509IdentityToken *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->policyId);
-	hv_stores(hv, "X509IdentityToken_policyId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->certificateData);
-	hv_stores(hv, "X509IdentityToken_certificateData", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "X509IdentityToken_policyId", sv);
+	pack_UA_String(sv, &in->policyId);
+
+	sv = newSV(0);
+	hv_stores(hv, "X509IdentityToken_certificateData", sv);
+	pack_UA_ByteString(sv, &in->certificateData);
+
+	return;
 }
 
 static void
 unpack_UA_X509IdentityToken(UA_X509IdentityToken *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_X509IdentityToken_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "X509IdentityToken_policyId", 0);
 	if (svp != NULL)
-		out->policyId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->policyId, *svp);
 
 	svp = hv_fetchs(hv, "X509IdentityToken_certificateData", 0);
 	if (svp != NULL)
-		out->certificateData = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->certificateData, *svp);
 
-
+	return;
 }
 #endif
 
 /* IssuedIdentityToken */
 #ifdef UA_TYPES_ISSUEDIDENTITYTOKEN
-static void XS_pack_UA_IssuedIdentityToken(SV *out, UA_IssuedIdentityToken in)  __attribute__((unused));
-static UA_IssuedIdentityToken XS_unpack_UA_IssuedIdentityToken(SV *in)  __attribute__((unused));
 static void pack_UA_IssuedIdentityToken(SV *out, UA_IssuedIdentityToken *in);
 static void unpack_UA_IssuedIdentityToken(UA_IssuedIdentityToken *out, SV *in);
 
@@ -7183,57 +6892,57 @@ pack_UA_IssuedIdentityToken(SV *out, UA_IssuedIdentityToken *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->policyId);
-	hv_stores(hv, "IssuedIdentityToken_policyId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->tokenData);
-	hv_stores(hv, "IssuedIdentityToken_tokenData", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->encryptionAlgorithm);
-	hv_stores(hv, "IssuedIdentityToken_encryptionAlgorithm", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "IssuedIdentityToken_policyId", sv);
+	pack_UA_String(sv, &in->policyId);
+
+	sv = newSV(0);
+	hv_stores(hv, "IssuedIdentityToken_tokenData", sv);
+	pack_UA_ByteString(sv, &in->tokenData);
+
+	sv = newSV(0);
+	hv_stores(hv, "IssuedIdentityToken_encryptionAlgorithm", sv);
+	pack_UA_String(sv, &in->encryptionAlgorithm);
+
+	return;
 }
 
 static void
 unpack_UA_IssuedIdentityToken(UA_IssuedIdentityToken *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_IssuedIdentityToken_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "IssuedIdentityToken_policyId", 0);
 	if (svp != NULL)
-		out->policyId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->policyId, *svp);
 
 	svp = hv_fetchs(hv, "IssuedIdentityToken_tokenData", 0);
 	if (svp != NULL)
-		out->tokenData = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->tokenData, *svp);
 
 	svp = hv_fetchs(hv, "IssuedIdentityToken_encryptionAlgorithm", 0);
 	if (svp != NULL)
-		out->encryptionAlgorithm = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->encryptionAlgorithm, *svp);
 
-
+	return;
 }
 #endif
 
 /* RsaEncryptedSecret */
 #ifdef UA_TYPES_RSAENCRYPTEDSECRET
-static void XS_pack_UA_RsaEncryptedSecret(SV *out, UA_RsaEncryptedSecret in)  __attribute__((unused));
-static UA_RsaEncryptedSecret XS_unpack_UA_RsaEncryptedSecret(SV *in)  __attribute__((unused));
 static void pack_UA_RsaEncryptedSecret(SV *out, UA_RsaEncryptedSecret *in);
 static void unpack_UA_RsaEncryptedSecret(UA_RsaEncryptedSecret *out, SV *in);
 
@@ -7241,21 +6950,19 @@ static void
 pack_UA_RsaEncryptedSecret(SV *out, UA_RsaEncryptedSecret *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_RsaEncryptedSecret(UA_RsaEncryptedSecret *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* ActivateSessionRequest */
 #ifdef UA_TYPES_ACTIVATESESSIONREQUEST
-static void XS_pack_UA_ActivateSessionRequest(SV *out, UA_ActivateSessionRequest in)  __attribute__((unused));
-static UA_ActivateSessionRequest XS_unpack_UA_ActivateSessionRequest(SV *in)  __attribute__((unused));
 static void pack_UA_ActivateSessionRequest(SV *out, UA_ActivateSessionRequest *in);
 static void unpack_UA_ActivateSessionRequest(UA_ActivateSessionRequest *out, SV *in);
 
@@ -7266,125 +6973,119 @@ pack_UA_ActivateSessionRequest(SV *out, UA_ActivateSessionRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "ActivateSessionRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_SignatureData(sv, in->clientSignature);
 	hv_stores(hv, "ActivateSessionRequest_clientSignature", sv);
+	pack_UA_SignatureData(sv, &in->clientSignature);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ActivateSessionRequest_clientSoftwareCertificates", newRV_noinc((SV*)av));
 	av_extend(av, in->clientSoftwareCertificatesSize);
 	for (i = 0; i < in->clientSoftwareCertificatesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_SignedSoftwareCertificate(sv, in->clientSoftwareCertificates[i]);
 		av_push(av, sv);
+		pack_UA_SignedSoftwareCertificate(sv, &in->clientSoftwareCertificates[i]);
 	}
-	hv_stores(hv, "ActivateSessionRequest_clientSoftwareCertificates", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ActivateSessionRequest_localeIds", newRV_noinc((SV*)av));
 	av_extend(av, in->localeIdsSize);
 	for (i = 0; i < in->localeIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->localeIds[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->localeIds[i]);
 	}
-	hv_stores(hv, "ActivateSessionRequest_localeIds", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->userIdentityToken);
 	hv_stores(hv, "ActivateSessionRequest_userIdentityToken", sv);
+	pack_UA_ExtensionObject(sv, &in->userIdentityToken);
 
 	sv = newSV(0);
-	XS_pack_UA_SignatureData(sv, in->userTokenSignature);
 	hv_stores(hv, "ActivateSessionRequest_userTokenSignature", sv);
+	pack_UA_SignatureData(sv, &in->userTokenSignature);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ActivateSessionRequest(UA_ActivateSessionRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ActivateSessionRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ActivateSessionRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "ActivateSessionRequest_clientSignature", 0);
 	if (svp != NULL)
-		out->clientSignature = XS_unpack_UA_SignatureData(*svp);
+		unpack_UA_SignatureData(&out->clientSignature, *svp);
 
 	svp = hv_fetchs(hv, "ActivateSessionRequest_clientSoftwareCertificates", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ActivateSessionRequest_clientSoftwareCertificates");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->clientSoftwareCertificates = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIGNEDSOFTWARECERTIFICATE]);
-		if (out->clientSoftwareCertificates == NULL) {
+		if (out->clientSoftwareCertificates == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->clientSoftwareCertificatesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->clientSoftwareCertificates[i] = XS_unpack_UA_SignedSoftwareCertificate(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_SignedSoftwareCertificate(&out->clientSoftwareCertificates[i], *svp);
 		}
-		out->clientSoftwareCertificatesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ActivateSessionRequest_localeIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ActivateSessionRequest_localeIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->localeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->localeIds == NULL) {
+		if (out->localeIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->localeIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->localeIds[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->localeIds[i], *svp);
 		}
-		out->localeIdsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ActivateSessionRequest_userIdentityToken", 0);
 	if (svp != NULL)
-		out->userIdentityToken = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->userIdentityToken, *svp);
 
 	svp = hv_fetchs(hv, "ActivateSessionRequest_userTokenSignature", 0);
 	if (svp != NULL)
-		out->userTokenSignature = XS_unpack_UA_SignatureData(*svp);
+		unpack_UA_SignatureData(&out->userTokenSignature, *svp);
 
-
+	return;
 }
 #endif
 
 /* ActivateSessionResponse */
 #ifdef UA_TYPES_ACTIVATESESSIONRESPONSE
-static void XS_pack_UA_ActivateSessionResponse(SV *out, UA_ActivateSessionResponse in)  __attribute__((unused));
-static UA_ActivateSessionResponse XS_unpack_UA_ActivateSessionResponse(SV *in)  __attribute__((unused));
 static void pack_UA_ActivateSessionResponse(SV *out, UA_ActivateSessionResponse *in);
 static void unpack_UA_ActivateSessionResponse(UA_ActivateSessionResponse *out, SV *in);
 
@@ -7395,109 +7096,103 @@ pack_UA_ActivateSessionResponse(SV *out, UA_ActivateSessionResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "ActivateSessionResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->serverNonce);
 	hv_stores(hv, "ActivateSessionResponse_serverNonce", sv);
+	pack_UA_ByteString(sv, &in->serverNonce);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ActivateSessionResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "ActivateSessionResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ActivateSessionResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "ActivateSessionResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ActivateSessionResponse(UA_ActivateSessionResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ActivateSessionResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ActivateSessionResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "ActivateSessionResponse_serverNonce", 0);
 	if (svp != NULL)
-		out->serverNonce = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->serverNonce, *svp);
 
 	svp = hv_fetchs(hv, "ActivateSessionResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ActivateSessionResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ActivateSessionResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ActivateSessionResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* CloseSessionRequest */
 #ifdef UA_TYPES_CLOSESESSIONREQUEST
-static void XS_pack_UA_CloseSessionRequest(SV *out, UA_CloseSessionRequest in)  __attribute__((unused));
-static UA_CloseSessionRequest XS_unpack_UA_CloseSessionRequest(SV *in)  __attribute__((unused));
 static void pack_UA_CloseSessionRequest(SV *out, UA_CloseSessionRequest *in);
 static void unpack_UA_CloseSessionRequest(UA_CloseSessionRequest *out, SV *in);
 
@@ -7506,49 +7201,49 @@ pack_UA_CloseSessionRequest(SV *out, UA_CloseSessionRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
-	hv_stores(hv, "CloseSessionRequest_requestHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->deleteSubscriptions);
-	hv_stores(hv, "CloseSessionRequest_deleteSubscriptions", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "CloseSessionRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "CloseSessionRequest_deleteSubscriptions", sv);
+	pack_UA_Boolean(sv, &in->deleteSubscriptions);
+
+	return;
 }
 
 static void
 unpack_UA_CloseSessionRequest(UA_CloseSessionRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CloseSessionRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CloseSessionRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "CloseSessionRequest_deleteSubscriptions", 0);
 	if (svp != NULL)
-		out->deleteSubscriptions = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->deleteSubscriptions, *svp);
 
-
+	return;
 }
 #endif
 
 /* CloseSessionResponse */
 #ifdef UA_TYPES_CLOSESESSIONRESPONSE
-static void XS_pack_UA_CloseSessionResponse(SV *out, UA_CloseSessionResponse in)  __attribute__((unused));
-static UA_CloseSessionResponse XS_unpack_UA_CloseSessionResponse(SV *in)  __attribute__((unused));
 static void pack_UA_CloseSessionResponse(SV *out, UA_CloseSessionResponse *in);
 static void unpack_UA_CloseSessionResponse(UA_CloseSessionResponse *out, SV *in);
 
@@ -7557,41 +7252,41 @@ pack_UA_CloseSessionResponse(SV *out, UA_CloseSessionResponse *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "CloseSessionResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CloseSessionResponse(UA_CloseSessionResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CloseSessionResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CloseSessionResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
-
+	return;
 }
 #endif
 
 /* CancelRequest */
 #ifdef UA_TYPES_CANCELREQUEST
-static void XS_pack_UA_CancelRequest(SV *out, UA_CancelRequest in)  __attribute__((unused));
-static UA_CancelRequest XS_unpack_UA_CancelRequest(SV *in)  __attribute__((unused));
 static void pack_UA_CancelRequest(SV *out, UA_CancelRequest *in);
 static void unpack_UA_CancelRequest(UA_CancelRequest *out, SV *in);
 
@@ -7600,49 +7295,49 @@ pack_UA_CancelRequest(SV *out, UA_CancelRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
-	hv_stores(hv, "CancelRequest_requestHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->requestHandle);
-	hv_stores(hv, "CancelRequest_requestHandle", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "CancelRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "CancelRequest_requestHandle", sv);
+	pack_UA_UInt32(sv, &in->requestHandle);
+
+	return;
 }
 
 static void
 unpack_UA_CancelRequest(UA_CancelRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CancelRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CancelRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "CancelRequest_requestHandle", 0);
 	if (svp != NULL)
-		out->requestHandle = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->requestHandle, *svp);
 
-
+	return;
 }
 #endif
 
 /* CancelResponse */
 #ifdef UA_TYPES_CANCELRESPONSE
-static void XS_pack_UA_CancelResponse(SV *out, UA_CancelResponse in)  __attribute__((unused));
-static UA_CancelResponse XS_unpack_UA_CancelResponse(SV *in)  __attribute__((unused));
 static void pack_UA_CancelResponse(SV *out, UA_CancelResponse *in);
 static void unpack_UA_CancelResponse(UA_CancelResponse *out, SV *in);
 
@@ -7651,49 +7346,49 @@ pack_UA_CancelResponse(SV *out, UA_CancelResponse *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
-	hv_stores(hv, "CancelResponse_responseHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->cancelCount);
-	hv_stores(hv, "CancelResponse_cancelCount", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "CancelResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "CancelResponse_cancelCount", sv);
+	pack_UA_UInt32(sv, &in->cancelCount);
+
+	return;
 }
 
 static void
 unpack_UA_CancelResponse(UA_CancelResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CancelResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CancelResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "CancelResponse_cancelCount", 0);
 	if (svp != NULL)
-		out->cancelCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->cancelCount, *svp);
 
-
+	return;
 }
 #endif
 
 /* NodeAttributesMask */
 #ifdef UA_TYPES_NODEATTRIBUTESMASK
-static void XS_pack_UA_NodeAttributesMask(SV *out, UA_NodeAttributesMask in)  __attribute__((unused));
-static UA_NodeAttributesMask XS_unpack_UA_NodeAttributesMask(SV *in)  __attribute__((unused));
 static void pack_UA_NodeAttributesMask(SV *out, UA_NodeAttributesMask *in);
 static void unpack_UA_NodeAttributesMask(UA_NodeAttributesMask *out, SV *in);
 
@@ -7714,8 +7409,6 @@ unpack_UA_NodeAttributesMask(UA_NodeAttributesMask *out, SV *in)
 
 /* NodeAttributes */
 #ifdef UA_TYPES_NODEATTRIBUTES
-static void XS_pack_UA_NodeAttributes(SV *out, UA_NodeAttributes in)  __attribute__((unused));
-static UA_NodeAttributes XS_unpack_UA_NodeAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_NodeAttributes(SV *out, UA_NodeAttributes *in);
 static void unpack_UA_NodeAttributes(UA_NodeAttributes *out, SV *in);
 
@@ -7724,73 +7417,73 @@ pack_UA_NodeAttributes(SV *out, UA_NodeAttributes *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
-	hv_stores(hv, "NodeAttributes_specifiedAttributes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "NodeAttributes_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "NodeAttributes_description", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
-	hv_stores(hv, "NodeAttributes_writeMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
-	hv_stores(hv, "NodeAttributes_userWriteMask", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "NodeAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
+
+	sv = newSV(0);
+	hv_stores(hv, "NodeAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "NodeAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	sv = newSV(0);
+	hv_stores(hv, "NodeAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "NodeAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
+
+	return;
 }
 
 static void
 unpack_UA_NodeAttributes(UA_NodeAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_NodeAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "NodeAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "NodeAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "NodeAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "NodeAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "NodeAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
-
+	return;
 }
 #endif
 
 /* ObjectAttributes */
 #ifdef UA_TYPES_OBJECTATTRIBUTES
-static void XS_pack_UA_ObjectAttributes(SV *out, UA_ObjectAttributes in)  __attribute__((unused));
-static UA_ObjectAttributes XS_unpack_UA_ObjectAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_ObjectAttributes(SV *out, UA_ObjectAttributes *in);
 static void unpack_UA_ObjectAttributes(UA_ObjectAttributes *out, SV *in);
 
@@ -7799,81 +7492,81 @@ pack_UA_ObjectAttributes(SV *out, UA_ObjectAttributes *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
-	hv_stores(hv, "ObjectAttributes_specifiedAttributes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "ObjectAttributes_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "ObjectAttributes_description", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
-	hv_stores(hv, "ObjectAttributes_writeMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
-	hv_stores(hv, "ObjectAttributes_userWriteMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->eventNotifier);
-	hv_stores(hv, "ObjectAttributes_eventNotifier", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectAttributes_eventNotifier", sv);
+	pack_UA_Byte(sv, &in->eventNotifier);
+
+	return;
 }
 
 static void
 unpack_UA_ObjectAttributes(UA_ObjectAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ObjectAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ObjectAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "ObjectAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "ObjectAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "ObjectAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "ObjectAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
 	svp = hv_fetchs(hv, "ObjectAttributes_eventNotifier", 0);
 	if (svp != NULL)
-		out->eventNotifier = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->eventNotifier, *svp);
 
-
+	return;
 }
 #endif
 
 /* VariableAttributes */
 #ifdef UA_TYPES_VARIABLEATTRIBUTES
-static void XS_pack_UA_VariableAttributes(SV *out, UA_VariableAttributes in)  __attribute__((unused));
-static UA_VariableAttributes XS_unpack_UA_VariableAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_VariableAttributes(SV *out, UA_VariableAttributes *in);
 static void unpack_UA_VariableAttributes(UA_VariableAttributes *out, SV *in);
 
@@ -7884,160 +7577,157 @@ pack_UA_VariableAttributes(SV *out, UA_VariableAttributes *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
 	hv_stores(hv, "VariableAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
 	hv_stores(hv, "VariableAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
 	hv_stores(hv, "VariableAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
 	hv_stores(hv, "VariableAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
 	hv_stores(hv, "VariableAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
 
 	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->value);
 	hv_stores(hv, "VariableAttributes_value", sv);
+	pack_UA_Variant(sv, &in->value);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->dataType);
 	hv_stores(hv, "VariableAttributes_dataType", sv);
+	pack_UA_NodeId(sv, &in->dataType);
 
 	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->valueRank);
 	hv_stores(hv, "VariableAttributes_valueRank", sv);
+	pack_UA_Int32(sv, &in->valueRank);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "VariableAttributes_arrayDimensions", newRV_noinc((SV*)av));
 	av_extend(av, in->arrayDimensionsSize);
 	for (i = 0; i < in->arrayDimensionsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->arrayDimensions[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->arrayDimensions[i]);
 	}
-	hv_stores(hv, "VariableAttributes_arrayDimensions", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->accessLevel);
 	hv_stores(hv, "VariableAttributes_accessLevel", sv);
+	pack_UA_Byte(sv, &in->accessLevel);
 
 	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->userAccessLevel);
 	hv_stores(hv, "VariableAttributes_userAccessLevel", sv);
+	pack_UA_Byte(sv, &in->userAccessLevel);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->minimumSamplingInterval);
 	hv_stores(hv, "VariableAttributes_minimumSamplingInterval", sv);
+	pack_UA_Double(sv, &in->minimumSamplingInterval);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->historizing);
 	hv_stores(hv, "VariableAttributes_historizing", sv);
+	pack_UA_Boolean(sv, &in->historizing);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_VariableAttributes(UA_VariableAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_VariableAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "VariableAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->value, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_dataType", 0);
 	if (svp != NULL)
-		out->dataType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->dataType, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_valueRank", 0);
 	if (svp != NULL)
-		out->valueRank = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->valueRank, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_arrayDimensions", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for VariableAttributes_arrayDimensions");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->arrayDimensions = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->arrayDimensions == NULL) {
+		if (out->arrayDimensions == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->arrayDimensionsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->arrayDimensions[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->arrayDimensions[i], *svp);
 		}
-		out->arrayDimensionsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "VariableAttributes_accessLevel", 0);
 	if (svp != NULL)
-		out->accessLevel = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->accessLevel, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_userAccessLevel", 0);
 	if (svp != NULL)
-		out->userAccessLevel = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->userAccessLevel, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_minimumSamplingInterval", 0);
 	if (svp != NULL)
-		out->minimumSamplingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->minimumSamplingInterval, *svp);
 
 	svp = hv_fetchs(hv, "VariableAttributes_historizing", 0);
 	if (svp != NULL)
-		out->historizing = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->historizing, *svp);
 
-
+	return;
 }
 #endif
 
 /* MethodAttributes */
 #ifdef UA_TYPES_METHODATTRIBUTES
-static void XS_pack_UA_MethodAttributes(SV *out, UA_MethodAttributes in)  __attribute__((unused));
-static UA_MethodAttributes XS_unpack_UA_MethodAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_MethodAttributes(SV *out, UA_MethodAttributes *in);
 static void unpack_UA_MethodAttributes(UA_MethodAttributes *out, SV *in);
 
@@ -8046,89 +7736,89 @@ pack_UA_MethodAttributes(SV *out, UA_MethodAttributes *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
-	hv_stores(hv, "MethodAttributes_specifiedAttributes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "MethodAttributes_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "MethodAttributes_description", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
-	hv_stores(hv, "MethodAttributes_writeMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
-	hv_stores(hv, "MethodAttributes_userWriteMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->executable);
-	hv_stores(hv, "MethodAttributes_executable", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->userExecutable);
-	hv_stores(hv, "MethodAttributes_userExecutable", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "MethodAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
+
+	sv = newSV(0);
+	hv_stores(hv, "MethodAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "MethodAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	sv = newSV(0);
+	hv_stores(hv, "MethodAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "MethodAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "MethodAttributes_executable", sv);
+	pack_UA_Boolean(sv, &in->executable);
+
+	sv = newSV(0);
+	hv_stores(hv, "MethodAttributes_userExecutable", sv);
+	pack_UA_Boolean(sv, &in->userExecutable);
+
+	return;
 }
 
 static void
 unpack_UA_MethodAttributes(UA_MethodAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_MethodAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "MethodAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "MethodAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "MethodAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "MethodAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "MethodAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
 	svp = hv_fetchs(hv, "MethodAttributes_executable", 0);
 	if (svp != NULL)
-		out->executable = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->executable, *svp);
 
 	svp = hv_fetchs(hv, "MethodAttributes_userExecutable", 0);
 	if (svp != NULL)
-		out->userExecutable = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->userExecutable, *svp);
 
-
+	return;
 }
 #endif
 
 /* ObjectTypeAttributes */
 #ifdef UA_TYPES_OBJECTTYPEATTRIBUTES
-static void XS_pack_UA_ObjectTypeAttributes(SV *out, UA_ObjectTypeAttributes in)  __attribute__((unused));
-static UA_ObjectTypeAttributes XS_unpack_UA_ObjectTypeAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_ObjectTypeAttributes(SV *out, UA_ObjectTypeAttributes *in);
 static void unpack_UA_ObjectTypeAttributes(UA_ObjectTypeAttributes *out, SV *in);
 
@@ -8137,81 +7827,81 @@ pack_UA_ObjectTypeAttributes(SV *out, UA_ObjectTypeAttributes *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
-	hv_stores(hv, "ObjectTypeAttributes_specifiedAttributes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "ObjectTypeAttributes_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "ObjectTypeAttributes_description", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
-	hv_stores(hv, "ObjectTypeAttributes_writeMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
-	hv_stores(hv, "ObjectTypeAttributes_userWriteMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isAbstract);
-	hv_stores(hv, "ObjectTypeAttributes_isAbstract", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectTypeAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectTypeAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectTypeAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectTypeAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectTypeAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "ObjectTypeAttributes_isAbstract", sv);
+	pack_UA_Boolean(sv, &in->isAbstract);
+
+	return;
 }
 
 static void
 unpack_UA_ObjectTypeAttributes(UA_ObjectTypeAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ObjectTypeAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ObjectTypeAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "ObjectTypeAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "ObjectTypeAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "ObjectTypeAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "ObjectTypeAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
 	svp = hv_fetchs(hv, "ObjectTypeAttributes_isAbstract", 0);
 	if (svp != NULL)
-		out->isAbstract = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isAbstract, *svp);
 
-
+	return;
 }
 #endif
 
 /* VariableTypeAttributes */
 #ifdef UA_TYPES_VARIABLETYPEATTRIBUTES
-static void XS_pack_UA_VariableTypeAttributes(SV *out, UA_VariableTypeAttributes in)  __attribute__((unused));
-static UA_VariableTypeAttributes XS_unpack_UA_VariableTypeAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_VariableTypeAttributes(SV *out, UA_VariableTypeAttributes *in);
 static void unpack_UA_VariableTypeAttributes(UA_VariableTypeAttributes *out, SV *in);
 
@@ -8222,136 +7912,133 @@ pack_UA_VariableTypeAttributes(SV *out, UA_VariableTypeAttributes *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
 	hv_stores(hv, "VariableTypeAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
 	hv_stores(hv, "VariableTypeAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
 	hv_stores(hv, "VariableTypeAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
 	hv_stores(hv, "VariableTypeAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
 	hv_stores(hv, "VariableTypeAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
 
 	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->value);
 	hv_stores(hv, "VariableTypeAttributes_value", sv);
+	pack_UA_Variant(sv, &in->value);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->dataType);
 	hv_stores(hv, "VariableTypeAttributes_dataType", sv);
+	pack_UA_NodeId(sv, &in->dataType);
 
 	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->valueRank);
 	hv_stores(hv, "VariableTypeAttributes_valueRank", sv);
+	pack_UA_Int32(sv, &in->valueRank);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "VariableTypeAttributes_arrayDimensions", newRV_noinc((SV*)av));
 	av_extend(av, in->arrayDimensionsSize);
 	for (i = 0; i < in->arrayDimensionsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->arrayDimensions[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->arrayDimensions[i]);
 	}
-	hv_stores(hv, "VariableTypeAttributes_arrayDimensions", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isAbstract);
 	hv_stores(hv, "VariableTypeAttributes_isAbstract", sv);
+	pack_UA_Boolean(sv, &in->isAbstract);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_VariableTypeAttributes(UA_VariableTypeAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_VariableTypeAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->value, *svp);
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_dataType", 0);
 	if (svp != NULL)
-		out->dataType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->dataType, *svp);
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_valueRank", 0);
 	if (svp != NULL)
-		out->valueRank = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->valueRank, *svp);
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_arrayDimensions", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for VariableTypeAttributes_arrayDimensions");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->arrayDimensions = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->arrayDimensions == NULL) {
+		if (out->arrayDimensions == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->arrayDimensionsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->arrayDimensions[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->arrayDimensions[i], *svp);
 		}
-		out->arrayDimensionsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "VariableTypeAttributes_isAbstract", 0);
 	if (svp != NULL)
-		out->isAbstract = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isAbstract, *svp);
 
-
+	return;
 }
 #endif
 
 /* ReferenceTypeAttributes */
 #ifdef UA_TYPES_REFERENCETYPEATTRIBUTES
-static void XS_pack_UA_ReferenceTypeAttributes(SV *out, UA_ReferenceTypeAttributes in)  __attribute__((unused));
-static UA_ReferenceTypeAttributes XS_unpack_UA_ReferenceTypeAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_ReferenceTypeAttributes(SV *out, UA_ReferenceTypeAttributes *in);
 static void unpack_UA_ReferenceTypeAttributes(UA_ReferenceTypeAttributes *out, SV *in);
 
@@ -8360,97 +8047,97 @@ pack_UA_ReferenceTypeAttributes(SV *out, UA_ReferenceTypeAttributes *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
-	hv_stores(hv, "ReferenceTypeAttributes_specifiedAttributes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "ReferenceTypeAttributes_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "ReferenceTypeAttributes_description", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
-	hv_stores(hv, "ReferenceTypeAttributes_writeMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
-	hv_stores(hv, "ReferenceTypeAttributes_userWriteMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isAbstract);
-	hv_stores(hv, "ReferenceTypeAttributes_isAbstract", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->symmetric);
-	hv_stores(hv, "ReferenceTypeAttributes_symmetric", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->inverseName);
-	hv_stores(hv, "ReferenceTypeAttributes_inverseName", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceTypeAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceTypeAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceTypeAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceTypeAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceTypeAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceTypeAttributes_isAbstract", sv);
+	pack_UA_Boolean(sv, &in->isAbstract);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceTypeAttributes_symmetric", sv);
+	pack_UA_Boolean(sv, &in->symmetric);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceTypeAttributes_inverseName", sv);
+	pack_UA_LocalizedText(sv, &in->inverseName);
+
+	return;
 }
 
 static void
 unpack_UA_ReferenceTypeAttributes(UA_ReferenceTypeAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReferenceTypeAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReferenceTypeAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceTypeAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceTypeAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceTypeAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceTypeAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceTypeAttributes_isAbstract", 0);
 	if (svp != NULL)
-		out->isAbstract = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isAbstract, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceTypeAttributes_symmetric", 0);
 	if (svp != NULL)
-		out->symmetric = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->symmetric, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceTypeAttributes_inverseName", 0);
 	if (svp != NULL)
-		out->inverseName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->inverseName, *svp);
 
-
+	return;
 }
 #endif
 
 /* DataTypeAttributes */
 #ifdef UA_TYPES_DATATYPEATTRIBUTES
-static void XS_pack_UA_DataTypeAttributes(SV *out, UA_DataTypeAttributes in)  __attribute__((unused));
-static UA_DataTypeAttributes XS_unpack_UA_DataTypeAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_DataTypeAttributes(SV *out, UA_DataTypeAttributes *in);
 static void unpack_UA_DataTypeAttributes(UA_DataTypeAttributes *out, SV *in);
 
@@ -8459,81 +8146,81 @@ pack_UA_DataTypeAttributes(SV *out, UA_DataTypeAttributes *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
-	hv_stores(hv, "DataTypeAttributes_specifiedAttributes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "DataTypeAttributes_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "DataTypeAttributes_description", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
-	hv_stores(hv, "DataTypeAttributes_writeMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
-	hv_stores(hv, "DataTypeAttributes_userWriteMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isAbstract);
-	hv_stores(hv, "DataTypeAttributes_isAbstract", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "DataTypeAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
+
+	sv = newSV(0);
+	hv_stores(hv, "DataTypeAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "DataTypeAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	sv = newSV(0);
+	hv_stores(hv, "DataTypeAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "DataTypeAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "DataTypeAttributes_isAbstract", sv);
+	pack_UA_Boolean(sv, &in->isAbstract);
+
+	return;
 }
 
 static void
 unpack_UA_DataTypeAttributes(UA_DataTypeAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DataTypeAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DataTypeAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "DataTypeAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "DataTypeAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "DataTypeAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "DataTypeAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
 	svp = hv_fetchs(hv, "DataTypeAttributes_isAbstract", 0);
 	if (svp != NULL)
-		out->isAbstract = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isAbstract, *svp);
 
-
+	return;
 }
 #endif
 
 /* ViewAttributes */
 #ifdef UA_TYPES_VIEWATTRIBUTES
-static void XS_pack_UA_ViewAttributes(SV *out, UA_ViewAttributes in)  __attribute__((unused));
-static UA_ViewAttributes XS_unpack_UA_ViewAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_ViewAttributes(SV *out, UA_ViewAttributes *in);
 static void unpack_UA_ViewAttributes(UA_ViewAttributes *out, SV *in);
 
@@ -8542,89 +8229,89 @@ pack_UA_ViewAttributes(SV *out, UA_ViewAttributes *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
-	hv_stores(hv, "ViewAttributes_specifiedAttributes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "ViewAttributes_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "ViewAttributes_description", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
-	hv_stores(hv, "ViewAttributes_writeMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
-	hv_stores(hv, "ViewAttributes_userWriteMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->containsNoLoops);
-	hv_stores(hv, "ViewAttributes_containsNoLoops", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->eventNotifier);
-	hv_stores(hv, "ViewAttributes_eventNotifier", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewAttributes_containsNoLoops", sv);
+	pack_UA_Boolean(sv, &in->containsNoLoops);
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewAttributes_eventNotifier", sv);
+	pack_UA_Byte(sv, &in->eventNotifier);
+
+	return;
 }
 
 static void
 unpack_UA_ViewAttributes(UA_ViewAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ViewAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ViewAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "ViewAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "ViewAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "ViewAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "ViewAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
 	svp = hv_fetchs(hv, "ViewAttributes_containsNoLoops", 0);
 	if (svp != NULL)
-		out->containsNoLoops = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->containsNoLoops, *svp);
 
 	svp = hv_fetchs(hv, "ViewAttributes_eventNotifier", 0);
 	if (svp != NULL)
-		out->eventNotifier = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->eventNotifier, *svp);
 
-
+	return;
 }
 #endif
 
 /* GenericAttributeValue */
 #ifdef UA_TYPES_GENERICATTRIBUTEVALUE
-static void XS_pack_UA_GenericAttributeValue(SV *out, UA_GenericAttributeValue in)  __attribute__((unused));
-static UA_GenericAttributeValue XS_unpack_UA_GenericAttributeValue(SV *in)  __attribute__((unused));
 static void pack_UA_GenericAttributeValue(SV *out, UA_GenericAttributeValue *in);
 static void unpack_UA_GenericAttributeValue(UA_GenericAttributeValue *out, SV *in);
 
@@ -8633,49 +8320,49 @@ pack_UA_GenericAttributeValue(SV *out, UA_GenericAttributeValue *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->attributeId);
-	hv_stores(hv, "GenericAttributeValue_attributeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->value);
-	hv_stores(hv, "GenericAttributeValue_value", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "GenericAttributeValue_attributeId", sv);
+	pack_UA_UInt32(sv, &in->attributeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "GenericAttributeValue_value", sv);
+	pack_UA_Variant(sv, &in->value);
+
+	return;
 }
 
 static void
 unpack_UA_GenericAttributeValue(UA_GenericAttributeValue *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_GenericAttributeValue_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "GenericAttributeValue_attributeId", 0);
 	if (svp != NULL)
-		out->attributeId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->attributeId, *svp);
 
 	svp = hv_fetchs(hv, "GenericAttributeValue_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->value, *svp);
 
-
+	return;
 }
 #endif
 
 /* GenericAttributes */
 #ifdef UA_TYPES_GENERICATTRIBUTES
-static void XS_pack_UA_GenericAttributes(SV *out, UA_GenericAttributes in)  __attribute__((unused));
-static UA_GenericAttributes XS_unpack_UA_GenericAttributes(SV *in)  __attribute__((unused));
 static void pack_UA_GenericAttributes(SV *out, UA_GenericAttributes *in);
 static void unpack_UA_GenericAttributes(UA_GenericAttributes *out, SV *in);
 
@@ -8686,104 +8373,101 @@ pack_UA_GenericAttributes(SV *out, UA_GenericAttributes *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->specifiedAttributes);
 	hv_stores(hv, "GenericAttributes_specifiedAttributes", sv);
+	pack_UA_UInt32(sv, &in->specifiedAttributes);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
 	hv_stores(hv, "GenericAttributes_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
 	hv_stores(hv, "GenericAttributes_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->writeMask);
 	hv_stores(hv, "GenericAttributes_writeMask", sv);
+	pack_UA_UInt32(sv, &in->writeMask);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->userWriteMask);
 	hv_stores(hv, "GenericAttributes_userWriteMask", sv);
+	pack_UA_UInt32(sv, &in->userWriteMask);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "GenericAttributes_attributeValues", newRV_noinc((SV*)av));
 	av_extend(av, in->attributeValuesSize);
 	for (i = 0; i < in->attributeValuesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_GenericAttributeValue(sv, in->attributeValues[i]);
 		av_push(av, sv);
+		pack_UA_GenericAttributeValue(sv, &in->attributeValues[i]);
 	}
-	hv_stores(hv, "GenericAttributes_attributeValues", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_GenericAttributes(UA_GenericAttributes *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_GenericAttributes_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "GenericAttributes_specifiedAttributes", 0);
 	if (svp != NULL)
-		out->specifiedAttributes = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->specifiedAttributes, *svp);
 
 	svp = hv_fetchs(hv, "GenericAttributes_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "GenericAttributes_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "GenericAttributes_writeMask", 0);
 	if (svp != NULL)
-		out->writeMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->writeMask, *svp);
 
 	svp = hv_fetchs(hv, "GenericAttributes_userWriteMask", 0);
 	if (svp != NULL)
-		out->userWriteMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->userWriteMask, *svp);
 
 	svp = hv_fetchs(hv, "GenericAttributes_attributeValues", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for GenericAttributes_attributeValues");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->attributeValues = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_GENERICATTRIBUTEVALUE]);
-		if (out->attributeValues == NULL) {
+		if (out->attributeValues == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->attributeValuesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->attributeValues[i] = XS_unpack_UA_GenericAttributeValue(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_GenericAttributeValue(&out->attributeValues[i], *svp);
 		}
-		out->attributeValuesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* AddNodesItem */
 #ifdef UA_TYPES_ADDNODESITEM
-static void XS_pack_UA_AddNodesItem(SV *out, UA_AddNodesItem in)  __attribute__((unused));
-static UA_AddNodesItem XS_unpack_UA_AddNodesItem(SV *in)  __attribute__((unused));
 static void pack_UA_AddNodesItem(SV *out, UA_AddNodesItem *in);
 static void unpack_UA_AddNodesItem(UA_AddNodesItem *out, SV *in);
 
@@ -8792,89 +8476,89 @@ pack_UA_AddNodesItem(SV *out, UA_AddNodesItem *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->parentNodeId);
-	hv_stores(hv, "AddNodesItem_parentNodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->referenceTypeId);
-	hv_stores(hv, "AddNodesItem_referenceTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->requestedNewNodeId);
-	hv_stores(hv, "AddNodesItem_requestedNewNodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->browseName);
-	hv_stores(hv, "AddNodesItem_browseName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeClass(sv, in->nodeClass);
-	hv_stores(hv, "AddNodesItem_nodeClass", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->nodeAttributes);
-	hv_stores(hv, "AddNodesItem_nodeAttributes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->typeDefinition);
-	hv_stores(hv, "AddNodesItem_typeDefinition", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "AddNodesItem_parentNodeId", sv);
+	pack_UA_ExpandedNodeId(sv, &in->parentNodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddNodesItem_referenceTypeId", sv);
+	pack_UA_NodeId(sv, &in->referenceTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddNodesItem_requestedNewNodeId", sv);
+	pack_UA_ExpandedNodeId(sv, &in->requestedNewNodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddNodesItem_browseName", sv);
+	pack_UA_QualifiedName(sv, &in->browseName);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddNodesItem_nodeClass", sv);
+	pack_UA_NodeClass(sv, &in->nodeClass);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddNodesItem_nodeAttributes", sv);
+	pack_UA_ExtensionObject(sv, &in->nodeAttributes);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddNodesItem_typeDefinition", sv);
+	pack_UA_ExpandedNodeId(sv, &in->typeDefinition);
+
+	return;
 }
 
 static void
 unpack_UA_AddNodesItem(UA_AddNodesItem *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AddNodesItem_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AddNodesItem_parentNodeId", 0);
 	if (svp != NULL)
-		out->parentNodeId = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->parentNodeId, *svp);
 
 	svp = hv_fetchs(hv, "AddNodesItem_referenceTypeId", 0);
 	if (svp != NULL)
-		out->referenceTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->referenceTypeId, *svp);
 
 	svp = hv_fetchs(hv, "AddNodesItem_requestedNewNodeId", 0);
 	if (svp != NULL)
-		out->requestedNewNodeId = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->requestedNewNodeId, *svp);
 
 	svp = hv_fetchs(hv, "AddNodesItem_browseName", 0);
 	if (svp != NULL)
-		out->browseName = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->browseName, *svp);
 
 	svp = hv_fetchs(hv, "AddNodesItem_nodeClass", 0);
 	if (svp != NULL)
-		out->nodeClass = XS_unpack_UA_NodeClass(*svp);
+		unpack_UA_NodeClass(&out->nodeClass, *svp);
 
 	svp = hv_fetchs(hv, "AddNodesItem_nodeAttributes", 0);
 	if (svp != NULL)
-		out->nodeAttributes = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->nodeAttributes, *svp);
 
 	svp = hv_fetchs(hv, "AddNodesItem_typeDefinition", 0);
 	if (svp != NULL)
-		out->typeDefinition = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->typeDefinition, *svp);
 
-
+	return;
 }
 #endif
 
 /* AddNodesResult */
 #ifdef UA_TYPES_ADDNODESRESULT
-static void XS_pack_UA_AddNodesResult(SV *out, UA_AddNodesResult in)  __attribute__((unused));
-static UA_AddNodesResult XS_unpack_UA_AddNodesResult(SV *in)  __attribute__((unused));
 static void pack_UA_AddNodesResult(SV *out, UA_AddNodesResult *in);
 static void unpack_UA_AddNodesResult(UA_AddNodesResult *out, SV *in);
 
@@ -8883,49 +8567,49 @@ pack_UA_AddNodesResult(SV *out, UA_AddNodesResult *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
-	hv_stores(hv, "AddNodesResult_statusCode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->addedNodeId);
-	hv_stores(hv, "AddNodesResult_addedNodeId", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "AddNodesResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddNodesResult_addedNodeId", sv);
+	pack_UA_NodeId(sv, &in->addedNodeId);
+
+	return;
 }
 
 static void
 unpack_UA_AddNodesResult(UA_AddNodesResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AddNodesResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AddNodesResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "AddNodesResult_addedNodeId", 0);
 	if (svp != NULL)
-		out->addedNodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->addedNodeId, *svp);
 
-
+	return;
 }
 #endif
 
 /* AddNodesRequest */
 #ifdef UA_TYPES_ADDNODESREQUEST
-static void XS_pack_UA_AddNodesRequest(SV *out, UA_AddNodesRequest in)  __attribute__((unused));
-static UA_AddNodesRequest XS_unpack_UA_AddNodesRequest(SV *in)  __attribute__((unused));
 static void pack_UA_AddNodesRequest(SV *out, UA_AddNodesRequest *in);
 static void unpack_UA_AddNodesRequest(UA_AddNodesRequest *out, SV *in);
 
@@ -8936,72 +8620,69 @@ pack_UA_AddNodesRequest(SV *out, UA_AddNodesRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "AddNodesRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "AddNodesRequest_nodesToAdd", newRV_noinc((SV*)av));
 	av_extend(av, in->nodesToAddSize);
 	for (i = 0; i < in->nodesToAddSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_AddNodesItem(sv, in->nodesToAdd[i]);
 		av_push(av, sv);
+		pack_UA_AddNodesItem(sv, &in->nodesToAdd[i]);
 	}
-	hv_stores(hv, "AddNodesRequest_nodesToAdd", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_AddNodesRequest(UA_AddNodesRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AddNodesRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AddNodesRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "AddNodesRequest_nodesToAdd", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for AddNodesRequest_nodesToAdd");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->nodesToAdd = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ADDNODESITEM]);
-		if (out->nodesToAdd == NULL) {
+		if (out->nodesToAdd == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->nodesToAddSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->nodesToAdd[i] = XS_unpack_UA_AddNodesItem(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_AddNodesItem(&out->nodesToAdd[i], *svp);
 		}
-		out->nodesToAddSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* AddNodesResponse */
 #ifdef UA_TYPES_ADDNODESRESPONSE
-static void XS_pack_UA_AddNodesResponse(SV *out, UA_AddNodesResponse in)  __attribute__((unused));
-static UA_AddNodesResponse XS_unpack_UA_AddNodesResponse(SV *in)  __attribute__((unused));
 static void pack_UA_AddNodesResponse(SV *out, UA_AddNodesResponse *in);
 static void unpack_UA_AddNodesResponse(UA_AddNodesResponse *out, SV *in);
 
@@ -9012,101 +8693,95 @@ pack_UA_AddNodesResponse(SV *out, UA_AddNodesResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "AddNodesResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "AddNodesResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_AddNodesResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_AddNodesResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "AddNodesResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "AddNodesResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "AddNodesResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_AddNodesResponse(UA_AddNodesResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AddNodesResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AddNodesResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "AddNodesResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for AddNodesResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ADDNODESRESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_AddNodesResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_AddNodesResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "AddNodesResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for AddNodesResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* AddReferencesItem */
 #ifdef UA_TYPES_ADDREFERENCESITEM
-static void XS_pack_UA_AddReferencesItem(SV *out, UA_AddReferencesItem in)  __attribute__((unused));
-static UA_AddReferencesItem XS_unpack_UA_AddReferencesItem(SV *in)  __attribute__((unused));
 static void pack_UA_AddReferencesItem(SV *out, UA_AddReferencesItem *in);
 static void unpack_UA_AddReferencesItem(UA_AddReferencesItem *out, SV *in);
 
@@ -9115,81 +8790,81 @@ pack_UA_AddReferencesItem(SV *out, UA_AddReferencesItem *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->sourceNodeId);
-	hv_stores(hv, "AddReferencesItem_sourceNodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->referenceTypeId);
-	hv_stores(hv, "AddReferencesItem_referenceTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isForward);
-	hv_stores(hv, "AddReferencesItem_isForward", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->targetServerUri);
-	hv_stores(hv, "AddReferencesItem_targetServerUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->targetNodeId);
-	hv_stores(hv, "AddReferencesItem_targetNodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeClass(sv, in->targetNodeClass);
-	hv_stores(hv, "AddReferencesItem_targetNodeClass", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "AddReferencesItem_sourceNodeId", sv);
+	pack_UA_NodeId(sv, &in->sourceNodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddReferencesItem_referenceTypeId", sv);
+	pack_UA_NodeId(sv, &in->referenceTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddReferencesItem_isForward", sv);
+	pack_UA_Boolean(sv, &in->isForward);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddReferencesItem_targetServerUri", sv);
+	pack_UA_String(sv, &in->targetServerUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddReferencesItem_targetNodeId", sv);
+	pack_UA_ExpandedNodeId(sv, &in->targetNodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "AddReferencesItem_targetNodeClass", sv);
+	pack_UA_NodeClass(sv, &in->targetNodeClass);
+
+	return;
 }
 
 static void
 unpack_UA_AddReferencesItem(UA_AddReferencesItem *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AddReferencesItem_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AddReferencesItem_sourceNodeId", 0);
 	if (svp != NULL)
-		out->sourceNodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->sourceNodeId, *svp);
 
 	svp = hv_fetchs(hv, "AddReferencesItem_referenceTypeId", 0);
 	if (svp != NULL)
-		out->referenceTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->referenceTypeId, *svp);
 
 	svp = hv_fetchs(hv, "AddReferencesItem_isForward", 0);
 	if (svp != NULL)
-		out->isForward = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isForward, *svp);
 
 	svp = hv_fetchs(hv, "AddReferencesItem_targetServerUri", 0);
 	if (svp != NULL)
-		out->targetServerUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->targetServerUri, *svp);
 
 	svp = hv_fetchs(hv, "AddReferencesItem_targetNodeId", 0);
 	if (svp != NULL)
-		out->targetNodeId = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->targetNodeId, *svp);
 
 	svp = hv_fetchs(hv, "AddReferencesItem_targetNodeClass", 0);
 	if (svp != NULL)
-		out->targetNodeClass = XS_unpack_UA_NodeClass(*svp);
+		unpack_UA_NodeClass(&out->targetNodeClass, *svp);
 
-
+	return;
 }
 #endif
 
 /* AddReferencesRequest */
 #ifdef UA_TYPES_ADDREFERENCESREQUEST
-static void XS_pack_UA_AddReferencesRequest(SV *out, UA_AddReferencesRequest in)  __attribute__((unused));
-static UA_AddReferencesRequest XS_unpack_UA_AddReferencesRequest(SV *in)  __attribute__((unused));
 static void pack_UA_AddReferencesRequest(SV *out, UA_AddReferencesRequest *in);
 static void unpack_UA_AddReferencesRequest(UA_AddReferencesRequest *out, SV *in);
 
@@ -9200,72 +8875,69 @@ pack_UA_AddReferencesRequest(SV *out, UA_AddReferencesRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "AddReferencesRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "AddReferencesRequest_referencesToAdd", newRV_noinc((SV*)av));
 	av_extend(av, in->referencesToAddSize);
 	for (i = 0; i < in->referencesToAddSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_AddReferencesItem(sv, in->referencesToAdd[i]);
 		av_push(av, sv);
+		pack_UA_AddReferencesItem(sv, &in->referencesToAdd[i]);
 	}
-	hv_stores(hv, "AddReferencesRequest_referencesToAdd", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_AddReferencesRequest(UA_AddReferencesRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AddReferencesRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AddReferencesRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "AddReferencesRequest_referencesToAdd", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for AddReferencesRequest_referencesToAdd");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->referencesToAdd = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ADDREFERENCESITEM]);
-		if (out->referencesToAdd == NULL) {
+		if (out->referencesToAdd == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->referencesToAddSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->referencesToAdd[i] = XS_unpack_UA_AddReferencesItem(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_AddReferencesItem(&out->referencesToAdd[i], *svp);
 		}
-		out->referencesToAddSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* AddReferencesResponse */
 #ifdef UA_TYPES_ADDREFERENCESRESPONSE
-static void XS_pack_UA_AddReferencesResponse(SV *out, UA_AddReferencesResponse in)  __attribute__((unused));
-static UA_AddReferencesResponse XS_unpack_UA_AddReferencesResponse(SV *in)  __attribute__((unused));
 static void pack_UA_AddReferencesResponse(SV *out, UA_AddReferencesResponse *in);
 static void unpack_UA_AddReferencesResponse(UA_AddReferencesResponse *out, SV *in);
 
@@ -9276,101 +8948,95 @@ pack_UA_AddReferencesResponse(SV *out, UA_AddReferencesResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "AddReferencesResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "AddReferencesResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "AddReferencesResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "AddReferencesResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "AddReferencesResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_AddReferencesResponse(UA_AddReferencesResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AddReferencesResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AddReferencesResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "AddReferencesResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for AddReferencesResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "AddReferencesResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for AddReferencesResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteNodesItem */
 #ifdef UA_TYPES_DELETENODESITEM
-static void XS_pack_UA_DeleteNodesItem(SV *out, UA_DeleteNodesItem in)  __attribute__((unused));
-static UA_DeleteNodesItem XS_unpack_UA_DeleteNodesItem(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteNodesItem(SV *out, UA_DeleteNodesItem *in);
 static void unpack_UA_DeleteNodesItem(UA_DeleteNodesItem *out, SV *in);
 
@@ -9379,49 +9045,49 @@ pack_UA_DeleteNodesItem(SV *out, UA_DeleteNodesItem *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
-	hv_stores(hv, "DeleteNodesItem_nodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->deleteTargetReferences);
-	hv_stores(hv, "DeleteNodesItem_deleteTargetReferences", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteNodesItem_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteNodesItem_deleteTargetReferences", sv);
+	pack_UA_Boolean(sv, &in->deleteTargetReferences);
+
+	return;
 }
 
 static void
 unpack_UA_DeleteNodesItem(UA_DeleteNodesItem *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteNodesItem_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteNodesItem_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "DeleteNodesItem_deleteTargetReferences", 0);
 	if (svp != NULL)
-		out->deleteTargetReferences = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->deleteTargetReferences, *svp);
 
-
+	return;
 }
 #endif
 
 /* DeleteNodesRequest */
 #ifdef UA_TYPES_DELETENODESREQUEST
-static void XS_pack_UA_DeleteNodesRequest(SV *out, UA_DeleteNodesRequest in)  __attribute__((unused));
-static UA_DeleteNodesRequest XS_unpack_UA_DeleteNodesRequest(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteNodesRequest(SV *out, UA_DeleteNodesRequest *in);
 static void unpack_UA_DeleteNodesRequest(UA_DeleteNodesRequest *out, SV *in);
 
@@ -9432,72 +9098,69 @@ pack_UA_DeleteNodesRequest(SV *out, UA_DeleteNodesRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "DeleteNodesRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteNodesRequest_nodesToDelete", newRV_noinc((SV*)av));
 	av_extend(av, in->nodesToDeleteSize);
 	for (i = 0; i < in->nodesToDeleteSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DeleteNodesItem(sv, in->nodesToDelete[i]);
 		av_push(av, sv);
+		pack_UA_DeleteNodesItem(sv, &in->nodesToDelete[i]);
 	}
-	hv_stores(hv, "DeleteNodesRequest_nodesToDelete", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteNodesRequest(UA_DeleteNodesRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteNodesRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteNodesRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "DeleteNodesRequest_nodesToDelete", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteNodesRequest_nodesToDelete");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->nodesToDelete = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DELETENODESITEM]);
-		if (out->nodesToDelete == NULL) {
+		if (out->nodesToDelete == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->nodesToDeleteSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->nodesToDelete[i] = XS_unpack_UA_DeleteNodesItem(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DeleteNodesItem(&out->nodesToDelete[i], *svp);
 		}
-		out->nodesToDeleteSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteNodesResponse */
 #ifdef UA_TYPES_DELETENODESRESPONSE
-static void XS_pack_UA_DeleteNodesResponse(SV *out, UA_DeleteNodesResponse in)  __attribute__((unused));
-static UA_DeleteNodesResponse XS_unpack_UA_DeleteNodesResponse(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteNodesResponse(SV *out, UA_DeleteNodesResponse *in);
 static void unpack_UA_DeleteNodesResponse(UA_DeleteNodesResponse *out, SV *in);
 
@@ -9508,101 +9171,95 @@ pack_UA_DeleteNodesResponse(SV *out, UA_DeleteNodesResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "DeleteNodesResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteNodesResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "DeleteNodesResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteNodesResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "DeleteNodesResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteNodesResponse(UA_DeleteNodesResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteNodesResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteNodesResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "DeleteNodesResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteNodesResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DeleteNodesResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteNodesResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteReferencesItem */
 #ifdef UA_TYPES_DELETEREFERENCESITEM
-static void XS_pack_UA_DeleteReferencesItem(SV *out, UA_DeleteReferencesItem in)  __attribute__((unused));
-static UA_DeleteReferencesItem XS_unpack_UA_DeleteReferencesItem(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteReferencesItem(SV *out, UA_DeleteReferencesItem *in);
 static void unpack_UA_DeleteReferencesItem(UA_DeleteReferencesItem *out, SV *in);
 
@@ -9611,73 +9268,73 @@ pack_UA_DeleteReferencesItem(SV *out, UA_DeleteReferencesItem *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->sourceNodeId);
-	hv_stores(hv, "DeleteReferencesItem_sourceNodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->referenceTypeId);
-	hv_stores(hv, "DeleteReferencesItem_referenceTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isForward);
-	hv_stores(hv, "DeleteReferencesItem_isForward", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->targetNodeId);
-	hv_stores(hv, "DeleteReferencesItem_targetNodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->deleteBidirectional);
-	hv_stores(hv, "DeleteReferencesItem_deleteBidirectional", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteReferencesItem_sourceNodeId", sv);
+	pack_UA_NodeId(sv, &in->sourceNodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteReferencesItem_referenceTypeId", sv);
+	pack_UA_NodeId(sv, &in->referenceTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteReferencesItem_isForward", sv);
+	pack_UA_Boolean(sv, &in->isForward);
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteReferencesItem_targetNodeId", sv);
+	pack_UA_ExpandedNodeId(sv, &in->targetNodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteReferencesItem_deleteBidirectional", sv);
+	pack_UA_Boolean(sv, &in->deleteBidirectional);
+
+	return;
 }
 
 static void
 unpack_UA_DeleteReferencesItem(UA_DeleteReferencesItem *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteReferencesItem_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteReferencesItem_sourceNodeId", 0);
 	if (svp != NULL)
-		out->sourceNodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->sourceNodeId, *svp);
 
 	svp = hv_fetchs(hv, "DeleteReferencesItem_referenceTypeId", 0);
 	if (svp != NULL)
-		out->referenceTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->referenceTypeId, *svp);
 
 	svp = hv_fetchs(hv, "DeleteReferencesItem_isForward", 0);
 	if (svp != NULL)
-		out->isForward = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isForward, *svp);
 
 	svp = hv_fetchs(hv, "DeleteReferencesItem_targetNodeId", 0);
 	if (svp != NULL)
-		out->targetNodeId = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->targetNodeId, *svp);
 
 	svp = hv_fetchs(hv, "DeleteReferencesItem_deleteBidirectional", 0);
 	if (svp != NULL)
-		out->deleteBidirectional = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->deleteBidirectional, *svp);
 
-
+	return;
 }
 #endif
 
 /* DeleteReferencesRequest */
 #ifdef UA_TYPES_DELETEREFERENCESREQUEST
-static void XS_pack_UA_DeleteReferencesRequest(SV *out, UA_DeleteReferencesRequest in)  __attribute__((unused));
-static UA_DeleteReferencesRequest XS_unpack_UA_DeleteReferencesRequest(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteReferencesRequest(SV *out, UA_DeleteReferencesRequest *in);
 static void unpack_UA_DeleteReferencesRequest(UA_DeleteReferencesRequest *out, SV *in);
 
@@ -9688,72 +9345,69 @@ pack_UA_DeleteReferencesRequest(SV *out, UA_DeleteReferencesRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "DeleteReferencesRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteReferencesRequest_referencesToDelete", newRV_noinc((SV*)av));
 	av_extend(av, in->referencesToDeleteSize);
 	for (i = 0; i < in->referencesToDeleteSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DeleteReferencesItem(sv, in->referencesToDelete[i]);
 		av_push(av, sv);
+		pack_UA_DeleteReferencesItem(sv, &in->referencesToDelete[i]);
 	}
-	hv_stores(hv, "DeleteReferencesRequest_referencesToDelete", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteReferencesRequest(UA_DeleteReferencesRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteReferencesRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteReferencesRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "DeleteReferencesRequest_referencesToDelete", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteReferencesRequest_referencesToDelete");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->referencesToDelete = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DELETEREFERENCESITEM]);
-		if (out->referencesToDelete == NULL) {
+		if (out->referencesToDelete == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->referencesToDeleteSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->referencesToDelete[i] = XS_unpack_UA_DeleteReferencesItem(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DeleteReferencesItem(&out->referencesToDelete[i], *svp);
 		}
-		out->referencesToDeleteSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteReferencesResponse */
 #ifdef UA_TYPES_DELETEREFERENCESRESPONSE
-static void XS_pack_UA_DeleteReferencesResponse(SV *out, UA_DeleteReferencesResponse in)  __attribute__((unused));
-static UA_DeleteReferencesResponse XS_unpack_UA_DeleteReferencesResponse(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteReferencesResponse(SV *out, UA_DeleteReferencesResponse *in);
 static void unpack_UA_DeleteReferencesResponse(UA_DeleteReferencesResponse *out, SV *in);
 
@@ -9764,101 +9418,95 @@ pack_UA_DeleteReferencesResponse(SV *out, UA_DeleteReferencesResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "DeleteReferencesResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteReferencesResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "DeleteReferencesResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteReferencesResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "DeleteReferencesResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteReferencesResponse(UA_DeleteReferencesResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteReferencesResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteReferencesResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "DeleteReferencesResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteReferencesResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DeleteReferencesResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteReferencesResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* AttributeWriteMask */
 #ifdef UA_TYPES_ATTRIBUTEWRITEMASK
-static void XS_pack_UA_AttributeWriteMask(SV *out, UA_AttributeWriteMask in)  __attribute__((unused));
-static UA_AttributeWriteMask XS_unpack_UA_AttributeWriteMask(SV *in)  __attribute__((unused));
 static void pack_UA_AttributeWriteMask(SV *out, UA_AttributeWriteMask *in);
 static void unpack_UA_AttributeWriteMask(UA_AttributeWriteMask *out, SV *in);
 
@@ -9879,8 +9527,6 @@ unpack_UA_AttributeWriteMask(UA_AttributeWriteMask *out, SV *in)
 
 /* BrowseDirection */
 #ifdef UA_TYPES_BROWSEDIRECTION
-static void XS_pack_UA_BrowseDirection(SV *out, UA_BrowseDirection in)  __attribute__((unused));
-static UA_BrowseDirection XS_unpack_UA_BrowseDirection(SV *in)  __attribute__((unused));
 static void pack_UA_BrowseDirection(SV *out, UA_BrowseDirection *in);
 static void unpack_UA_BrowseDirection(UA_BrowseDirection *out, SV *in);
 
@@ -9901,8 +9547,6 @@ unpack_UA_BrowseDirection(UA_BrowseDirection *out, SV *in)
 
 /* ViewDescription */
 #ifdef UA_TYPES_VIEWDESCRIPTION
-static void XS_pack_UA_ViewDescription(SV *out, UA_ViewDescription in)  __attribute__((unused));
-static UA_ViewDescription XS_unpack_UA_ViewDescription(SV *in)  __attribute__((unused));
 static void pack_UA_ViewDescription(SV *out, UA_ViewDescription *in);
 static void unpack_UA_ViewDescription(UA_ViewDescription *out, SV *in);
 
@@ -9911,57 +9555,57 @@ pack_UA_ViewDescription(SV *out, UA_ViewDescription *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->viewId);
-	hv_stores(hv, "ViewDescription_viewId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->timestamp);
-	hv_stores(hv, "ViewDescription_timestamp", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->viewVersion);
-	hv_stores(hv, "ViewDescription_viewVersion", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewDescription_viewId", sv);
+	pack_UA_NodeId(sv, &in->viewId);
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewDescription_timestamp", sv);
+	pack_UA_DateTime(sv, &in->timestamp);
+
+	sv = newSV(0);
+	hv_stores(hv, "ViewDescription_viewVersion", sv);
+	pack_UA_UInt32(sv, &in->viewVersion);
+
+	return;
 }
 
 static void
 unpack_UA_ViewDescription(UA_ViewDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ViewDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ViewDescription_viewId", 0);
 	if (svp != NULL)
-		out->viewId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->viewId, *svp);
 
 	svp = hv_fetchs(hv, "ViewDescription_timestamp", 0);
 	if (svp != NULL)
-		out->timestamp = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->timestamp, *svp);
 
 	svp = hv_fetchs(hv, "ViewDescription_viewVersion", 0);
 	if (svp != NULL)
-		out->viewVersion = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->viewVersion, *svp);
 
-
+	return;
 }
 #endif
 
 /* BrowseDescription */
 #ifdef UA_TYPES_BROWSEDESCRIPTION
-static void XS_pack_UA_BrowseDescription(SV *out, UA_BrowseDescription in)  __attribute__((unused));
-static UA_BrowseDescription XS_unpack_UA_BrowseDescription(SV *in)  __attribute__((unused));
 static void pack_UA_BrowseDescription(SV *out, UA_BrowseDescription *in);
 static void unpack_UA_BrowseDescription(UA_BrowseDescription *out, SV *in);
 
@@ -9970,81 +9614,81 @@ pack_UA_BrowseDescription(SV *out, UA_BrowseDescription *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
-	hv_stores(hv, "BrowseDescription_nodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_BrowseDirection(sv, in->browseDirection);
-	hv_stores(hv, "BrowseDescription_browseDirection", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->referenceTypeId);
-	hv_stores(hv, "BrowseDescription_referenceTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->includeSubtypes);
-	hv_stores(hv, "BrowseDescription_includeSubtypes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->nodeClassMask);
-	hv_stores(hv, "BrowseDescription_nodeClassMask", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->resultMask);
-	hv_stores(hv, "BrowseDescription_resultMask", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowseDescription_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowseDescription_browseDirection", sv);
+	pack_UA_BrowseDirection(sv, &in->browseDirection);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowseDescription_referenceTypeId", sv);
+	pack_UA_NodeId(sv, &in->referenceTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowseDescription_includeSubtypes", sv);
+	pack_UA_Boolean(sv, &in->includeSubtypes);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowseDescription_nodeClassMask", sv);
+	pack_UA_UInt32(sv, &in->nodeClassMask);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowseDescription_resultMask", sv);
+	pack_UA_UInt32(sv, &in->resultMask);
+
+	return;
 }
 
 static void
 unpack_UA_BrowseDescription(UA_BrowseDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrowseDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrowseDescription_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "BrowseDescription_browseDirection", 0);
 	if (svp != NULL)
-		out->browseDirection = XS_unpack_UA_BrowseDirection(*svp);
+		unpack_UA_BrowseDirection(&out->browseDirection, *svp);
 
 	svp = hv_fetchs(hv, "BrowseDescription_referenceTypeId", 0);
 	if (svp != NULL)
-		out->referenceTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->referenceTypeId, *svp);
 
 	svp = hv_fetchs(hv, "BrowseDescription_includeSubtypes", 0);
 	if (svp != NULL)
-		out->includeSubtypes = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->includeSubtypes, *svp);
 
 	svp = hv_fetchs(hv, "BrowseDescription_nodeClassMask", 0);
 	if (svp != NULL)
-		out->nodeClassMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->nodeClassMask, *svp);
 
 	svp = hv_fetchs(hv, "BrowseDescription_resultMask", 0);
 	if (svp != NULL)
-		out->resultMask = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->resultMask, *svp);
 
-
+	return;
 }
 #endif
 
 /* BrowseResultMask */
 #ifdef UA_TYPES_BROWSERESULTMASK
-static void XS_pack_UA_BrowseResultMask(SV *out, UA_BrowseResultMask in)  __attribute__((unused));
-static UA_BrowseResultMask XS_unpack_UA_BrowseResultMask(SV *in)  __attribute__((unused));
 static void pack_UA_BrowseResultMask(SV *out, UA_BrowseResultMask *in);
 static void unpack_UA_BrowseResultMask(UA_BrowseResultMask *out, SV *in);
 
@@ -10065,8 +9709,6 @@ unpack_UA_BrowseResultMask(UA_BrowseResultMask *out, SV *in)
 
 /* ReferenceDescription */
 #ifdef UA_TYPES_REFERENCEDESCRIPTION
-static void XS_pack_UA_ReferenceDescription(SV *out, UA_ReferenceDescription in)  __attribute__((unused));
-static UA_ReferenceDescription XS_unpack_UA_ReferenceDescription(SV *in)  __attribute__((unused));
 static void pack_UA_ReferenceDescription(SV *out, UA_ReferenceDescription *in);
 static void unpack_UA_ReferenceDescription(UA_ReferenceDescription *out, SV *in);
 
@@ -10075,89 +9717,89 @@ pack_UA_ReferenceDescription(SV *out, UA_ReferenceDescription *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->referenceTypeId);
-	hv_stores(hv, "ReferenceDescription_referenceTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isForward);
-	hv_stores(hv, "ReferenceDescription_isForward", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->nodeId);
-	hv_stores(hv, "ReferenceDescription_nodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->browseName);
-	hv_stores(hv, "ReferenceDescription_browseName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "ReferenceDescription_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeClass(sv, in->nodeClass);
-	hv_stores(hv, "ReferenceDescription_nodeClass", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->typeDefinition);
-	hv_stores(hv, "ReferenceDescription_typeDefinition", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceDescription_referenceTypeId", sv);
+	pack_UA_NodeId(sv, &in->referenceTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceDescription_isForward", sv);
+	pack_UA_Boolean(sv, &in->isForward);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceDescription_nodeId", sv);
+	pack_UA_ExpandedNodeId(sv, &in->nodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceDescription_browseName", sv);
+	pack_UA_QualifiedName(sv, &in->browseName);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceDescription_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceDescription_nodeClass", sv);
+	pack_UA_NodeClass(sv, &in->nodeClass);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReferenceDescription_typeDefinition", sv);
+	pack_UA_ExpandedNodeId(sv, &in->typeDefinition);
+
+	return;
 }
 
 static void
 unpack_UA_ReferenceDescription(UA_ReferenceDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReferenceDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReferenceDescription_referenceTypeId", 0);
 	if (svp != NULL)
-		out->referenceTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->referenceTypeId, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceDescription_isForward", 0);
 	if (svp != NULL)
-		out->isForward = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isForward, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceDescription_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceDescription_browseName", 0);
 	if (svp != NULL)
-		out->browseName = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->browseName, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceDescription_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceDescription_nodeClass", 0);
 	if (svp != NULL)
-		out->nodeClass = XS_unpack_UA_NodeClass(*svp);
+		unpack_UA_NodeClass(&out->nodeClass, *svp);
 
 	svp = hv_fetchs(hv, "ReferenceDescription_typeDefinition", 0);
 	if (svp != NULL)
-		out->typeDefinition = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->typeDefinition, *svp);
 
-
+	return;
 }
 #endif
 
 /* ContinuationPoint */
 #ifdef UA_TYPES_CONTINUATIONPOINT
-static void XS_pack_UA_ContinuationPoint(SV *out, UA_ContinuationPoint in)  __attribute__((unused));
-static UA_ContinuationPoint XS_unpack_UA_ContinuationPoint(SV *in)  __attribute__((unused));
 static void pack_UA_ContinuationPoint(SV *out, UA_ContinuationPoint *in);
 static void unpack_UA_ContinuationPoint(UA_ContinuationPoint *out, SV *in);
 
@@ -10165,21 +9807,19 @@ static void
 pack_UA_ContinuationPoint(SV *out, UA_ContinuationPoint *in)
 {
 	dTHX;
-	XS_pack_UA_ByteString(out, *in);
+	pack_UA_ByteString(out, in);
 }
 
 static void
 unpack_UA_ContinuationPoint(UA_ContinuationPoint *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_ByteString(in);
+	unpack_UA_ByteString(out, in);
 }
 #endif
 
 /* BrowseResult */
 #ifdef UA_TYPES_BROWSERESULT
-static void XS_pack_UA_BrowseResult(SV *out, UA_BrowseResult in)  __attribute__((unused));
-static UA_BrowseResult XS_unpack_UA_BrowseResult(SV *in)  __attribute__((unused));
 static void pack_UA_BrowseResult(SV *out, UA_BrowseResult *in);
 static void unpack_UA_BrowseResult(UA_BrowseResult *out, SV *in);
 
@@ -10190,80 +9830,77 @@ pack_UA_BrowseResult(SV *out, UA_BrowseResult *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
 	hv_stores(hv, "BrowseResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
 
 	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->continuationPoint);
 	hv_stores(hv, "BrowseResult_continuationPoint", sv);
+	pack_UA_ByteString(sv, &in->continuationPoint);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "BrowseResult_references", newRV_noinc((SV*)av));
 	av_extend(av, in->referencesSize);
 	for (i = 0; i < in->referencesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ReferenceDescription(sv, in->references[i]);
 		av_push(av, sv);
+		pack_UA_ReferenceDescription(sv, &in->references[i]);
 	}
-	hv_stores(hv, "BrowseResult_references", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_BrowseResult(UA_BrowseResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrowseResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrowseResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "BrowseResult_continuationPoint", 0);
 	if (svp != NULL)
-		out->continuationPoint = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->continuationPoint, *svp);
 
 	svp = hv_fetchs(hv, "BrowseResult_references", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for BrowseResult_references");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->references = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_REFERENCEDESCRIPTION]);
-		if (out->references == NULL) {
+		if (out->references == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->referencesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->references[i] = XS_unpack_UA_ReferenceDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ReferenceDescription(&out->references[i], *svp);
 		}
-		out->referencesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* BrowseRequest */
 #ifdef UA_TYPES_BROWSEREQUEST
-static void XS_pack_UA_BrowseRequest(SV *out, UA_BrowseRequest in)  __attribute__((unused));
-static UA_BrowseRequest XS_unpack_UA_BrowseRequest(SV *in)  __attribute__((unused));
 static void pack_UA_BrowseRequest(SV *out, UA_BrowseRequest *in);
 static void unpack_UA_BrowseRequest(UA_BrowseRequest *out, SV *in);
 
@@ -10274,88 +9911,85 @@ pack_UA_BrowseRequest(SV *out, UA_BrowseRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "BrowseRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_ViewDescription(sv, in->view);
 	hv_stores(hv, "BrowseRequest_view", sv);
+	pack_UA_ViewDescription(sv, &in->view);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->requestedMaxReferencesPerNode);
 	hv_stores(hv, "BrowseRequest_requestedMaxReferencesPerNode", sv);
+	pack_UA_UInt32(sv, &in->requestedMaxReferencesPerNode);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "BrowseRequest_nodesToBrowse", newRV_noinc((SV*)av));
 	av_extend(av, in->nodesToBrowseSize);
 	for (i = 0; i < in->nodesToBrowseSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_BrowseDescription(sv, in->nodesToBrowse[i]);
 		av_push(av, sv);
+		pack_UA_BrowseDescription(sv, &in->nodesToBrowse[i]);
 	}
-	hv_stores(hv, "BrowseRequest_nodesToBrowse", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_BrowseRequest(UA_BrowseRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrowseRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrowseRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "BrowseRequest_view", 0);
 	if (svp != NULL)
-		out->view = XS_unpack_UA_ViewDescription(*svp);
+		unpack_UA_ViewDescription(&out->view, *svp);
 
 	svp = hv_fetchs(hv, "BrowseRequest_requestedMaxReferencesPerNode", 0);
 	if (svp != NULL)
-		out->requestedMaxReferencesPerNode = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->requestedMaxReferencesPerNode, *svp);
 
 	svp = hv_fetchs(hv, "BrowseRequest_nodesToBrowse", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for BrowseRequest_nodesToBrowse");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->nodesToBrowse = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSEDESCRIPTION]);
-		if (out->nodesToBrowse == NULL) {
+		if (out->nodesToBrowse == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->nodesToBrowseSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->nodesToBrowse[i] = XS_unpack_UA_BrowseDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_BrowseDescription(&out->nodesToBrowse[i], *svp);
 		}
-		out->nodesToBrowseSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* BrowseResponse */
 #ifdef UA_TYPES_BROWSERESPONSE
-static void XS_pack_UA_BrowseResponse(SV *out, UA_BrowseResponse in)  __attribute__((unused));
-static UA_BrowseResponse XS_unpack_UA_BrowseResponse(SV *in)  __attribute__((unused));
 static void pack_UA_BrowseResponse(SV *out, UA_BrowseResponse *in);
 static void unpack_UA_BrowseResponse(UA_BrowseResponse *out, SV *in);
 
@@ -10366,101 +10000,95 @@ pack_UA_BrowseResponse(SV *out, UA_BrowseResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "BrowseResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "BrowseResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_BrowseResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_BrowseResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "BrowseResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "BrowseResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "BrowseResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_BrowseResponse(UA_BrowseResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrowseResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrowseResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "BrowseResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for BrowseResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSERESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_BrowseResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_BrowseResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "BrowseResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for BrowseResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* BrowseNextRequest */
 #ifdef UA_TYPES_BROWSENEXTREQUEST
-static void XS_pack_UA_BrowseNextRequest(SV *out, UA_BrowseNextRequest in)  __attribute__((unused));
-static UA_BrowseNextRequest XS_unpack_UA_BrowseNextRequest(SV *in)  __attribute__((unused));
 static void pack_UA_BrowseNextRequest(SV *out, UA_BrowseNextRequest *in);
 static void unpack_UA_BrowseNextRequest(UA_BrowseNextRequest *out, SV *in);
 
@@ -10471,80 +10099,77 @@ pack_UA_BrowseNextRequest(SV *out, UA_BrowseNextRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "BrowseNextRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->releaseContinuationPoints);
 	hv_stores(hv, "BrowseNextRequest_releaseContinuationPoints", sv);
+	pack_UA_Boolean(sv, &in->releaseContinuationPoints);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "BrowseNextRequest_continuationPoints", newRV_noinc((SV*)av));
 	av_extend(av, in->continuationPointsSize);
 	for (i = 0; i < in->continuationPointsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ByteString(sv, in->continuationPoints[i]);
 		av_push(av, sv);
+		pack_UA_ByteString(sv, &in->continuationPoints[i]);
 	}
-	hv_stores(hv, "BrowseNextRequest_continuationPoints", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_BrowseNextRequest(UA_BrowseNextRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrowseNextRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrowseNextRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "BrowseNextRequest_releaseContinuationPoints", 0);
 	if (svp != NULL)
-		out->releaseContinuationPoints = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->releaseContinuationPoints, *svp);
 
 	svp = hv_fetchs(hv, "BrowseNextRequest_continuationPoints", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for BrowseNextRequest_continuationPoints");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->continuationPoints = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BYTESTRING]);
-		if (out->continuationPoints == NULL) {
+		if (out->continuationPoints == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->continuationPointsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->continuationPoints[i] = XS_unpack_UA_ByteString(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ByteString(&out->continuationPoints[i], *svp);
 		}
-		out->continuationPointsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* BrowseNextResponse */
 #ifdef UA_TYPES_BROWSENEXTRESPONSE
-static void XS_pack_UA_BrowseNextResponse(SV *out, UA_BrowseNextResponse in)  __attribute__((unused));
-static UA_BrowseNextResponse XS_unpack_UA_BrowseNextResponse(SV *in)  __attribute__((unused));
 static void pack_UA_BrowseNextResponse(SV *out, UA_BrowseNextResponse *in);
 static void unpack_UA_BrowseNextResponse(UA_BrowseNextResponse *out, SV *in);
 
@@ -10555,101 +10180,95 @@ pack_UA_BrowseNextResponse(SV *out, UA_BrowseNextResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "BrowseNextResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "BrowseNextResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_BrowseResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_BrowseResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "BrowseNextResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "BrowseNextResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "BrowseNextResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_BrowseNextResponse(UA_BrowseNextResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrowseNextResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrowseNextResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "BrowseNextResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for BrowseNextResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSERESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_BrowseResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_BrowseResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "BrowseNextResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for BrowseNextResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* RelativePathElement */
 #ifdef UA_TYPES_RELATIVEPATHELEMENT
-static void XS_pack_UA_RelativePathElement(SV *out, UA_RelativePathElement in)  __attribute__((unused));
-static UA_RelativePathElement XS_unpack_UA_RelativePathElement(SV *in)  __attribute__((unused));
 static void pack_UA_RelativePathElement(SV *out, UA_RelativePathElement *in);
 static void unpack_UA_RelativePathElement(UA_RelativePathElement *out, SV *in);
 
@@ -10658,65 +10277,65 @@ pack_UA_RelativePathElement(SV *out, UA_RelativePathElement *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->referenceTypeId);
-	hv_stores(hv, "RelativePathElement_referenceTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isInverse);
-	hv_stores(hv, "RelativePathElement_isInverse", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->includeSubtypes);
-	hv_stores(hv, "RelativePathElement_includeSubtypes", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->targetName);
-	hv_stores(hv, "RelativePathElement_targetName", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "RelativePathElement_referenceTypeId", sv);
+	pack_UA_NodeId(sv, &in->referenceTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "RelativePathElement_isInverse", sv);
+	pack_UA_Boolean(sv, &in->isInverse);
+
+	sv = newSV(0);
+	hv_stores(hv, "RelativePathElement_includeSubtypes", sv);
+	pack_UA_Boolean(sv, &in->includeSubtypes);
+
+	sv = newSV(0);
+	hv_stores(hv, "RelativePathElement_targetName", sv);
+	pack_UA_QualifiedName(sv, &in->targetName);
+
+	return;
 }
 
 static void
 unpack_UA_RelativePathElement(UA_RelativePathElement *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RelativePathElement_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RelativePathElement_referenceTypeId", 0);
 	if (svp != NULL)
-		out->referenceTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->referenceTypeId, *svp);
 
 	svp = hv_fetchs(hv, "RelativePathElement_isInverse", 0);
 	if (svp != NULL)
-		out->isInverse = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isInverse, *svp);
 
 	svp = hv_fetchs(hv, "RelativePathElement_includeSubtypes", 0);
 	if (svp != NULL)
-		out->includeSubtypes = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->includeSubtypes, *svp);
 
 	svp = hv_fetchs(hv, "RelativePathElement_targetName", 0);
 	if (svp != NULL)
-		out->targetName = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->targetName, *svp);
 
-
+	return;
 }
 #endif
 
 /* RelativePath */
 #ifdef UA_TYPES_RELATIVEPATH
-static void XS_pack_UA_RelativePath(SV *out, UA_RelativePath in)  __attribute__((unused));
-static UA_RelativePath XS_unpack_UA_RelativePath(SV *in)  __attribute__((unused));
 static void pack_UA_RelativePath(SV *out, UA_RelativePath *in);
 static void unpack_UA_RelativePath(UA_RelativePath *out, SV *in);
 
@@ -10727,64 +10346,61 @@ pack_UA_RelativePath(SV *out, UA_RelativePath *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "RelativePath_elements", newRV_noinc((SV*)av));
 	av_extend(av, in->elementsSize);
 	for (i = 0; i < in->elementsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_RelativePathElement(sv, in->elements[i]);
 		av_push(av, sv);
+		pack_UA_RelativePathElement(sv, &in->elements[i]);
 	}
-	hv_stores(hv, "RelativePath_elements", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_RelativePath(UA_RelativePath *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RelativePath_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RelativePath_elements", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for RelativePath_elements");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->elements = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_RELATIVEPATHELEMENT]);
-		if (out->elements == NULL) {
+		if (out->elements == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->elementsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->elements[i] = XS_unpack_UA_RelativePathElement(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_RelativePathElement(&out->elements[i], *svp);
 		}
-		out->elementsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* BrowsePath */
 #ifdef UA_TYPES_BROWSEPATH
-static void XS_pack_UA_BrowsePath(SV *out, UA_BrowsePath in)  __attribute__((unused));
-static UA_BrowsePath XS_unpack_UA_BrowsePath(SV *in)  __attribute__((unused));
 static void pack_UA_BrowsePath(SV *out, UA_BrowsePath *in);
 static void unpack_UA_BrowsePath(UA_BrowsePath *out, SV *in);
 
@@ -10793,49 +10409,49 @@ pack_UA_BrowsePath(SV *out, UA_BrowsePath *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->startingNode);
-	hv_stores(hv, "BrowsePath_startingNode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_RelativePath(sv, in->relativePath);
-	hv_stores(hv, "BrowsePath_relativePath", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowsePath_startingNode", sv);
+	pack_UA_NodeId(sv, &in->startingNode);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowsePath_relativePath", sv);
+	pack_UA_RelativePath(sv, &in->relativePath);
+
+	return;
 }
 
 static void
 unpack_UA_BrowsePath(UA_BrowsePath *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrowsePath_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrowsePath_startingNode", 0);
 	if (svp != NULL)
-		out->startingNode = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->startingNode, *svp);
 
 	svp = hv_fetchs(hv, "BrowsePath_relativePath", 0);
 	if (svp != NULL)
-		out->relativePath = XS_unpack_UA_RelativePath(*svp);
+		unpack_UA_RelativePath(&out->relativePath, *svp);
 
-
+	return;
 }
 #endif
 
 /* BrowsePathTarget */
 #ifdef UA_TYPES_BROWSEPATHTARGET
-static void XS_pack_UA_BrowsePathTarget(SV *out, UA_BrowsePathTarget in)  __attribute__((unused));
-static UA_BrowsePathTarget XS_unpack_UA_BrowsePathTarget(SV *in)  __attribute__((unused));
 static void pack_UA_BrowsePathTarget(SV *out, UA_BrowsePathTarget *in);
 static void unpack_UA_BrowsePathTarget(UA_BrowsePathTarget *out, SV *in);
 
@@ -10844,49 +10460,49 @@ pack_UA_BrowsePathTarget(SV *out, UA_BrowsePathTarget *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->targetId);
-	hv_stores(hv, "BrowsePathTarget_targetId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->remainingPathIndex);
-	hv_stores(hv, "BrowsePathTarget_remainingPathIndex", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowsePathTarget_targetId", sv);
+	pack_UA_ExpandedNodeId(sv, &in->targetId);
+
+	sv = newSV(0);
+	hv_stores(hv, "BrowsePathTarget_remainingPathIndex", sv);
+	pack_UA_UInt32(sv, &in->remainingPathIndex);
+
+	return;
 }
 
 static void
 unpack_UA_BrowsePathTarget(UA_BrowsePathTarget *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrowsePathTarget_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrowsePathTarget_targetId", 0);
 	if (svp != NULL)
-		out->targetId = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->targetId, *svp);
 
 	svp = hv_fetchs(hv, "BrowsePathTarget_remainingPathIndex", 0);
 	if (svp != NULL)
-		out->remainingPathIndex = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->remainingPathIndex, *svp);
 
-
+	return;
 }
 #endif
 
 /* BrowsePathResult */
 #ifdef UA_TYPES_BROWSEPATHRESULT
-static void XS_pack_UA_BrowsePathResult(SV *out, UA_BrowsePathResult in)  __attribute__((unused));
-static UA_BrowsePathResult XS_unpack_UA_BrowsePathResult(SV *in)  __attribute__((unused));
 static void pack_UA_BrowsePathResult(SV *out, UA_BrowsePathResult *in);
 static void unpack_UA_BrowsePathResult(UA_BrowsePathResult *out, SV *in);
 
@@ -10897,72 +10513,69 @@ pack_UA_BrowsePathResult(SV *out, UA_BrowsePathResult *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
 	hv_stores(hv, "BrowsePathResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "BrowsePathResult_targets", newRV_noinc((SV*)av));
 	av_extend(av, in->targetsSize);
 	for (i = 0; i < in->targetsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_BrowsePathTarget(sv, in->targets[i]);
 		av_push(av, sv);
+		pack_UA_BrowsePathTarget(sv, &in->targets[i]);
 	}
-	hv_stores(hv, "BrowsePathResult_targets", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_BrowsePathResult(UA_BrowsePathResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BrowsePathResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BrowsePathResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "BrowsePathResult_targets", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for BrowsePathResult_targets");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->targets = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSEPATHTARGET]);
-		if (out->targets == NULL) {
+		if (out->targets == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->targetsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->targets[i] = XS_unpack_UA_BrowsePathTarget(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_BrowsePathTarget(&out->targets[i], *svp);
 		}
-		out->targetsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* TranslateBrowsePathsToNodeIdsRequest */
 #ifdef UA_TYPES_TRANSLATEBROWSEPATHSTONODEIDSREQUEST
-static void XS_pack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *out, UA_TranslateBrowsePathsToNodeIdsRequest in)  __attribute__((unused));
-static UA_TranslateBrowsePathsToNodeIdsRequest XS_unpack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *in)  __attribute__((unused));
 static void pack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *out, UA_TranslateBrowsePathsToNodeIdsRequest *in);
 static void unpack_UA_TranslateBrowsePathsToNodeIdsRequest(UA_TranslateBrowsePathsToNodeIdsRequest *out, SV *in);
 
@@ -10973,72 +10586,69 @@ pack_UA_TranslateBrowsePathsToNodeIdsRequest(SV *out, UA_TranslateBrowsePathsToN
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "TranslateBrowsePathsToNodeIdsRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TranslateBrowsePathsToNodeIdsRequest_browsePaths", newRV_noinc((SV*)av));
 	av_extend(av, in->browsePathsSize);
 	for (i = 0; i < in->browsePathsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_BrowsePath(sv, in->browsePaths[i]);
 		av_push(av, sv);
+		pack_UA_BrowsePath(sv, &in->browsePaths[i]);
 	}
-	hv_stores(hv, "TranslateBrowsePathsToNodeIdsRequest_browsePaths", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_TranslateBrowsePathsToNodeIdsRequest(UA_TranslateBrowsePathsToNodeIdsRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_TranslateBrowsePathsToNodeIdsRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "TranslateBrowsePathsToNodeIdsRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "TranslateBrowsePathsToNodeIdsRequest_browsePaths", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TranslateBrowsePathsToNodeIdsRequest_browsePaths");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->browsePaths = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSEPATH]);
-		if (out->browsePaths == NULL) {
+		if (out->browsePaths == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->browsePathsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->browsePaths[i] = XS_unpack_UA_BrowsePath(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_BrowsePath(&out->browsePaths[i], *svp);
 		}
-		out->browsePathsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* TranslateBrowsePathsToNodeIdsResponse */
 #ifdef UA_TYPES_TRANSLATEBROWSEPATHSTONODEIDSRESPONSE
-static void XS_pack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *out, UA_TranslateBrowsePathsToNodeIdsResponse in)  __attribute__((unused));
-static UA_TranslateBrowsePathsToNodeIdsResponse XS_unpack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *in)  __attribute__((unused));
 static void pack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *out, UA_TranslateBrowsePathsToNodeIdsResponse *in);
 static void unpack_UA_TranslateBrowsePathsToNodeIdsResponse(UA_TranslateBrowsePathsToNodeIdsResponse *out, SV *in);
 
@@ -11049,101 +10659,95 @@ pack_UA_TranslateBrowsePathsToNodeIdsResponse(SV *out, UA_TranslateBrowsePathsTo
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "TranslateBrowsePathsToNodeIdsResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TranslateBrowsePathsToNodeIdsResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_BrowsePathResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_BrowsePathResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "TranslateBrowsePathsToNodeIdsResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TranslateBrowsePathsToNodeIdsResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "TranslateBrowsePathsToNodeIdsResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_TranslateBrowsePathsToNodeIdsResponse(UA_TranslateBrowsePathsToNodeIdsResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_TranslateBrowsePathsToNodeIdsResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "TranslateBrowsePathsToNodeIdsResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "TranslateBrowsePathsToNodeIdsResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TranslateBrowsePathsToNodeIdsResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BROWSEPATHRESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_BrowsePathResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_BrowsePathResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "TranslateBrowsePathsToNodeIdsResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TranslateBrowsePathsToNodeIdsResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* RegisterNodesRequest */
 #ifdef UA_TYPES_REGISTERNODESREQUEST
-static void XS_pack_UA_RegisterNodesRequest(SV *out, UA_RegisterNodesRequest in)  __attribute__((unused));
-static UA_RegisterNodesRequest XS_unpack_UA_RegisterNodesRequest(SV *in)  __attribute__((unused));
 static void pack_UA_RegisterNodesRequest(SV *out, UA_RegisterNodesRequest *in);
 static void unpack_UA_RegisterNodesRequest(UA_RegisterNodesRequest *out, SV *in);
 
@@ -11154,72 +10758,69 @@ pack_UA_RegisterNodesRequest(SV *out, UA_RegisterNodesRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "RegisterNodesRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "RegisterNodesRequest_nodesToRegister", newRV_noinc((SV*)av));
 	av_extend(av, in->nodesToRegisterSize);
 	for (i = 0; i < in->nodesToRegisterSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_NodeId(sv, in->nodesToRegister[i]);
 		av_push(av, sv);
+		pack_UA_NodeId(sv, &in->nodesToRegister[i]);
 	}
-	hv_stores(hv, "RegisterNodesRequest_nodesToRegister", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_RegisterNodesRequest(UA_RegisterNodesRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RegisterNodesRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RegisterNodesRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "RegisterNodesRequest_nodesToRegister", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for RegisterNodesRequest_nodesToRegister");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->nodesToRegister = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_NODEID]);
-		if (out->nodesToRegister == NULL) {
+		if (out->nodesToRegister == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->nodesToRegisterSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->nodesToRegister[i] = XS_unpack_UA_NodeId(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_NodeId(&out->nodesToRegister[i], *svp);
 		}
-		out->nodesToRegisterSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* RegisterNodesResponse */
 #ifdef UA_TYPES_REGISTERNODESRESPONSE
-static void XS_pack_UA_RegisterNodesResponse(SV *out, UA_RegisterNodesResponse in)  __attribute__((unused));
-static UA_RegisterNodesResponse XS_unpack_UA_RegisterNodesResponse(SV *in)  __attribute__((unused));
 static void pack_UA_RegisterNodesResponse(SV *out, UA_RegisterNodesResponse *in);
 static void unpack_UA_RegisterNodesResponse(UA_RegisterNodesResponse *out, SV *in);
 
@@ -11230,72 +10831,69 @@ pack_UA_RegisterNodesResponse(SV *out, UA_RegisterNodesResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "RegisterNodesResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "RegisterNodesResponse_registeredNodeIds", newRV_noinc((SV*)av));
 	av_extend(av, in->registeredNodeIdsSize);
 	for (i = 0; i < in->registeredNodeIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_NodeId(sv, in->registeredNodeIds[i]);
 		av_push(av, sv);
+		pack_UA_NodeId(sv, &in->registeredNodeIds[i]);
 	}
-	hv_stores(hv, "RegisterNodesResponse_registeredNodeIds", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_RegisterNodesResponse(UA_RegisterNodesResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RegisterNodesResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RegisterNodesResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "RegisterNodesResponse_registeredNodeIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for RegisterNodesResponse_registeredNodeIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->registeredNodeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_NODEID]);
-		if (out->registeredNodeIds == NULL) {
+		if (out->registeredNodeIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->registeredNodeIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->registeredNodeIds[i] = XS_unpack_UA_NodeId(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_NodeId(&out->registeredNodeIds[i], *svp);
 		}
-		out->registeredNodeIdsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* UnregisterNodesRequest */
 #ifdef UA_TYPES_UNREGISTERNODESREQUEST
-static void XS_pack_UA_UnregisterNodesRequest(SV *out, UA_UnregisterNodesRequest in)  __attribute__((unused));
-static UA_UnregisterNodesRequest XS_unpack_UA_UnregisterNodesRequest(SV *in)  __attribute__((unused));
 static void pack_UA_UnregisterNodesRequest(SV *out, UA_UnregisterNodesRequest *in);
 static void unpack_UA_UnregisterNodesRequest(UA_UnregisterNodesRequest *out, SV *in);
 
@@ -11306,72 +10904,69 @@ pack_UA_UnregisterNodesRequest(SV *out, UA_UnregisterNodesRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "UnregisterNodesRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "UnregisterNodesRequest_nodesToUnregister", newRV_noinc((SV*)av));
 	av_extend(av, in->nodesToUnregisterSize);
 	for (i = 0; i < in->nodesToUnregisterSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_NodeId(sv, in->nodesToUnregister[i]);
 		av_push(av, sv);
+		pack_UA_NodeId(sv, &in->nodesToUnregister[i]);
 	}
-	hv_stores(hv, "UnregisterNodesRequest_nodesToUnregister", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_UnregisterNodesRequest(UA_UnregisterNodesRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UnregisterNodesRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UnregisterNodesRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "UnregisterNodesRequest_nodesToUnregister", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UnregisterNodesRequest_nodesToUnregister");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->nodesToUnregister = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_NODEID]);
-		if (out->nodesToUnregister == NULL) {
+		if (out->nodesToUnregister == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->nodesToUnregisterSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->nodesToUnregister[i] = XS_unpack_UA_NodeId(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_NodeId(&out->nodesToUnregister[i], *svp);
 		}
-		out->nodesToUnregisterSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* UnregisterNodesResponse */
 #ifdef UA_TYPES_UNREGISTERNODESRESPONSE
-static void XS_pack_UA_UnregisterNodesResponse(SV *out, UA_UnregisterNodesResponse in)  __attribute__((unused));
-static UA_UnregisterNodesResponse XS_unpack_UA_UnregisterNodesResponse(SV *in)  __attribute__((unused));
 static void pack_UA_UnregisterNodesResponse(SV *out, UA_UnregisterNodesResponse *in);
 static void unpack_UA_UnregisterNodesResponse(UA_UnregisterNodesResponse *out, SV *in);
 
@@ -11380,41 +10975,41 @@ pack_UA_UnregisterNodesResponse(SV *out, UA_UnregisterNodesResponse *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "UnregisterNodesResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_UnregisterNodesResponse(UA_UnregisterNodesResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UnregisterNodesResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UnregisterNodesResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
-
+	return;
 }
 #endif
 
 /* Counter */
 #ifdef UA_TYPES_COUNTER
-static void XS_pack_UA_Counter(SV *out, UA_Counter in)  __attribute__((unused));
-static UA_Counter XS_unpack_UA_Counter(SV *in)  __attribute__((unused));
 static void pack_UA_Counter(SV *out, UA_Counter *in);
 static void unpack_UA_Counter(UA_Counter *out, SV *in);
 
@@ -11422,21 +11017,19 @@ static void
 pack_UA_Counter(SV *out, UA_Counter *in)
 {
 	dTHX;
-	XS_pack_UA_UInt32(out, *in);
+	pack_UA_UInt32(out, in);
 }
 
 static void
 unpack_UA_Counter(UA_Counter *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_UInt32(in);
+	unpack_UA_UInt32(out, in);
 }
 #endif
 
 /* Time */
 #ifdef UA_TYPES_TIME
-static void XS_pack_UA_Time(SV *out, UA_Time in)  __attribute__((unused));
-static UA_Time XS_unpack_UA_Time(SV *in)  __attribute__((unused));
 static void pack_UA_Time(SV *out, UA_Time *in);
 static void unpack_UA_Time(UA_Time *out, SV *in);
 
@@ -11444,21 +11037,19 @@ static void
 pack_UA_Time(SV *out, UA_Time *in)
 {
 	dTHX;
-	XS_pack_UA_String(out, *in);
+	pack_UA_String(out, in);
 }
 
 static void
 unpack_UA_Time(UA_Time *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_String(in);
+	unpack_UA_String(out, in);
 }
 #endif
 
 /* Date */
 #ifdef UA_TYPES_DATE
-static void XS_pack_UA_Date(SV *out, UA_Date in)  __attribute__((unused));
-static UA_Date XS_unpack_UA_Date(SV *in)  __attribute__((unused));
 static void pack_UA_Date(SV *out, UA_Date *in);
 static void unpack_UA_Date(UA_Date *out, SV *in);
 
@@ -11466,21 +11057,19 @@ static void
 pack_UA_Date(SV *out, UA_Date *in)
 {
 	dTHX;
-	XS_pack_UA_DateTime(out, *in);
+	pack_UA_DateTime(out, in);
 }
 
 static void
 unpack_UA_Date(UA_Date *out, SV *in)
 {
 	dTHX;
-	*out = XS_unpack_UA_DateTime(in);
+	unpack_UA_DateTime(out, in);
 }
 #endif
 
 /* EndpointConfiguration */
 #ifdef UA_TYPES_ENDPOINTCONFIGURATION
-static void XS_pack_UA_EndpointConfiguration(SV *out, UA_EndpointConfiguration in)  __attribute__((unused));
-static UA_EndpointConfiguration XS_unpack_UA_EndpointConfiguration(SV *in)  __attribute__((unused));
 static void pack_UA_EndpointConfiguration(SV *out, UA_EndpointConfiguration *in);
 static void unpack_UA_EndpointConfiguration(UA_EndpointConfiguration *out, SV *in);
 
@@ -11489,105 +11078,105 @@ pack_UA_EndpointConfiguration(SV *out, UA_EndpointConfiguration *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->operationTimeout);
-	hv_stores(hv, "EndpointConfiguration_operationTimeout", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->useBinaryEncoding);
-	hv_stores(hv, "EndpointConfiguration_useBinaryEncoding", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->maxStringLength);
-	hv_stores(hv, "EndpointConfiguration_maxStringLength", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->maxByteStringLength);
-	hv_stores(hv, "EndpointConfiguration_maxByteStringLength", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->maxArrayLength);
-	hv_stores(hv, "EndpointConfiguration_maxArrayLength", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->maxMessageSize);
-	hv_stores(hv, "EndpointConfiguration_maxMessageSize", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->maxBufferSize);
-	hv_stores(hv, "EndpointConfiguration_maxBufferSize", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->channelLifetime);
-	hv_stores(hv, "EndpointConfiguration_channelLifetime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->securityTokenLifetime);
-	hv_stores(hv, "EndpointConfiguration_securityTokenLifetime", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointConfiguration_operationTimeout", sv);
+	pack_UA_Int32(sv, &in->operationTimeout);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointConfiguration_useBinaryEncoding", sv);
+	pack_UA_Boolean(sv, &in->useBinaryEncoding);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointConfiguration_maxStringLength", sv);
+	pack_UA_Int32(sv, &in->maxStringLength);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointConfiguration_maxByteStringLength", sv);
+	pack_UA_Int32(sv, &in->maxByteStringLength);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointConfiguration_maxArrayLength", sv);
+	pack_UA_Int32(sv, &in->maxArrayLength);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointConfiguration_maxMessageSize", sv);
+	pack_UA_Int32(sv, &in->maxMessageSize);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointConfiguration_maxBufferSize", sv);
+	pack_UA_Int32(sv, &in->maxBufferSize);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointConfiguration_channelLifetime", sv);
+	pack_UA_Int32(sv, &in->channelLifetime);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointConfiguration_securityTokenLifetime", sv);
+	pack_UA_Int32(sv, &in->securityTokenLifetime);
+
+	return;
 }
 
 static void
 unpack_UA_EndpointConfiguration(UA_EndpointConfiguration *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EndpointConfiguration_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EndpointConfiguration_operationTimeout", 0);
 	if (svp != NULL)
-		out->operationTimeout = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->operationTimeout, *svp);
 
 	svp = hv_fetchs(hv, "EndpointConfiguration_useBinaryEncoding", 0);
 	if (svp != NULL)
-		out->useBinaryEncoding = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->useBinaryEncoding, *svp);
 
 	svp = hv_fetchs(hv, "EndpointConfiguration_maxStringLength", 0);
 	if (svp != NULL)
-		out->maxStringLength = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->maxStringLength, *svp);
 
 	svp = hv_fetchs(hv, "EndpointConfiguration_maxByteStringLength", 0);
 	if (svp != NULL)
-		out->maxByteStringLength = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->maxByteStringLength, *svp);
 
 	svp = hv_fetchs(hv, "EndpointConfiguration_maxArrayLength", 0);
 	if (svp != NULL)
-		out->maxArrayLength = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->maxArrayLength, *svp);
 
 	svp = hv_fetchs(hv, "EndpointConfiguration_maxMessageSize", 0);
 	if (svp != NULL)
-		out->maxMessageSize = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->maxMessageSize, *svp);
 
 	svp = hv_fetchs(hv, "EndpointConfiguration_maxBufferSize", 0);
 	if (svp != NULL)
-		out->maxBufferSize = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->maxBufferSize, *svp);
 
 	svp = hv_fetchs(hv, "EndpointConfiguration_channelLifetime", 0);
 	if (svp != NULL)
-		out->channelLifetime = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->channelLifetime, *svp);
 
 	svp = hv_fetchs(hv, "EndpointConfiguration_securityTokenLifetime", 0);
 	if (svp != NULL)
-		out->securityTokenLifetime = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->securityTokenLifetime, *svp);
 
-
+	return;
 }
 #endif
 
 /* QueryDataDescription */
 #ifdef UA_TYPES_QUERYDATADESCRIPTION
-static void XS_pack_UA_QueryDataDescription(SV *out, UA_QueryDataDescription in)  __attribute__((unused));
-static UA_QueryDataDescription XS_unpack_UA_QueryDataDescription(SV *in)  __attribute__((unused));
 static void pack_UA_QueryDataDescription(SV *out, UA_QueryDataDescription *in);
 static void unpack_UA_QueryDataDescription(UA_QueryDataDescription *out, SV *in);
 
@@ -11596,57 +11185,57 @@ pack_UA_QueryDataDescription(SV *out, UA_QueryDataDescription *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RelativePath(sv, in->relativePath);
-	hv_stores(hv, "QueryDataDescription_relativePath", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->attributeId);
-	hv_stores(hv, "QueryDataDescription_attributeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->indexRange);
-	hv_stores(hv, "QueryDataDescription_indexRange", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "QueryDataDescription_relativePath", sv);
+	pack_UA_RelativePath(sv, &in->relativePath);
+
+	sv = newSV(0);
+	hv_stores(hv, "QueryDataDescription_attributeId", sv);
+	pack_UA_UInt32(sv, &in->attributeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "QueryDataDescription_indexRange", sv);
+	pack_UA_String(sv, &in->indexRange);
+
+	return;
 }
 
 static void
 unpack_UA_QueryDataDescription(UA_QueryDataDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_QueryDataDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "QueryDataDescription_relativePath", 0);
 	if (svp != NULL)
-		out->relativePath = XS_unpack_UA_RelativePath(*svp);
+		unpack_UA_RelativePath(&out->relativePath, *svp);
 
 	svp = hv_fetchs(hv, "QueryDataDescription_attributeId", 0);
 	if (svp != NULL)
-		out->attributeId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->attributeId, *svp);
 
 	svp = hv_fetchs(hv, "QueryDataDescription_indexRange", 0);
 	if (svp != NULL)
-		out->indexRange = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->indexRange, *svp);
 
-
+	return;
 }
 #endif
 
 /* NodeTypeDescription */
 #ifdef UA_TYPES_NODETYPEDESCRIPTION
-static void XS_pack_UA_NodeTypeDescription(SV *out, UA_NodeTypeDescription in)  __attribute__((unused));
-static UA_NodeTypeDescription XS_unpack_UA_NodeTypeDescription(SV *in)  __attribute__((unused));
 static void pack_UA_NodeTypeDescription(SV *out, UA_NodeTypeDescription *in);
 static void unpack_UA_NodeTypeDescription(UA_NodeTypeDescription *out, SV *in);
 
@@ -11657,80 +11246,77 @@ pack_UA_NodeTypeDescription(SV *out, UA_NodeTypeDescription *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->typeDefinitionNode);
 	hv_stores(hv, "NodeTypeDescription_typeDefinitionNode", sv);
+	pack_UA_ExpandedNodeId(sv, &in->typeDefinitionNode);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->includeSubTypes);
 	hv_stores(hv, "NodeTypeDescription_includeSubTypes", sv);
+	pack_UA_Boolean(sv, &in->includeSubTypes);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "NodeTypeDescription_dataToReturn", newRV_noinc((SV*)av));
 	av_extend(av, in->dataToReturnSize);
 	for (i = 0; i < in->dataToReturnSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_QueryDataDescription(sv, in->dataToReturn[i]);
 		av_push(av, sv);
+		pack_UA_QueryDataDescription(sv, &in->dataToReturn[i]);
 	}
-	hv_stores(hv, "NodeTypeDescription_dataToReturn", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_NodeTypeDescription(UA_NodeTypeDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_NodeTypeDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "NodeTypeDescription_typeDefinitionNode", 0);
 	if (svp != NULL)
-		out->typeDefinitionNode = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->typeDefinitionNode, *svp);
 
 	svp = hv_fetchs(hv, "NodeTypeDescription_includeSubTypes", 0);
 	if (svp != NULL)
-		out->includeSubTypes = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->includeSubTypes, *svp);
 
 	svp = hv_fetchs(hv, "NodeTypeDescription_dataToReturn", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for NodeTypeDescription_dataToReturn");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataToReturn = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_QUERYDATADESCRIPTION]);
-		if (out->dataToReturn == NULL) {
+		if (out->dataToReturn == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataToReturnSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataToReturn[i] = XS_unpack_UA_QueryDataDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_QueryDataDescription(&out->dataToReturn[i], *svp);
 		}
-		out->dataToReturnSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* FilterOperator */
 #ifdef UA_TYPES_FILTEROPERATOR
-static void XS_pack_UA_FilterOperator(SV *out, UA_FilterOperator in)  __attribute__((unused));
-static UA_FilterOperator XS_unpack_UA_FilterOperator(SV *in)  __attribute__((unused));
 static void pack_UA_FilterOperator(SV *out, UA_FilterOperator *in);
 static void unpack_UA_FilterOperator(UA_FilterOperator *out, SV *in);
 
@@ -11751,8 +11337,6 @@ unpack_UA_FilterOperator(UA_FilterOperator *out, SV *in)
 
 /* QueryDataSet */
 #ifdef UA_TYPES_QUERYDATASET
-static void XS_pack_UA_QueryDataSet(SV *out, UA_QueryDataSet in)  __attribute__((unused));
-static UA_QueryDataSet XS_unpack_UA_QueryDataSet(SV *in)  __attribute__((unused));
 static void pack_UA_QueryDataSet(SV *out, UA_QueryDataSet *in);
 static void unpack_UA_QueryDataSet(UA_QueryDataSet *out, SV *in);
 
@@ -11763,80 +11347,77 @@ pack_UA_QueryDataSet(SV *out, UA_QueryDataSet *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->nodeId);
 	hv_stores(hv, "QueryDataSet_nodeId", sv);
+	pack_UA_ExpandedNodeId(sv, &in->nodeId);
 
 	sv = newSV(0);
-	XS_pack_UA_ExpandedNodeId(sv, in->typeDefinitionNode);
 	hv_stores(hv, "QueryDataSet_typeDefinitionNode", sv);
+	pack_UA_ExpandedNodeId(sv, &in->typeDefinitionNode);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "QueryDataSet_values", newRV_noinc((SV*)av));
 	av_extend(av, in->valuesSize);
 	for (i = 0; i < in->valuesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Variant(sv, in->values[i]);
 		av_push(av, sv);
+		pack_UA_Variant(sv, &in->values[i]);
 	}
-	hv_stores(hv, "QueryDataSet_values", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_QueryDataSet(UA_QueryDataSet *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_QueryDataSet_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "QueryDataSet_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "QueryDataSet_typeDefinitionNode", 0);
 	if (svp != NULL)
-		out->typeDefinitionNode = XS_unpack_UA_ExpandedNodeId(*svp);
+		unpack_UA_ExpandedNodeId(&out->typeDefinitionNode, *svp);
 
 	svp = hv_fetchs(hv, "QueryDataSet_values", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for QueryDataSet_values");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->values = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
-		if (out->values == NULL) {
+		if (out->values == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->valuesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->values[i] = XS_unpack_UA_Variant(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Variant(&out->values[i], *svp);
 		}
-		out->valuesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* NodeReference */
 #ifdef UA_TYPES_NODEREFERENCE
-static void XS_pack_UA_NodeReference(SV *out, UA_NodeReference in)  __attribute__((unused));
-static UA_NodeReference XS_unpack_UA_NodeReference(SV *in)  __attribute__((unused));
 static void pack_UA_NodeReference(SV *out, UA_NodeReference *in);
 static void unpack_UA_NodeReference(UA_NodeReference *out, SV *in);
 
@@ -11847,88 +11428,85 @@ pack_UA_NodeReference(SV *out, UA_NodeReference *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
 	hv_stores(hv, "NodeReference_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->referenceTypeId);
 	hv_stores(hv, "NodeReference_referenceTypeId", sv);
+	pack_UA_NodeId(sv, &in->referenceTypeId);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isForward);
 	hv_stores(hv, "NodeReference_isForward", sv);
+	pack_UA_Boolean(sv, &in->isForward);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "NodeReference_referencedNodeIds", newRV_noinc((SV*)av));
 	av_extend(av, in->referencedNodeIdsSize);
 	for (i = 0; i < in->referencedNodeIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_NodeId(sv, in->referencedNodeIds[i]);
 		av_push(av, sv);
+		pack_UA_NodeId(sv, &in->referencedNodeIds[i]);
 	}
-	hv_stores(hv, "NodeReference_referencedNodeIds", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_NodeReference(UA_NodeReference *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_NodeReference_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "NodeReference_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "NodeReference_referenceTypeId", 0);
 	if (svp != NULL)
-		out->referenceTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->referenceTypeId, *svp);
 
 	svp = hv_fetchs(hv, "NodeReference_isForward", 0);
 	if (svp != NULL)
-		out->isForward = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isForward, *svp);
 
 	svp = hv_fetchs(hv, "NodeReference_referencedNodeIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for NodeReference_referencedNodeIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->referencedNodeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_NODEID]);
-		if (out->referencedNodeIds == NULL) {
+		if (out->referencedNodeIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->referencedNodeIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->referencedNodeIds[i] = XS_unpack_UA_NodeId(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_NodeId(&out->referencedNodeIds[i], *svp);
 		}
-		out->referencedNodeIdsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ContentFilterElement */
 #ifdef UA_TYPES_CONTENTFILTERELEMENT
-static void XS_pack_UA_ContentFilterElement(SV *out, UA_ContentFilterElement in)  __attribute__((unused));
-static UA_ContentFilterElement XS_unpack_UA_ContentFilterElement(SV *in)  __attribute__((unused));
 static void pack_UA_ContentFilterElement(SV *out, UA_ContentFilterElement *in);
 static void unpack_UA_ContentFilterElement(UA_ContentFilterElement *out, SV *in);
 
@@ -11939,72 +11517,69 @@ pack_UA_ContentFilterElement(SV *out, UA_ContentFilterElement *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_FilterOperator(sv, in->filterOperator);
 	hv_stores(hv, "ContentFilterElement_filterOperator", sv);
+	pack_UA_FilterOperator(sv, &in->filterOperator);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ContentFilterElement_filterOperands", newRV_noinc((SV*)av));
 	av_extend(av, in->filterOperandsSize);
 	for (i = 0; i < in->filterOperandsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ExtensionObject(sv, in->filterOperands[i]);
 		av_push(av, sv);
+		pack_UA_ExtensionObject(sv, &in->filterOperands[i]);
 	}
-	hv_stores(hv, "ContentFilterElement_filterOperands", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ContentFilterElement(UA_ContentFilterElement *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ContentFilterElement_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ContentFilterElement_filterOperator", 0);
 	if (svp != NULL)
-		out->filterOperator = XS_unpack_UA_FilterOperator(*svp);
+		unpack_UA_FilterOperator(&out->filterOperator, *svp);
 
 	svp = hv_fetchs(hv, "ContentFilterElement_filterOperands", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ContentFilterElement_filterOperands");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->filterOperands = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
-		if (out->filterOperands == NULL) {
+		if (out->filterOperands == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->filterOperandsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->filterOperands[i] = XS_unpack_UA_ExtensionObject(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ExtensionObject(&out->filterOperands[i], *svp);
 		}
-		out->filterOperandsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ContentFilter */
 #ifdef UA_TYPES_CONTENTFILTER
-static void XS_pack_UA_ContentFilter(SV *out, UA_ContentFilter in)  __attribute__((unused));
-static UA_ContentFilter XS_unpack_UA_ContentFilter(SV *in)  __attribute__((unused));
 static void pack_UA_ContentFilter(SV *out, UA_ContentFilter *in);
 static void unpack_UA_ContentFilter(UA_ContentFilter *out, SV *in);
 
@@ -12015,64 +11590,61 @@ pack_UA_ContentFilter(SV *out, UA_ContentFilter *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "ContentFilter_elements", newRV_noinc((SV*)av));
 	av_extend(av, in->elementsSize);
 	for (i = 0; i < in->elementsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ContentFilterElement(sv, in->elements[i]);
 		av_push(av, sv);
+		pack_UA_ContentFilterElement(sv, &in->elements[i]);
 	}
-	hv_stores(hv, "ContentFilter_elements", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ContentFilter(UA_ContentFilter *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ContentFilter_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ContentFilter_elements", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ContentFilter_elements");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->elements = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENT]);
-		if (out->elements == NULL) {
+		if (out->elements == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->elementsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->elements[i] = XS_unpack_UA_ContentFilterElement(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ContentFilterElement(&out->elements[i], *svp);
 		}
-		out->elementsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* FilterOperand */
 #ifdef UA_TYPES_FILTEROPERAND
-static void XS_pack_UA_FilterOperand(SV *out, UA_FilterOperand in)  __attribute__((unused));
-static UA_FilterOperand XS_unpack_UA_FilterOperand(SV *in)  __attribute__((unused));
 static void pack_UA_FilterOperand(SV *out, UA_FilterOperand *in);
 static void unpack_UA_FilterOperand(UA_FilterOperand *out, SV *in);
 
@@ -12093,8 +11665,6 @@ unpack_UA_FilterOperand(UA_FilterOperand *out, SV *in)
 
 /* ElementOperand */
 #ifdef UA_TYPES_ELEMENTOPERAND
-static void XS_pack_UA_ElementOperand(SV *out, UA_ElementOperand in)  __attribute__((unused));
-static UA_ElementOperand XS_unpack_UA_ElementOperand(SV *in)  __attribute__((unused));
 static void pack_UA_ElementOperand(SV *out, UA_ElementOperand *in);
 static void unpack_UA_ElementOperand(UA_ElementOperand *out, SV *in);
 
@@ -12103,41 +11673,41 @@ pack_UA_ElementOperand(SV *out, UA_ElementOperand *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->index);
 	hv_stores(hv, "ElementOperand_index", sv);
+	pack_UA_UInt32(sv, &in->index);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ElementOperand(UA_ElementOperand *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ElementOperand_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ElementOperand_index", 0);
 	if (svp != NULL)
-		out->index = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->index, *svp);
 
-
+	return;
 }
 #endif
 
 /* LiteralOperand */
 #ifdef UA_TYPES_LITERALOPERAND
-static void XS_pack_UA_LiteralOperand(SV *out, UA_LiteralOperand in)  __attribute__((unused));
-static UA_LiteralOperand XS_unpack_UA_LiteralOperand(SV *in)  __attribute__((unused));
 static void pack_UA_LiteralOperand(SV *out, UA_LiteralOperand *in);
 static void unpack_UA_LiteralOperand(UA_LiteralOperand *out, SV *in);
 
@@ -12146,41 +11716,41 @@ pack_UA_LiteralOperand(SV *out, UA_LiteralOperand *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->value);
 	hv_stores(hv, "LiteralOperand_value", sv);
+	pack_UA_Variant(sv, &in->value);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_LiteralOperand(UA_LiteralOperand *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_LiteralOperand_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "LiteralOperand_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->value, *svp);
 
-
+	return;
 }
 #endif
 
 /* AttributeOperand */
 #ifdef UA_TYPES_ATTRIBUTEOPERAND
-static void XS_pack_UA_AttributeOperand(SV *out, UA_AttributeOperand in)  __attribute__((unused));
-static UA_AttributeOperand XS_unpack_UA_AttributeOperand(SV *in)  __attribute__((unused));
 static void pack_UA_AttributeOperand(SV *out, UA_AttributeOperand *in);
 static void unpack_UA_AttributeOperand(UA_AttributeOperand *out, SV *in);
 
@@ -12189,73 +11759,73 @@ pack_UA_AttributeOperand(SV *out, UA_AttributeOperand *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
-	hv_stores(hv, "AttributeOperand_nodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->alias);
-	hv_stores(hv, "AttributeOperand_alias", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_RelativePath(sv, in->browsePath);
-	hv_stores(hv, "AttributeOperand_browsePath", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->attributeId);
-	hv_stores(hv, "AttributeOperand_attributeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->indexRange);
-	hv_stores(hv, "AttributeOperand_indexRange", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "AttributeOperand_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "AttributeOperand_alias", sv);
+	pack_UA_String(sv, &in->alias);
+
+	sv = newSV(0);
+	hv_stores(hv, "AttributeOperand_browsePath", sv);
+	pack_UA_RelativePath(sv, &in->browsePath);
+
+	sv = newSV(0);
+	hv_stores(hv, "AttributeOperand_attributeId", sv);
+	pack_UA_UInt32(sv, &in->attributeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "AttributeOperand_indexRange", sv);
+	pack_UA_String(sv, &in->indexRange);
+
+	return;
 }
 
 static void
 unpack_UA_AttributeOperand(UA_AttributeOperand *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AttributeOperand_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AttributeOperand_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "AttributeOperand_alias", 0);
 	if (svp != NULL)
-		out->alias = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->alias, *svp);
 
 	svp = hv_fetchs(hv, "AttributeOperand_browsePath", 0);
 	if (svp != NULL)
-		out->browsePath = XS_unpack_UA_RelativePath(*svp);
+		unpack_UA_RelativePath(&out->browsePath, *svp);
 
 	svp = hv_fetchs(hv, "AttributeOperand_attributeId", 0);
 	if (svp != NULL)
-		out->attributeId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->attributeId, *svp);
 
 	svp = hv_fetchs(hv, "AttributeOperand_indexRange", 0);
 	if (svp != NULL)
-		out->indexRange = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->indexRange, *svp);
 
-
+	return;
 }
 #endif
 
 /* SimpleAttributeOperand */
 #ifdef UA_TYPES_SIMPLEATTRIBUTEOPERAND
-static void XS_pack_UA_SimpleAttributeOperand(SV *out, UA_SimpleAttributeOperand in)  __attribute__((unused));
-static UA_SimpleAttributeOperand XS_unpack_UA_SimpleAttributeOperand(SV *in)  __attribute__((unused));
 static void pack_UA_SimpleAttributeOperand(SV *out, UA_SimpleAttributeOperand *in);
 static void unpack_UA_SimpleAttributeOperand(UA_SimpleAttributeOperand *out, SV *in);
 
@@ -12266,88 +11836,85 @@ pack_UA_SimpleAttributeOperand(SV *out, UA_SimpleAttributeOperand *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->typeDefinitionId);
 	hv_stores(hv, "SimpleAttributeOperand_typeDefinitionId", sv);
+	pack_UA_NodeId(sv, &in->typeDefinitionId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SimpleAttributeOperand_browsePath", newRV_noinc((SV*)av));
 	av_extend(av, in->browsePathSize);
 	for (i = 0; i < in->browsePathSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_QualifiedName(sv, in->browsePath[i]);
 		av_push(av, sv);
+		pack_UA_QualifiedName(sv, &in->browsePath[i]);
 	}
-	hv_stores(hv, "SimpleAttributeOperand_browsePath", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->attributeId);
 	hv_stores(hv, "SimpleAttributeOperand_attributeId", sv);
+	pack_UA_UInt32(sv, &in->attributeId);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->indexRange);
 	hv_stores(hv, "SimpleAttributeOperand_indexRange", sv);
+	pack_UA_String(sv, &in->indexRange);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SimpleAttributeOperand(UA_SimpleAttributeOperand *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SimpleAttributeOperand_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SimpleAttributeOperand_typeDefinitionId", 0);
 	if (svp != NULL)
-		out->typeDefinitionId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->typeDefinitionId, *svp);
 
 	svp = hv_fetchs(hv, "SimpleAttributeOperand_browsePath", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SimpleAttributeOperand_browsePath");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->browsePath = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
-		if (out->browsePath == NULL) {
+		if (out->browsePath == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->browsePathSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->browsePath[i] = XS_unpack_UA_QualifiedName(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_QualifiedName(&out->browsePath[i], *svp);
 		}
-		out->browsePathSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SimpleAttributeOperand_attributeId", 0);
 	if (svp != NULL)
-		out->attributeId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->attributeId, *svp);
 
 	svp = hv_fetchs(hv, "SimpleAttributeOperand_indexRange", 0);
 	if (svp != NULL)
-		out->indexRange = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->indexRange, *svp);
 
-
+	return;
 }
 #endif
 
 /* ContentFilterElementResult */
 #ifdef UA_TYPES_CONTENTFILTERELEMENTRESULT
-static void XS_pack_UA_ContentFilterElementResult(SV *out, UA_ContentFilterElementResult in)  __attribute__((unused));
-static UA_ContentFilterElementResult XS_unpack_UA_ContentFilterElementResult(SV *in)  __attribute__((unused));
 static void pack_UA_ContentFilterElementResult(SV *out, UA_ContentFilterElementResult *in);
 static void unpack_UA_ContentFilterElementResult(UA_ContentFilterElementResult *out, SV *in);
 
@@ -12358,101 +11925,95 @@ pack_UA_ContentFilterElementResult(SV *out, UA_ContentFilterElementResult *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
 	hv_stores(hv, "ContentFilterElementResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ContentFilterElementResult_operandStatusCodes", newRV_noinc((SV*)av));
 	av_extend(av, in->operandStatusCodesSize);
 	for (i = 0; i < in->operandStatusCodesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->operandStatusCodes[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->operandStatusCodes[i]);
 	}
-	hv_stores(hv, "ContentFilterElementResult_operandStatusCodes", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ContentFilterElementResult_operandDiagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->operandDiagnosticInfosSize);
 	for (i = 0; i < in->operandDiagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->operandDiagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->operandDiagnosticInfos[i]);
 	}
-	hv_stores(hv, "ContentFilterElementResult_operandDiagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ContentFilterElementResult(UA_ContentFilterElementResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ContentFilterElementResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ContentFilterElementResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "ContentFilterElementResult_operandStatusCodes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ContentFilterElementResult_operandStatusCodes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->operandStatusCodes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->operandStatusCodes == NULL) {
+		if (out->operandStatusCodes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->operandStatusCodesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->operandStatusCodes[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->operandStatusCodes[i], *svp);
 		}
-		out->operandStatusCodesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ContentFilterElementResult_operandDiagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ContentFilterElementResult_operandDiagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->operandDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->operandDiagnosticInfos == NULL) {
+		if (out->operandDiagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->operandDiagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->operandDiagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->operandDiagnosticInfos[i], *svp);
 		}
-		out->operandDiagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ContentFilterResult */
 #ifdef UA_TYPES_CONTENTFILTERRESULT
-static void XS_pack_UA_ContentFilterResult(SV *out, UA_ContentFilterResult in)  __attribute__((unused));
-static UA_ContentFilterResult XS_unpack_UA_ContentFilterResult(SV *in)  __attribute__((unused));
 static void pack_UA_ContentFilterResult(SV *out, UA_ContentFilterResult *in);
 static void unpack_UA_ContentFilterResult(UA_ContentFilterResult *out, SV *in);
 
@@ -12463,93 +12024,87 @@ pack_UA_ContentFilterResult(SV *out, UA_ContentFilterResult *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "ContentFilterResult_elementResults", newRV_noinc((SV*)av));
 	av_extend(av, in->elementResultsSize);
 	for (i = 0; i < in->elementResultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ContentFilterElementResult(sv, in->elementResults[i]);
 		av_push(av, sv);
+		pack_UA_ContentFilterElementResult(sv, &in->elementResults[i]);
 	}
-	hv_stores(hv, "ContentFilterResult_elementResults", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ContentFilterResult_elementDiagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->elementDiagnosticInfosSize);
 	for (i = 0; i < in->elementDiagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->elementDiagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->elementDiagnosticInfos[i]);
 	}
-	hv_stores(hv, "ContentFilterResult_elementDiagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ContentFilterResult(UA_ContentFilterResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ContentFilterResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ContentFilterResult_elementResults", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ContentFilterResult_elementResults");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->elementResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_CONTENTFILTERELEMENTRESULT]);
-		if (out->elementResults == NULL) {
+		if (out->elementResults == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->elementResultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->elementResults[i] = XS_unpack_UA_ContentFilterElementResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ContentFilterElementResult(&out->elementResults[i], *svp);
 		}
-		out->elementResultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ContentFilterResult_elementDiagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ContentFilterResult_elementDiagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->elementDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->elementDiagnosticInfos == NULL) {
+		if (out->elementDiagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->elementDiagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->elementDiagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->elementDiagnosticInfos[i], *svp);
 		}
-		out->elementDiagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ParsingResult */
 #ifdef UA_TYPES_PARSINGRESULT
-static void XS_pack_UA_ParsingResult(SV *out, UA_ParsingResult in)  __attribute__((unused));
-static UA_ParsingResult XS_unpack_UA_ParsingResult(SV *in)  __attribute__((unused));
 static void pack_UA_ParsingResult(SV *out, UA_ParsingResult *in);
 static void unpack_UA_ParsingResult(UA_ParsingResult *out, SV *in);
 
@@ -12560,101 +12115,95 @@ pack_UA_ParsingResult(SV *out, UA_ParsingResult *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
 	hv_stores(hv, "ParsingResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ParsingResult_dataStatusCodes", newRV_noinc((SV*)av));
 	av_extend(av, in->dataStatusCodesSize);
 	for (i = 0; i < in->dataStatusCodesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->dataStatusCodes[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->dataStatusCodes[i]);
 	}
-	hv_stores(hv, "ParsingResult_dataStatusCodes", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ParsingResult_dataDiagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->dataDiagnosticInfosSize);
 	for (i = 0; i < in->dataDiagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->dataDiagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->dataDiagnosticInfos[i]);
 	}
-	hv_stores(hv, "ParsingResult_dataDiagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ParsingResult(UA_ParsingResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ParsingResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ParsingResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "ParsingResult_dataStatusCodes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ParsingResult_dataStatusCodes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataStatusCodes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->dataStatusCodes == NULL) {
+		if (out->dataStatusCodes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataStatusCodesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataStatusCodes[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->dataStatusCodes[i], *svp);
 		}
-		out->dataStatusCodesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ParsingResult_dataDiagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ParsingResult_dataDiagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->dataDiagnosticInfos == NULL) {
+		if (out->dataDiagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataDiagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataDiagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->dataDiagnosticInfos[i], *svp);
 		}
-		out->dataDiagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* QueryFirstRequest */
 #ifdef UA_TYPES_QUERYFIRSTREQUEST
-static void XS_pack_UA_QueryFirstRequest(SV *out, UA_QueryFirstRequest in)  __attribute__((unused));
-static UA_QueryFirstRequest XS_unpack_UA_QueryFirstRequest(SV *in)  __attribute__((unused));
 static void pack_UA_QueryFirstRequest(SV *out, UA_QueryFirstRequest *in);
 static void unpack_UA_QueryFirstRequest(UA_QueryFirstRequest *out, SV *in);
 
@@ -12665,104 +12214,101 @@ pack_UA_QueryFirstRequest(SV *out, UA_QueryFirstRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "QueryFirstRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_ViewDescription(sv, in->view);
 	hv_stores(hv, "QueryFirstRequest_view", sv);
+	pack_UA_ViewDescription(sv, &in->view);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "QueryFirstRequest_nodeTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->nodeTypesSize);
 	for (i = 0; i < in->nodeTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_NodeTypeDescription(sv, in->nodeTypes[i]);
 		av_push(av, sv);
+		pack_UA_NodeTypeDescription(sv, &in->nodeTypes[i]);
 	}
-	hv_stores(hv, "QueryFirstRequest_nodeTypes", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ContentFilter(sv, in->filter);
 	hv_stores(hv, "QueryFirstRequest_filter", sv);
+	pack_UA_ContentFilter(sv, &in->filter);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxDataSetsToReturn);
 	hv_stores(hv, "QueryFirstRequest_maxDataSetsToReturn", sv);
+	pack_UA_UInt32(sv, &in->maxDataSetsToReturn);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxReferencesToReturn);
 	hv_stores(hv, "QueryFirstRequest_maxReferencesToReturn", sv);
+	pack_UA_UInt32(sv, &in->maxReferencesToReturn);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_QueryFirstRequest(UA_QueryFirstRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_QueryFirstRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "QueryFirstRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "QueryFirstRequest_view", 0);
 	if (svp != NULL)
-		out->view = XS_unpack_UA_ViewDescription(*svp);
+		unpack_UA_ViewDescription(&out->view, *svp);
 
 	svp = hv_fetchs(hv, "QueryFirstRequest_nodeTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for QueryFirstRequest_nodeTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->nodeTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_NODETYPEDESCRIPTION]);
-		if (out->nodeTypes == NULL) {
+		if (out->nodeTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->nodeTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->nodeTypes[i] = XS_unpack_UA_NodeTypeDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_NodeTypeDescription(&out->nodeTypes[i], *svp);
 		}
-		out->nodeTypesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "QueryFirstRequest_filter", 0);
 	if (svp != NULL)
-		out->filter = XS_unpack_UA_ContentFilter(*svp);
+		unpack_UA_ContentFilter(&out->filter, *svp);
 
 	svp = hv_fetchs(hv, "QueryFirstRequest_maxDataSetsToReturn", 0);
 	if (svp != NULL)
-		out->maxDataSetsToReturn = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxDataSetsToReturn, *svp);
 
 	svp = hv_fetchs(hv, "QueryFirstRequest_maxReferencesToReturn", 0);
 	if (svp != NULL)
-		out->maxReferencesToReturn = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxReferencesToReturn, *svp);
 
-
+	return;
 }
 #endif
 
 /* QueryFirstResponse */
 #ifdef UA_TYPES_QUERYFIRSTRESPONSE
-static void XS_pack_UA_QueryFirstResponse(SV *out, UA_QueryFirstResponse in)  __attribute__((unused));
-static UA_QueryFirstResponse XS_unpack_UA_QueryFirstResponse(SV *in)  __attribute__((unused));
 static void pack_UA_QueryFirstResponse(SV *out, UA_QueryFirstResponse *in);
 static void unpack_UA_QueryFirstResponse(UA_QueryFirstResponse *out, SV *in);
 
@@ -12773,146 +12319,137 @@ pack_UA_QueryFirstResponse(SV *out, UA_QueryFirstResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "QueryFirstResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "QueryFirstResponse_queryDataSets", newRV_noinc((SV*)av));
 	av_extend(av, in->queryDataSetsSize);
 	for (i = 0; i < in->queryDataSetsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_QueryDataSet(sv, in->queryDataSets[i]);
 		av_push(av, sv);
+		pack_UA_QueryDataSet(sv, &in->queryDataSets[i]);
 	}
-	hv_stores(hv, "QueryFirstResponse_queryDataSets", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->continuationPoint);
 	hv_stores(hv, "QueryFirstResponse_continuationPoint", sv);
+	pack_UA_ByteString(sv, &in->continuationPoint);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "QueryFirstResponse_parsingResults", newRV_noinc((SV*)av));
 	av_extend(av, in->parsingResultsSize);
 	for (i = 0; i < in->parsingResultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ParsingResult(sv, in->parsingResults[i]);
 		av_push(av, sv);
+		pack_UA_ParsingResult(sv, &in->parsingResults[i]);
 	}
-	hv_stores(hv, "QueryFirstResponse_parsingResults", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "QueryFirstResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "QueryFirstResponse_diagnosticInfos", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ContentFilterResult(sv, in->filterResult);
 	hv_stores(hv, "QueryFirstResponse_filterResult", sv);
+	pack_UA_ContentFilterResult(sv, &in->filterResult);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_QueryFirstResponse(UA_QueryFirstResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_QueryFirstResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "QueryFirstResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "QueryFirstResponse_queryDataSets", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for QueryFirstResponse_queryDataSets");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->queryDataSets = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_QUERYDATASET]);
-		if (out->queryDataSets == NULL) {
+		if (out->queryDataSets == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->queryDataSetsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->queryDataSets[i] = XS_unpack_UA_QueryDataSet(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_QueryDataSet(&out->queryDataSets[i], *svp);
 		}
-		out->queryDataSetsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "QueryFirstResponse_continuationPoint", 0);
 	if (svp != NULL)
-		out->continuationPoint = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->continuationPoint, *svp);
 
 	svp = hv_fetchs(hv, "QueryFirstResponse_parsingResults", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for QueryFirstResponse_parsingResults");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->parsingResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_PARSINGRESULT]);
-		if (out->parsingResults == NULL) {
+		if (out->parsingResults == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->parsingResultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->parsingResults[i] = XS_unpack_UA_ParsingResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ParsingResult(&out->parsingResults[i], *svp);
 		}
-		out->parsingResultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "QueryFirstResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for QueryFirstResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
 	svp = hv_fetchs(hv, "QueryFirstResponse_filterResult", 0);
 	if (svp != NULL)
-		out->filterResult = XS_unpack_UA_ContentFilterResult(*svp);
+		unpack_UA_ContentFilterResult(&out->filterResult, *svp);
 
-
+	return;
 }
 #endif
 
 /* QueryNextRequest */
 #ifdef UA_TYPES_QUERYNEXTREQUEST
-static void XS_pack_UA_QueryNextRequest(SV *out, UA_QueryNextRequest in)  __attribute__((unused));
-static UA_QueryNextRequest XS_unpack_UA_QueryNextRequest(SV *in)  __attribute__((unused));
 static void pack_UA_QueryNextRequest(SV *out, UA_QueryNextRequest *in);
 static void unpack_UA_QueryNextRequest(UA_QueryNextRequest *out, SV *in);
 
@@ -12921,57 +12458,57 @@ pack_UA_QueryNextRequest(SV *out, UA_QueryNextRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
-	hv_stores(hv, "QueryNextRequest_requestHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->releaseContinuationPoint);
-	hv_stores(hv, "QueryNextRequest_releaseContinuationPoint", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->continuationPoint);
-	hv_stores(hv, "QueryNextRequest_continuationPoint", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "QueryNextRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "QueryNextRequest_releaseContinuationPoint", sv);
+	pack_UA_Boolean(sv, &in->releaseContinuationPoint);
+
+	sv = newSV(0);
+	hv_stores(hv, "QueryNextRequest_continuationPoint", sv);
+	pack_UA_ByteString(sv, &in->continuationPoint);
+
+	return;
 }
 
 static void
 unpack_UA_QueryNextRequest(UA_QueryNextRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_QueryNextRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "QueryNextRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "QueryNextRequest_releaseContinuationPoint", 0);
 	if (svp != NULL)
-		out->releaseContinuationPoint = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->releaseContinuationPoint, *svp);
 
 	svp = hv_fetchs(hv, "QueryNextRequest_continuationPoint", 0);
 	if (svp != NULL)
-		out->continuationPoint = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->continuationPoint, *svp);
 
-
+	return;
 }
 #endif
 
 /* QueryNextResponse */
 #ifdef UA_TYPES_QUERYNEXTRESPONSE
-static void XS_pack_UA_QueryNextResponse(SV *out, UA_QueryNextResponse in)  __attribute__((unused));
-static UA_QueryNextResponse XS_unpack_UA_QueryNextResponse(SV *in)  __attribute__((unused));
 static void pack_UA_QueryNextResponse(SV *out, UA_QueryNextResponse *in);
 static void unpack_UA_QueryNextResponse(UA_QueryNextResponse *out, SV *in);
 
@@ -12982,80 +12519,77 @@ pack_UA_QueryNextResponse(SV *out, UA_QueryNextResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "QueryNextResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "QueryNextResponse_queryDataSets", newRV_noinc((SV*)av));
 	av_extend(av, in->queryDataSetsSize);
 	for (i = 0; i < in->queryDataSetsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_QueryDataSet(sv, in->queryDataSets[i]);
 		av_push(av, sv);
+		pack_UA_QueryDataSet(sv, &in->queryDataSets[i]);
 	}
-	hv_stores(hv, "QueryNextResponse_queryDataSets", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->revisedContinuationPoint);
 	hv_stores(hv, "QueryNextResponse_revisedContinuationPoint", sv);
+	pack_UA_ByteString(sv, &in->revisedContinuationPoint);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_QueryNextResponse(UA_QueryNextResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_QueryNextResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "QueryNextResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "QueryNextResponse_queryDataSets", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for QueryNextResponse_queryDataSets");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->queryDataSets = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_QUERYDATASET]);
-		if (out->queryDataSets == NULL) {
+		if (out->queryDataSets == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->queryDataSetsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->queryDataSets[i] = XS_unpack_UA_QueryDataSet(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_QueryDataSet(&out->queryDataSets[i], *svp);
 		}
-		out->queryDataSetsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "QueryNextResponse_revisedContinuationPoint", 0);
 	if (svp != NULL)
-		out->revisedContinuationPoint = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->revisedContinuationPoint, *svp);
 
-
+	return;
 }
 #endif
 
 /* TimestampsToReturn */
 #ifdef UA_TYPES_TIMESTAMPSTORETURN
-static void XS_pack_UA_TimestampsToReturn(SV *out, UA_TimestampsToReturn in)  __attribute__((unused));
-static UA_TimestampsToReturn XS_unpack_UA_TimestampsToReturn(SV *in)  __attribute__((unused));
 static void pack_UA_TimestampsToReturn(SV *out, UA_TimestampsToReturn *in);
 static void unpack_UA_TimestampsToReturn(UA_TimestampsToReturn *out, SV *in);
 
@@ -13076,8 +12610,6 @@ unpack_UA_TimestampsToReturn(UA_TimestampsToReturn *out, SV *in)
 
 /* ReadValueId */
 #ifdef UA_TYPES_READVALUEID
-static void XS_pack_UA_ReadValueId(SV *out, UA_ReadValueId in)  __attribute__((unused));
-static UA_ReadValueId XS_unpack_UA_ReadValueId(SV *in)  __attribute__((unused));
 static void pack_UA_ReadValueId(SV *out, UA_ReadValueId *in);
 static void unpack_UA_ReadValueId(UA_ReadValueId *out, SV *in);
 
@@ -13086,65 +12618,65 @@ pack_UA_ReadValueId(SV *out, UA_ReadValueId *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
-	hv_stores(hv, "ReadValueId_nodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->attributeId);
-	hv_stores(hv, "ReadValueId_attributeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->indexRange);
-	hv_stores(hv, "ReadValueId_indexRange", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->dataEncoding);
-	hv_stores(hv, "ReadValueId_dataEncoding", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadValueId_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadValueId_attributeId", sv);
+	pack_UA_UInt32(sv, &in->attributeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadValueId_indexRange", sv);
+	pack_UA_String(sv, &in->indexRange);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadValueId_dataEncoding", sv);
+	pack_UA_QualifiedName(sv, &in->dataEncoding);
+
+	return;
 }
 
 static void
 unpack_UA_ReadValueId(UA_ReadValueId *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReadValueId_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReadValueId_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "ReadValueId_attributeId", 0);
 	if (svp != NULL)
-		out->attributeId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->attributeId, *svp);
 
 	svp = hv_fetchs(hv, "ReadValueId_indexRange", 0);
 	if (svp != NULL)
-		out->indexRange = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->indexRange, *svp);
 
 	svp = hv_fetchs(hv, "ReadValueId_dataEncoding", 0);
 	if (svp != NULL)
-		out->dataEncoding = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->dataEncoding, *svp);
 
-
+	return;
 }
 #endif
 
 /* ReadRequest */
 #ifdef UA_TYPES_READREQUEST
-static void XS_pack_UA_ReadRequest(SV *out, UA_ReadRequest in)  __attribute__((unused));
-static UA_ReadRequest XS_unpack_UA_ReadRequest(SV *in)  __attribute__((unused));
 static void pack_UA_ReadRequest(SV *out, UA_ReadRequest *in);
 static void unpack_UA_ReadRequest(UA_ReadRequest *out, SV *in);
 
@@ -13155,88 +12687,85 @@ pack_UA_ReadRequest(SV *out, UA_ReadRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "ReadRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->maxAge);
 	hv_stores(hv, "ReadRequest_maxAge", sv);
+	pack_UA_Double(sv, &in->maxAge);
 
 	sv = newSV(0);
-	XS_pack_UA_TimestampsToReturn(sv, in->timestampsToReturn);
 	hv_stores(hv, "ReadRequest_timestampsToReturn", sv);
+	pack_UA_TimestampsToReturn(sv, &in->timestampsToReturn);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ReadRequest_nodesToRead", newRV_noinc((SV*)av));
 	av_extend(av, in->nodesToReadSize);
 	for (i = 0; i < in->nodesToReadSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ReadValueId(sv, in->nodesToRead[i]);
 		av_push(av, sv);
+		pack_UA_ReadValueId(sv, &in->nodesToRead[i]);
 	}
-	hv_stores(hv, "ReadRequest_nodesToRead", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ReadRequest(UA_ReadRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReadRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReadRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "ReadRequest_maxAge", 0);
 	if (svp != NULL)
-		out->maxAge = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->maxAge, *svp);
 
 	svp = hv_fetchs(hv, "ReadRequest_timestampsToReturn", 0);
 	if (svp != NULL)
-		out->timestampsToReturn = XS_unpack_UA_TimestampsToReturn(*svp);
+		unpack_UA_TimestampsToReturn(&out->timestampsToReturn, *svp);
 
 	svp = hv_fetchs(hv, "ReadRequest_nodesToRead", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ReadRequest_nodesToRead");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->nodesToRead = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_READVALUEID]);
-		if (out->nodesToRead == NULL) {
+		if (out->nodesToRead == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->nodesToReadSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->nodesToRead[i] = XS_unpack_UA_ReadValueId(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ReadValueId(&out->nodesToRead[i], *svp);
 		}
-		out->nodesToReadSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ReadResponse */
 #ifdef UA_TYPES_READRESPONSE
-static void XS_pack_UA_ReadResponse(SV *out, UA_ReadResponse in)  __attribute__((unused));
-static UA_ReadResponse XS_unpack_UA_ReadResponse(SV *in)  __attribute__((unused));
 static void pack_UA_ReadResponse(SV *out, UA_ReadResponse *in);
 static void unpack_UA_ReadResponse(UA_ReadResponse *out, SV *in);
 
@@ -13247,101 +12776,95 @@ pack_UA_ReadResponse(SV *out, UA_ReadResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "ReadResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ReadResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DataValue(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_DataValue(sv, &in->results[i]);
 	}
-	hv_stores(hv, "ReadResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ReadResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "ReadResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ReadResponse(UA_ReadResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReadResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReadResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "ReadResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ReadResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATAVALUE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_DataValue(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DataValue(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ReadResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ReadResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryReadValueId */
 #ifdef UA_TYPES_HISTORYREADVALUEID
-static void XS_pack_UA_HistoryReadValueId(SV *out, UA_HistoryReadValueId in)  __attribute__((unused));
-static UA_HistoryReadValueId XS_unpack_UA_HistoryReadValueId(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryReadValueId(SV *out, UA_HistoryReadValueId *in);
 static void unpack_UA_HistoryReadValueId(UA_HistoryReadValueId *out, SV *in);
 
@@ -13350,65 +12873,65 @@ pack_UA_HistoryReadValueId(SV *out, UA_HistoryReadValueId *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
-	hv_stores(hv, "HistoryReadValueId_nodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->indexRange);
-	hv_stores(hv, "HistoryReadValueId_indexRange", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->dataEncoding);
-	hv_stores(hv, "HistoryReadValueId_dataEncoding", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->continuationPoint);
-	hv_stores(hv, "HistoryReadValueId_continuationPoint", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "HistoryReadValueId_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "HistoryReadValueId_indexRange", sv);
+	pack_UA_String(sv, &in->indexRange);
+
+	sv = newSV(0);
+	hv_stores(hv, "HistoryReadValueId_dataEncoding", sv);
+	pack_UA_QualifiedName(sv, &in->dataEncoding);
+
+	sv = newSV(0);
+	hv_stores(hv, "HistoryReadValueId_continuationPoint", sv);
+	pack_UA_ByteString(sv, &in->continuationPoint);
+
+	return;
 }
 
 static void
 unpack_UA_HistoryReadValueId(UA_HistoryReadValueId *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryReadValueId_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryReadValueId_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadValueId_indexRange", 0);
 	if (svp != NULL)
-		out->indexRange = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->indexRange, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadValueId_dataEncoding", 0);
 	if (svp != NULL)
-		out->dataEncoding = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->dataEncoding, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadValueId_continuationPoint", 0);
 	if (svp != NULL)
-		out->continuationPoint = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->continuationPoint, *svp);
 
-
+	return;
 }
 #endif
 
 /* HistoryReadResult */
 #ifdef UA_TYPES_HISTORYREADRESULT
-static void XS_pack_UA_HistoryReadResult(SV *out, UA_HistoryReadResult in)  __attribute__((unused));
-static UA_HistoryReadResult XS_unpack_UA_HistoryReadResult(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryReadResult(SV *out, UA_HistoryReadResult *in);
 static void unpack_UA_HistoryReadResult(UA_HistoryReadResult *out, SV *in);
 
@@ -13417,57 +12940,57 @@ pack_UA_HistoryReadResult(SV *out, UA_HistoryReadResult *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
-	hv_stores(hv, "HistoryReadResult_statusCode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->continuationPoint);
-	hv_stores(hv, "HistoryReadResult_continuationPoint", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->historyData);
-	hv_stores(hv, "HistoryReadResult_historyData", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "HistoryReadResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
+
+	sv = newSV(0);
+	hv_stores(hv, "HistoryReadResult_continuationPoint", sv);
+	pack_UA_ByteString(sv, &in->continuationPoint);
+
+	sv = newSV(0);
+	hv_stores(hv, "HistoryReadResult_historyData", sv);
+	pack_UA_ExtensionObject(sv, &in->historyData);
+
+	return;
 }
 
 static void
 unpack_UA_HistoryReadResult(UA_HistoryReadResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryReadResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryReadResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadResult_continuationPoint", 0);
 	if (svp != NULL)
-		out->continuationPoint = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->continuationPoint, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadResult_historyData", 0);
 	if (svp != NULL)
-		out->historyData = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->historyData, *svp);
 
-
+	return;
 }
 #endif
 
 /* HistoryReadDetails */
 #ifdef UA_TYPES_HISTORYREADDETAILS
-static void XS_pack_UA_HistoryReadDetails(SV *out, UA_HistoryReadDetails in)  __attribute__((unused));
-static UA_HistoryReadDetails XS_unpack_UA_HistoryReadDetails(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryReadDetails(SV *out, UA_HistoryReadDetails *in);
 static void unpack_UA_HistoryReadDetails(UA_HistoryReadDetails *out, SV *in);
 
@@ -13488,8 +13011,6 @@ unpack_UA_HistoryReadDetails(UA_HistoryReadDetails *out, SV *in)
 
 /* ReadRawModifiedDetails */
 #ifdef UA_TYPES_READRAWMODIFIEDDETAILS
-static void XS_pack_UA_ReadRawModifiedDetails(SV *out, UA_ReadRawModifiedDetails in)  __attribute__((unused));
-static UA_ReadRawModifiedDetails XS_unpack_UA_ReadRawModifiedDetails(SV *in)  __attribute__((unused));
 static void pack_UA_ReadRawModifiedDetails(SV *out, UA_ReadRawModifiedDetails *in);
 static void unpack_UA_ReadRawModifiedDetails(UA_ReadRawModifiedDetails *out, SV *in);
 
@@ -13498,73 +13019,73 @@ pack_UA_ReadRawModifiedDetails(SV *out, UA_ReadRawModifiedDetails *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isReadModified);
-	hv_stores(hv, "ReadRawModifiedDetails_isReadModified", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->startTime);
-	hv_stores(hv, "ReadRawModifiedDetails_startTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->endTime);
-	hv_stores(hv, "ReadRawModifiedDetails_endTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->numValuesPerNode);
-	hv_stores(hv, "ReadRawModifiedDetails_numValuesPerNode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->returnBounds);
-	hv_stores(hv, "ReadRawModifiedDetails_returnBounds", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadRawModifiedDetails_isReadModified", sv);
+	pack_UA_Boolean(sv, &in->isReadModified);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadRawModifiedDetails_startTime", sv);
+	pack_UA_DateTime(sv, &in->startTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadRawModifiedDetails_endTime", sv);
+	pack_UA_DateTime(sv, &in->endTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadRawModifiedDetails_numValuesPerNode", sv);
+	pack_UA_UInt32(sv, &in->numValuesPerNode);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadRawModifiedDetails_returnBounds", sv);
+	pack_UA_Boolean(sv, &in->returnBounds);
+
+	return;
 }
 
 static void
 unpack_UA_ReadRawModifiedDetails(UA_ReadRawModifiedDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReadRawModifiedDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReadRawModifiedDetails_isReadModified", 0);
 	if (svp != NULL)
-		out->isReadModified = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isReadModified, *svp);
 
 	svp = hv_fetchs(hv, "ReadRawModifiedDetails_startTime", 0);
 	if (svp != NULL)
-		out->startTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->startTime, *svp);
 
 	svp = hv_fetchs(hv, "ReadRawModifiedDetails_endTime", 0);
 	if (svp != NULL)
-		out->endTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->endTime, *svp);
 
 	svp = hv_fetchs(hv, "ReadRawModifiedDetails_numValuesPerNode", 0);
 	if (svp != NULL)
-		out->numValuesPerNode = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->numValuesPerNode, *svp);
 
 	svp = hv_fetchs(hv, "ReadRawModifiedDetails_returnBounds", 0);
 	if (svp != NULL)
-		out->returnBounds = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->returnBounds, *svp);
 
-
+	return;
 }
 #endif
 
 /* ReadAtTimeDetails */
 #ifdef UA_TYPES_READATTIMEDETAILS
-static void XS_pack_UA_ReadAtTimeDetails(SV *out, UA_ReadAtTimeDetails in)  __attribute__((unused));
-static UA_ReadAtTimeDetails XS_unpack_UA_ReadAtTimeDetails(SV *in)  __attribute__((unused));
 static void pack_UA_ReadAtTimeDetails(SV *out, UA_ReadAtTimeDetails *in);
 static void unpack_UA_ReadAtTimeDetails(UA_ReadAtTimeDetails *out, SV *in);
 
@@ -13575,72 +13096,69 @@ pack_UA_ReadAtTimeDetails(SV *out, UA_ReadAtTimeDetails *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "ReadAtTimeDetails_reqTimes", newRV_noinc((SV*)av));
 	av_extend(av, in->reqTimesSize);
 	for (i = 0; i < in->reqTimesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DateTime(sv, in->reqTimes[i]);
 		av_push(av, sv);
+		pack_UA_DateTime(sv, &in->reqTimes[i]);
 	}
-	hv_stores(hv, "ReadAtTimeDetails_reqTimes", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->useSimpleBounds);
 	hv_stores(hv, "ReadAtTimeDetails_useSimpleBounds", sv);
+	pack_UA_Boolean(sv, &in->useSimpleBounds);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ReadAtTimeDetails(UA_ReadAtTimeDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReadAtTimeDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReadAtTimeDetails_reqTimes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ReadAtTimeDetails_reqTimes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->reqTimes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATETIME]);
-		if (out->reqTimes == NULL) {
+		if (out->reqTimes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->reqTimesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->reqTimes[i] = XS_unpack_UA_DateTime(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DateTime(&out->reqTimes[i], *svp);
 		}
-		out->reqTimesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ReadAtTimeDetails_useSimpleBounds", 0);
 	if (svp != NULL)
-		out->useSimpleBounds = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->useSimpleBounds, *svp);
 
-
+	return;
 }
 #endif
 
 /* ReadAnnotationDataDetails */
 #ifdef UA_TYPES_READANNOTATIONDATADETAILS
-static void XS_pack_UA_ReadAnnotationDataDetails(SV *out, UA_ReadAnnotationDataDetails in)  __attribute__((unused));
-static UA_ReadAnnotationDataDetails XS_unpack_UA_ReadAnnotationDataDetails(SV *in)  __attribute__((unused));
 static void pack_UA_ReadAnnotationDataDetails(SV *out, UA_ReadAnnotationDataDetails *in);
 static void unpack_UA_ReadAnnotationDataDetails(UA_ReadAnnotationDataDetails *out, SV *in);
 
@@ -13651,64 +13169,61 @@ pack_UA_ReadAnnotationDataDetails(SV *out, UA_ReadAnnotationDataDetails *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "ReadAnnotationDataDetails_reqTimes", newRV_noinc((SV*)av));
 	av_extend(av, in->reqTimesSize);
 	for (i = 0; i < in->reqTimesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DateTime(sv, in->reqTimes[i]);
 		av_push(av, sv);
+		pack_UA_DateTime(sv, &in->reqTimes[i]);
 	}
-	hv_stores(hv, "ReadAnnotationDataDetails_reqTimes", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ReadAnnotationDataDetails(UA_ReadAnnotationDataDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReadAnnotationDataDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReadAnnotationDataDetails_reqTimes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ReadAnnotationDataDetails_reqTimes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->reqTimes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATETIME]);
-		if (out->reqTimes == NULL) {
+		if (out->reqTimes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->reqTimesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->reqTimes[i] = XS_unpack_UA_DateTime(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DateTime(&out->reqTimes[i], *svp);
 		}
-		out->reqTimesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryData */
 #ifdef UA_TYPES_HISTORYDATA
-static void XS_pack_UA_HistoryData(SV *out, UA_HistoryData in)  __attribute__((unused));
-static UA_HistoryData XS_unpack_UA_HistoryData(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryData(SV *out, UA_HistoryData *in);
 static void unpack_UA_HistoryData(UA_HistoryData *out, SV *in);
 
@@ -13719,64 +13234,61 @@ pack_UA_HistoryData(SV *out, UA_HistoryData *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "HistoryData_dataValues", newRV_noinc((SV*)av));
 	av_extend(av, in->dataValuesSize);
 	for (i = 0; i < in->dataValuesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DataValue(sv, in->dataValues[i]);
 		av_push(av, sv);
+		pack_UA_DataValue(sv, &in->dataValues[i]);
 	}
-	hv_stores(hv, "HistoryData_dataValues", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryData(UA_HistoryData *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryData_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryData_dataValues", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryData_dataValues");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataValues = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATAVALUE]);
-		if (out->dataValues == NULL) {
+		if (out->dataValues == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataValuesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataValues[i] = XS_unpack_UA_DataValue(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DataValue(&out->dataValues[i], *svp);
 		}
-		out->dataValuesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryReadRequest */
 #ifdef UA_TYPES_HISTORYREADREQUEST
-static void XS_pack_UA_HistoryReadRequest(SV *out, UA_HistoryReadRequest in)  __attribute__((unused));
-static UA_HistoryReadRequest XS_unpack_UA_HistoryReadRequest(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryReadRequest(SV *out, UA_HistoryReadRequest *in);
 static void unpack_UA_HistoryReadRequest(UA_HistoryReadRequest *out, SV *in);
 
@@ -13787,96 +13299,93 @@ pack_UA_HistoryReadRequest(SV *out, UA_HistoryReadRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "HistoryReadRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->historyReadDetails);
 	hv_stores(hv, "HistoryReadRequest_historyReadDetails", sv);
+	pack_UA_ExtensionObject(sv, &in->historyReadDetails);
 
 	sv = newSV(0);
-	XS_pack_UA_TimestampsToReturn(sv, in->timestampsToReturn);
 	hv_stores(hv, "HistoryReadRequest_timestampsToReturn", sv);
+	pack_UA_TimestampsToReturn(sv, &in->timestampsToReturn);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->releaseContinuationPoints);
 	hv_stores(hv, "HistoryReadRequest_releaseContinuationPoints", sv);
+	pack_UA_Boolean(sv, &in->releaseContinuationPoints);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "HistoryReadRequest_nodesToRead", newRV_noinc((SV*)av));
 	av_extend(av, in->nodesToReadSize);
 	for (i = 0; i < in->nodesToReadSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_HistoryReadValueId(sv, in->nodesToRead[i]);
 		av_push(av, sv);
+		pack_UA_HistoryReadValueId(sv, &in->nodesToRead[i]);
 	}
-	hv_stores(hv, "HistoryReadRequest_nodesToRead", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryReadRequest(UA_HistoryReadRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryReadRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryReadRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadRequest_historyReadDetails", 0);
 	if (svp != NULL)
-		out->historyReadDetails = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->historyReadDetails, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadRequest_timestampsToReturn", 0);
 	if (svp != NULL)
-		out->timestampsToReturn = XS_unpack_UA_TimestampsToReturn(*svp);
+		unpack_UA_TimestampsToReturn(&out->timestampsToReturn, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadRequest_releaseContinuationPoints", 0);
 	if (svp != NULL)
-		out->releaseContinuationPoints = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->releaseContinuationPoints, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadRequest_nodesToRead", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryReadRequest_nodesToRead");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->nodesToRead = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_HISTORYREADVALUEID]);
-		if (out->nodesToRead == NULL) {
+		if (out->nodesToRead == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->nodesToReadSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->nodesToRead[i] = XS_unpack_UA_HistoryReadValueId(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_HistoryReadValueId(&out->nodesToRead[i], *svp);
 		}
-		out->nodesToReadSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryReadResponse */
 #ifdef UA_TYPES_HISTORYREADRESPONSE
-static void XS_pack_UA_HistoryReadResponse(SV *out, UA_HistoryReadResponse in)  __attribute__((unused));
-static UA_HistoryReadResponse XS_unpack_UA_HistoryReadResponse(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryReadResponse(SV *out, UA_HistoryReadResponse *in);
 static void unpack_UA_HistoryReadResponse(UA_HistoryReadResponse *out, SV *in);
 
@@ -13887,101 +13396,95 @@ pack_UA_HistoryReadResponse(SV *out, UA_HistoryReadResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "HistoryReadResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "HistoryReadResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_HistoryReadResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_HistoryReadResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "HistoryReadResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "HistoryReadResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "HistoryReadResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryReadResponse(UA_HistoryReadResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryReadResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryReadResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "HistoryReadResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryReadResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_HISTORYREADRESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_HistoryReadResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_HistoryReadResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "HistoryReadResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryReadResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* WriteValue */
 #ifdef UA_TYPES_WRITEVALUE
-static void XS_pack_UA_WriteValue(SV *out, UA_WriteValue in)  __attribute__((unused));
-static UA_WriteValue XS_unpack_UA_WriteValue(SV *in)  __attribute__((unused));
 static void pack_UA_WriteValue(SV *out, UA_WriteValue *in);
 static void unpack_UA_WriteValue(UA_WriteValue *out, SV *in);
 
@@ -13990,65 +13493,65 @@ pack_UA_WriteValue(SV *out, UA_WriteValue *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
-	hv_stores(hv, "WriteValue_nodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->attributeId);
-	hv_stores(hv, "WriteValue_attributeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->indexRange);
-	hv_stores(hv, "WriteValue_indexRange", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DataValue(sv, in->value);
-	hv_stores(hv, "WriteValue_value", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "WriteValue_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "WriteValue_attributeId", sv);
+	pack_UA_UInt32(sv, &in->attributeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "WriteValue_indexRange", sv);
+	pack_UA_String(sv, &in->indexRange);
+
+	sv = newSV(0);
+	hv_stores(hv, "WriteValue_value", sv);
+	pack_UA_DataValue(sv, &in->value);
+
+	return;
 }
 
 static void
 unpack_UA_WriteValue(UA_WriteValue *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_WriteValue_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "WriteValue_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "WriteValue_attributeId", 0);
 	if (svp != NULL)
-		out->attributeId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->attributeId, *svp);
 
 	svp = hv_fetchs(hv, "WriteValue_indexRange", 0);
 	if (svp != NULL)
-		out->indexRange = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->indexRange, *svp);
 
 	svp = hv_fetchs(hv, "WriteValue_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_DataValue(*svp);
+		unpack_UA_DataValue(&out->value, *svp);
 
-
+	return;
 }
 #endif
 
 /* WriteRequest */
 #ifdef UA_TYPES_WRITEREQUEST
-static void XS_pack_UA_WriteRequest(SV *out, UA_WriteRequest in)  __attribute__((unused));
-static UA_WriteRequest XS_unpack_UA_WriteRequest(SV *in)  __attribute__((unused));
 static void pack_UA_WriteRequest(SV *out, UA_WriteRequest *in);
 static void unpack_UA_WriteRequest(UA_WriteRequest *out, SV *in);
 
@@ -14059,72 +13562,69 @@ pack_UA_WriteRequest(SV *out, UA_WriteRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "WriteRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "WriteRequest_nodesToWrite", newRV_noinc((SV*)av));
 	av_extend(av, in->nodesToWriteSize);
 	for (i = 0; i < in->nodesToWriteSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_WriteValue(sv, in->nodesToWrite[i]);
 		av_push(av, sv);
+		pack_UA_WriteValue(sv, &in->nodesToWrite[i]);
 	}
-	hv_stores(hv, "WriteRequest_nodesToWrite", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_WriteRequest(UA_WriteRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_WriteRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "WriteRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "WriteRequest_nodesToWrite", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for WriteRequest_nodesToWrite");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->nodesToWrite = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_WRITEVALUE]);
-		if (out->nodesToWrite == NULL) {
+		if (out->nodesToWrite == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->nodesToWriteSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->nodesToWrite[i] = XS_unpack_UA_WriteValue(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_WriteValue(&out->nodesToWrite[i], *svp);
 		}
-		out->nodesToWriteSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* WriteResponse */
 #ifdef UA_TYPES_WRITERESPONSE
-static void XS_pack_UA_WriteResponse(SV *out, UA_WriteResponse in)  __attribute__((unused));
-static UA_WriteResponse XS_unpack_UA_WriteResponse(SV *in)  __attribute__((unused));
 static void pack_UA_WriteResponse(SV *out, UA_WriteResponse *in);
 static void unpack_UA_WriteResponse(UA_WriteResponse *out, SV *in);
 
@@ -14135,101 +13635,95 @@ pack_UA_WriteResponse(SV *out, UA_WriteResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "WriteResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "WriteResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "WriteResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "WriteResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "WriteResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_WriteResponse(UA_WriteResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_WriteResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "WriteResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "WriteResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for WriteResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "WriteResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for WriteResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryUpdateDetails */
 #ifdef UA_TYPES_HISTORYUPDATEDETAILS
-static void XS_pack_UA_HistoryUpdateDetails(SV *out, UA_HistoryUpdateDetails in)  __attribute__((unused));
-static UA_HistoryUpdateDetails XS_unpack_UA_HistoryUpdateDetails(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryUpdateDetails(SV *out, UA_HistoryUpdateDetails *in);
 static void unpack_UA_HistoryUpdateDetails(UA_HistoryUpdateDetails *out, SV *in);
 
@@ -14238,41 +13732,41 @@ pack_UA_HistoryUpdateDetails(SV *out, UA_HistoryUpdateDetails *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
 	hv_stores(hv, "HistoryUpdateDetails_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryUpdateDetails(UA_HistoryUpdateDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryUpdateDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryUpdateDetails_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
-
+	return;
 }
 #endif
 
 /* HistoryUpdateType */
 #ifdef UA_TYPES_HISTORYUPDATETYPE
-static void XS_pack_UA_HistoryUpdateType(SV *out, UA_HistoryUpdateType in)  __attribute__((unused));
-static UA_HistoryUpdateType XS_unpack_UA_HistoryUpdateType(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryUpdateType(SV *out, UA_HistoryUpdateType *in);
 static void unpack_UA_HistoryUpdateType(UA_HistoryUpdateType *out, SV *in);
 
@@ -14293,8 +13787,6 @@ unpack_UA_HistoryUpdateType(UA_HistoryUpdateType *out, SV *in)
 
 /* PerformUpdateType */
 #ifdef UA_TYPES_PERFORMUPDATETYPE
-static void XS_pack_UA_PerformUpdateType(SV *out, UA_PerformUpdateType in)  __attribute__((unused));
-static UA_PerformUpdateType XS_unpack_UA_PerformUpdateType(SV *in)  __attribute__((unused));
 static void pack_UA_PerformUpdateType(SV *out, UA_PerformUpdateType *in);
 static void unpack_UA_PerformUpdateType(UA_PerformUpdateType *out, SV *in);
 
@@ -14315,8 +13807,6 @@ unpack_UA_PerformUpdateType(UA_PerformUpdateType *out, SV *in)
 
 /* UpdateDataDetails */
 #ifdef UA_TYPES_UPDATEDATADETAILS
-static void XS_pack_UA_UpdateDataDetails(SV *out, UA_UpdateDataDetails in)  __attribute__((unused));
-static UA_UpdateDataDetails XS_unpack_UA_UpdateDataDetails(SV *in)  __attribute__((unused));
 static void pack_UA_UpdateDataDetails(SV *out, UA_UpdateDataDetails *in);
 static void unpack_UA_UpdateDataDetails(UA_UpdateDataDetails *out, SV *in);
 
@@ -14327,80 +13817,77 @@ pack_UA_UpdateDataDetails(SV *out, UA_UpdateDataDetails *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
 	hv_stores(hv, "UpdateDataDetails_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
 
 	sv = newSV(0);
-	XS_pack_UA_PerformUpdateType(sv, in->performInsertReplace);
 	hv_stores(hv, "UpdateDataDetails_performInsertReplace", sv);
+	pack_UA_PerformUpdateType(sv, &in->performInsertReplace);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "UpdateDataDetails_updateValues", newRV_noinc((SV*)av));
 	av_extend(av, in->updateValuesSize);
 	for (i = 0; i < in->updateValuesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DataValue(sv, in->updateValues[i]);
 		av_push(av, sv);
+		pack_UA_DataValue(sv, &in->updateValues[i]);
 	}
-	hv_stores(hv, "UpdateDataDetails_updateValues", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_UpdateDataDetails(UA_UpdateDataDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UpdateDataDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UpdateDataDetails_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "UpdateDataDetails_performInsertReplace", 0);
 	if (svp != NULL)
-		out->performInsertReplace = XS_unpack_UA_PerformUpdateType(*svp);
+		unpack_UA_PerformUpdateType(&out->performInsertReplace, *svp);
 
 	svp = hv_fetchs(hv, "UpdateDataDetails_updateValues", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UpdateDataDetails_updateValues");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->updateValues = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATAVALUE]);
-		if (out->updateValues == NULL) {
+		if (out->updateValues == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->updateValuesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->updateValues[i] = XS_unpack_UA_DataValue(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DataValue(&out->updateValues[i], *svp);
 		}
-		out->updateValuesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* UpdateStructureDataDetails */
 #ifdef UA_TYPES_UPDATESTRUCTUREDATADETAILS
-static void XS_pack_UA_UpdateStructureDataDetails(SV *out, UA_UpdateStructureDataDetails in)  __attribute__((unused));
-static UA_UpdateStructureDataDetails XS_unpack_UA_UpdateStructureDataDetails(SV *in)  __attribute__((unused));
 static void pack_UA_UpdateStructureDataDetails(SV *out, UA_UpdateStructureDataDetails *in);
 static void unpack_UA_UpdateStructureDataDetails(UA_UpdateStructureDataDetails *out, SV *in);
 
@@ -14411,80 +13898,77 @@ pack_UA_UpdateStructureDataDetails(SV *out, UA_UpdateStructureDataDetails *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
 	hv_stores(hv, "UpdateStructureDataDetails_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
 
 	sv = newSV(0);
-	XS_pack_UA_PerformUpdateType(sv, in->performInsertReplace);
 	hv_stores(hv, "UpdateStructureDataDetails_performInsertReplace", sv);
+	pack_UA_PerformUpdateType(sv, &in->performInsertReplace);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "UpdateStructureDataDetails_updateValues", newRV_noinc((SV*)av));
 	av_extend(av, in->updateValuesSize);
 	for (i = 0; i < in->updateValuesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DataValue(sv, in->updateValues[i]);
 		av_push(av, sv);
+		pack_UA_DataValue(sv, &in->updateValues[i]);
 	}
-	hv_stores(hv, "UpdateStructureDataDetails_updateValues", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_UpdateStructureDataDetails(UA_UpdateStructureDataDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UpdateStructureDataDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UpdateStructureDataDetails_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "UpdateStructureDataDetails_performInsertReplace", 0);
 	if (svp != NULL)
-		out->performInsertReplace = XS_unpack_UA_PerformUpdateType(*svp);
+		unpack_UA_PerformUpdateType(&out->performInsertReplace, *svp);
 
 	svp = hv_fetchs(hv, "UpdateStructureDataDetails_updateValues", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UpdateStructureDataDetails_updateValues");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->updateValues = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATAVALUE]);
-		if (out->updateValues == NULL) {
+		if (out->updateValues == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->updateValuesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->updateValues[i] = XS_unpack_UA_DataValue(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DataValue(&out->updateValues[i], *svp);
 		}
-		out->updateValuesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteRawModifiedDetails */
 #ifdef UA_TYPES_DELETERAWMODIFIEDDETAILS
-static void XS_pack_UA_DeleteRawModifiedDetails(SV *out, UA_DeleteRawModifiedDetails in)  __attribute__((unused));
-static UA_DeleteRawModifiedDetails XS_unpack_UA_DeleteRawModifiedDetails(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteRawModifiedDetails(SV *out, UA_DeleteRawModifiedDetails *in);
 static void unpack_UA_DeleteRawModifiedDetails(UA_DeleteRawModifiedDetails *out, SV *in);
 
@@ -14493,65 +13977,65 @@ pack_UA_DeleteRawModifiedDetails(SV *out, UA_DeleteRawModifiedDetails *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
-	hv_stores(hv, "DeleteRawModifiedDetails_nodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->isDeleteModified);
-	hv_stores(hv, "DeleteRawModifiedDetails_isDeleteModified", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->startTime);
-	hv_stores(hv, "DeleteRawModifiedDetails_startTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->endTime);
-	hv_stores(hv, "DeleteRawModifiedDetails_endTime", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteRawModifiedDetails_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteRawModifiedDetails_isDeleteModified", sv);
+	pack_UA_Boolean(sv, &in->isDeleteModified);
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteRawModifiedDetails_startTime", sv);
+	pack_UA_DateTime(sv, &in->startTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "DeleteRawModifiedDetails_endTime", sv);
+	pack_UA_DateTime(sv, &in->endTime);
+
+	return;
 }
 
 static void
 unpack_UA_DeleteRawModifiedDetails(UA_DeleteRawModifiedDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteRawModifiedDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteRawModifiedDetails_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "DeleteRawModifiedDetails_isDeleteModified", 0);
 	if (svp != NULL)
-		out->isDeleteModified = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->isDeleteModified, *svp);
 
 	svp = hv_fetchs(hv, "DeleteRawModifiedDetails_startTime", 0);
 	if (svp != NULL)
-		out->startTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->startTime, *svp);
 
 	svp = hv_fetchs(hv, "DeleteRawModifiedDetails_endTime", 0);
 	if (svp != NULL)
-		out->endTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->endTime, *svp);
 
-
+	return;
 }
 #endif
 
 /* DeleteAtTimeDetails */
 #ifdef UA_TYPES_DELETEATTIMEDETAILS
-static void XS_pack_UA_DeleteAtTimeDetails(SV *out, UA_DeleteAtTimeDetails in)  __attribute__((unused));
-static UA_DeleteAtTimeDetails XS_unpack_UA_DeleteAtTimeDetails(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteAtTimeDetails(SV *out, UA_DeleteAtTimeDetails *in);
 static void unpack_UA_DeleteAtTimeDetails(UA_DeleteAtTimeDetails *out, SV *in);
 
@@ -14562,72 +14046,69 @@ pack_UA_DeleteAtTimeDetails(SV *out, UA_DeleteAtTimeDetails *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
 	hv_stores(hv, "DeleteAtTimeDetails_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteAtTimeDetails_reqTimes", newRV_noinc((SV*)av));
 	av_extend(av, in->reqTimesSize);
 	for (i = 0; i < in->reqTimesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DateTime(sv, in->reqTimes[i]);
 		av_push(av, sv);
+		pack_UA_DateTime(sv, &in->reqTimes[i]);
 	}
-	hv_stores(hv, "DeleteAtTimeDetails_reqTimes", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteAtTimeDetails(UA_DeleteAtTimeDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteAtTimeDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteAtTimeDetails_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "DeleteAtTimeDetails_reqTimes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteAtTimeDetails_reqTimes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->reqTimes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATETIME]);
-		if (out->reqTimes == NULL) {
+		if (out->reqTimes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->reqTimesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->reqTimes[i] = XS_unpack_UA_DateTime(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DateTime(&out->reqTimes[i], *svp);
 		}
-		out->reqTimesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteEventDetails */
 #ifdef UA_TYPES_DELETEEVENTDETAILS
-static void XS_pack_UA_DeleteEventDetails(SV *out, UA_DeleteEventDetails in)  __attribute__((unused));
-static UA_DeleteEventDetails XS_unpack_UA_DeleteEventDetails(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteEventDetails(SV *out, UA_DeleteEventDetails *in);
 static void unpack_UA_DeleteEventDetails(UA_DeleteEventDetails *out, SV *in);
 
@@ -14638,72 +14119,69 @@ pack_UA_DeleteEventDetails(SV *out, UA_DeleteEventDetails *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
 	hv_stores(hv, "DeleteEventDetails_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteEventDetails_eventIds", newRV_noinc((SV*)av));
 	av_extend(av, in->eventIdsSize);
 	for (i = 0; i < in->eventIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ByteString(sv, in->eventIds[i]);
 		av_push(av, sv);
+		pack_UA_ByteString(sv, &in->eventIds[i]);
 	}
-	hv_stores(hv, "DeleteEventDetails_eventIds", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteEventDetails(UA_DeleteEventDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteEventDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteEventDetails_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "DeleteEventDetails_eventIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteEventDetails_eventIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->eventIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_BYTESTRING]);
-		if (out->eventIds == NULL) {
+		if (out->eventIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->eventIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->eventIds[i] = XS_unpack_UA_ByteString(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ByteString(&out->eventIds[i], *svp);
 		}
-		out->eventIdsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryUpdateResult */
 #ifdef UA_TYPES_HISTORYUPDATERESULT
-static void XS_pack_UA_HistoryUpdateResult(SV *out, UA_HistoryUpdateResult in)  __attribute__((unused));
-static UA_HistoryUpdateResult XS_unpack_UA_HistoryUpdateResult(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryUpdateResult(SV *out, UA_HistoryUpdateResult *in);
 static void unpack_UA_HistoryUpdateResult(UA_HistoryUpdateResult *out, SV *in);
 
@@ -14714,101 +14192,95 @@ pack_UA_HistoryUpdateResult(SV *out, UA_HistoryUpdateResult *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
 	hv_stores(hv, "HistoryUpdateResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "HistoryUpdateResult_operationResults", newRV_noinc((SV*)av));
 	av_extend(av, in->operationResultsSize);
 	for (i = 0; i < in->operationResultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->operationResults[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->operationResults[i]);
 	}
-	hv_stores(hv, "HistoryUpdateResult_operationResults", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "HistoryUpdateResult_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "HistoryUpdateResult_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryUpdateResult(UA_HistoryUpdateResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryUpdateResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryUpdateResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "HistoryUpdateResult_operationResults", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryUpdateResult_operationResults");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->operationResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->operationResults == NULL) {
+		if (out->operationResults == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->operationResultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->operationResults[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->operationResults[i], *svp);
 		}
-		out->operationResultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "HistoryUpdateResult_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryUpdateResult_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryUpdateRequest */
 #ifdef UA_TYPES_HISTORYUPDATEREQUEST
-static void XS_pack_UA_HistoryUpdateRequest(SV *out, UA_HistoryUpdateRequest in)  __attribute__((unused));
-static UA_HistoryUpdateRequest XS_unpack_UA_HistoryUpdateRequest(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryUpdateRequest(SV *out, UA_HistoryUpdateRequest *in);
 static void unpack_UA_HistoryUpdateRequest(UA_HistoryUpdateRequest *out, SV *in);
 
@@ -14819,72 +14291,69 @@ pack_UA_HistoryUpdateRequest(SV *out, UA_HistoryUpdateRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "HistoryUpdateRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "HistoryUpdateRequest_historyUpdateDetails", newRV_noinc((SV*)av));
 	av_extend(av, in->historyUpdateDetailsSize);
 	for (i = 0; i < in->historyUpdateDetailsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ExtensionObject(sv, in->historyUpdateDetails[i]);
 		av_push(av, sv);
+		pack_UA_ExtensionObject(sv, &in->historyUpdateDetails[i]);
 	}
-	hv_stores(hv, "HistoryUpdateRequest_historyUpdateDetails", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryUpdateRequest(UA_HistoryUpdateRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryUpdateRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryUpdateRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "HistoryUpdateRequest_historyUpdateDetails", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryUpdateRequest_historyUpdateDetails");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->historyUpdateDetails = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
-		if (out->historyUpdateDetails == NULL) {
+		if (out->historyUpdateDetails == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->historyUpdateDetailsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->historyUpdateDetails[i] = XS_unpack_UA_ExtensionObject(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ExtensionObject(&out->historyUpdateDetails[i], *svp);
 		}
-		out->historyUpdateDetailsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryUpdateResponse */
 #ifdef UA_TYPES_HISTORYUPDATERESPONSE
-static void XS_pack_UA_HistoryUpdateResponse(SV *out, UA_HistoryUpdateResponse in)  __attribute__((unused));
-static UA_HistoryUpdateResponse XS_unpack_UA_HistoryUpdateResponse(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryUpdateResponse(SV *out, UA_HistoryUpdateResponse *in);
 static void unpack_UA_HistoryUpdateResponse(UA_HistoryUpdateResponse *out, SV *in);
 
@@ -14895,101 +14364,95 @@ pack_UA_HistoryUpdateResponse(SV *out, UA_HistoryUpdateResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "HistoryUpdateResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "HistoryUpdateResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_HistoryUpdateResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_HistoryUpdateResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "HistoryUpdateResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "HistoryUpdateResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "HistoryUpdateResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryUpdateResponse(UA_HistoryUpdateResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryUpdateResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryUpdateResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "HistoryUpdateResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryUpdateResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_HISTORYUPDATERESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_HistoryUpdateResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_HistoryUpdateResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "HistoryUpdateResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryUpdateResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* CallMethodRequest */
 #ifdef UA_TYPES_CALLMETHODREQUEST
-static void XS_pack_UA_CallMethodRequest(SV *out, UA_CallMethodRequest in)  __attribute__((unused));
-static UA_CallMethodRequest XS_unpack_UA_CallMethodRequest(SV *in)  __attribute__((unused));
 static void pack_UA_CallMethodRequest(SV *out, UA_CallMethodRequest *in);
 static void unpack_UA_CallMethodRequest(UA_CallMethodRequest *out, SV *in);
 
@@ -15000,80 +14463,77 @@ pack_UA_CallMethodRequest(SV *out, UA_CallMethodRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->objectId);
 	hv_stores(hv, "CallMethodRequest_objectId", sv);
+	pack_UA_NodeId(sv, &in->objectId);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->methodId);
 	hv_stores(hv, "CallMethodRequest_methodId", sv);
+	pack_UA_NodeId(sv, &in->methodId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CallMethodRequest_inputArguments", newRV_noinc((SV*)av));
 	av_extend(av, in->inputArgumentsSize);
 	for (i = 0; i < in->inputArgumentsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Variant(sv, in->inputArguments[i]);
 		av_push(av, sv);
+		pack_UA_Variant(sv, &in->inputArguments[i]);
 	}
-	hv_stores(hv, "CallMethodRequest_inputArguments", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CallMethodRequest(UA_CallMethodRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CallMethodRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CallMethodRequest_objectId", 0);
 	if (svp != NULL)
-		out->objectId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->objectId, *svp);
 
 	svp = hv_fetchs(hv, "CallMethodRequest_methodId", 0);
 	if (svp != NULL)
-		out->methodId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->methodId, *svp);
 
 	svp = hv_fetchs(hv, "CallMethodRequest_inputArguments", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CallMethodRequest_inputArguments");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->inputArguments = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
-		if (out->inputArguments == NULL) {
+		if (out->inputArguments == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->inputArgumentsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->inputArguments[i] = XS_unpack_UA_Variant(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Variant(&out->inputArguments[i], *svp);
 		}
-		out->inputArgumentsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* CallMethodResult */
 #ifdef UA_TYPES_CALLMETHODRESULT
-static void XS_pack_UA_CallMethodResult(SV *out, UA_CallMethodResult in)  __attribute__((unused));
-static UA_CallMethodResult XS_unpack_UA_CallMethodResult(SV *in)  __attribute__((unused));
 static void pack_UA_CallMethodResult(SV *out, UA_CallMethodResult *in);
 static void unpack_UA_CallMethodResult(UA_CallMethodResult *out, SV *in);
 
@@ -15084,130 +14544,121 @@ pack_UA_CallMethodResult(SV *out, UA_CallMethodResult *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
 	hv_stores(hv, "CallMethodResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CallMethodResult_inputArgumentResults", newRV_noinc((SV*)av));
 	av_extend(av, in->inputArgumentResultsSize);
 	for (i = 0; i < in->inputArgumentResultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->inputArgumentResults[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->inputArgumentResults[i]);
 	}
-	hv_stores(hv, "CallMethodResult_inputArgumentResults", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CallMethodResult_inputArgumentDiagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->inputArgumentDiagnosticInfosSize);
 	for (i = 0; i < in->inputArgumentDiagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->inputArgumentDiagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->inputArgumentDiagnosticInfos[i]);
 	}
-	hv_stores(hv, "CallMethodResult_inputArgumentDiagnosticInfos", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CallMethodResult_outputArguments", newRV_noinc((SV*)av));
 	av_extend(av, in->outputArgumentsSize);
 	for (i = 0; i < in->outputArgumentsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Variant(sv, in->outputArguments[i]);
 		av_push(av, sv);
+		pack_UA_Variant(sv, &in->outputArguments[i]);
 	}
-	hv_stores(hv, "CallMethodResult_outputArguments", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CallMethodResult(UA_CallMethodResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CallMethodResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CallMethodResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "CallMethodResult_inputArgumentResults", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CallMethodResult_inputArgumentResults");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->inputArgumentResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->inputArgumentResults == NULL) {
+		if (out->inputArgumentResults == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->inputArgumentResultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->inputArgumentResults[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->inputArgumentResults[i], *svp);
 		}
-		out->inputArgumentResultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "CallMethodResult_inputArgumentDiagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CallMethodResult_inputArgumentDiagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->inputArgumentDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->inputArgumentDiagnosticInfos == NULL) {
+		if (out->inputArgumentDiagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->inputArgumentDiagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->inputArgumentDiagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->inputArgumentDiagnosticInfos[i], *svp);
 		}
-		out->inputArgumentDiagnosticInfosSize = i;
 	}
 
 	svp = hv_fetchs(hv, "CallMethodResult_outputArguments", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CallMethodResult_outputArguments");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->outputArguments = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
-		if (out->outputArguments == NULL) {
+		if (out->outputArguments == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->outputArgumentsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->outputArguments[i] = XS_unpack_UA_Variant(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Variant(&out->outputArguments[i], *svp);
 		}
-		out->outputArgumentsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* CallRequest */
 #ifdef UA_TYPES_CALLREQUEST
-static void XS_pack_UA_CallRequest(SV *out, UA_CallRequest in)  __attribute__((unused));
-static UA_CallRequest XS_unpack_UA_CallRequest(SV *in)  __attribute__((unused));
 static void pack_UA_CallRequest(SV *out, UA_CallRequest *in);
 static void unpack_UA_CallRequest(UA_CallRequest *out, SV *in);
 
@@ -15218,72 +14669,69 @@ pack_UA_CallRequest(SV *out, UA_CallRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "CallRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CallRequest_methodsToCall", newRV_noinc((SV*)av));
 	av_extend(av, in->methodsToCallSize);
 	for (i = 0; i < in->methodsToCallSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_CallMethodRequest(sv, in->methodsToCall[i]);
 		av_push(av, sv);
+		pack_UA_CallMethodRequest(sv, &in->methodsToCall[i]);
 	}
-	hv_stores(hv, "CallRequest_methodsToCall", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CallRequest(UA_CallRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CallRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CallRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "CallRequest_methodsToCall", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CallRequest_methodsToCall");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->methodsToCall = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_CALLMETHODREQUEST]);
-		if (out->methodsToCall == NULL) {
+		if (out->methodsToCall == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->methodsToCallSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->methodsToCall[i] = XS_unpack_UA_CallMethodRequest(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_CallMethodRequest(&out->methodsToCall[i], *svp);
 		}
-		out->methodsToCallSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* CallResponse */
 #ifdef UA_TYPES_CALLRESPONSE
-static void XS_pack_UA_CallResponse(SV *out, UA_CallResponse in)  __attribute__((unused));
-static UA_CallResponse XS_unpack_UA_CallResponse(SV *in)  __attribute__((unused));
 static void pack_UA_CallResponse(SV *out, UA_CallResponse *in);
 static void unpack_UA_CallResponse(UA_CallResponse *out, SV *in);
 
@@ -15294,101 +14742,95 @@ pack_UA_CallResponse(SV *out, UA_CallResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "CallResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CallResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_CallMethodResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_CallMethodResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "CallResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CallResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "CallResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CallResponse(UA_CallResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CallResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CallResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "CallResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CallResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_CALLMETHODRESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_CallMethodResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_CallMethodResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "CallResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CallResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* MonitoringMode */
 #ifdef UA_TYPES_MONITORINGMODE
-static void XS_pack_UA_MonitoringMode(SV *out, UA_MonitoringMode in)  __attribute__((unused));
-static UA_MonitoringMode XS_unpack_UA_MonitoringMode(SV *in)  __attribute__((unused));
 static void pack_UA_MonitoringMode(SV *out, UA_MonitoringMode *in);
 static void unpack_UA_MonitoringMode(UA_MonitoringMode *out, SV *in);
 
@@ -15409,8 +14851,6 @@ unpack_UA_MonitoringMode(UA_MonitoringMode *out, SV *in)
 
 /* DataChangeTrigger */
 #ifdef UA_TYPES_DATACHANGETRIGGER
-static void XS_pack_UA_DataChangeTrigger(SV *out, UA_DataChangeTrigger in)  __attribute__((unused));
-static UA_DataChangeTrigger XS_unpack_UA_DataChangeTrigger(SV *in)  __attribute__((unused));
 static void pack_UA_DataChangeTrigger(SV *out, UA_DataChangeTrigger *in);
 static void unpack_UA_DataChangeTrigger(UA_DataChangeTrigger *out, SV *in);
 
@@ -15431,8 +14871,6 @@ unpack_UA_DataChangeTrigger(UA_DataChangeTrigger *out, SV *in)
 
 /* DeadbandType */
 #ifdef UA_TYPES_DEADBANDTYPE
-static void XS_pack_UA_DeadbandType(SV *out, UA_DeadbandType in)  __attribute__((unused));
-static UA_DeadbandType XS_unpack_UA_DeadbandType(SV *in)  __attribute__((unused));
 static void pack_UA_DeadbandType(SV *out, UA_DeadbandType *in);
 static void unpack_UA_DeadbandType(UA_DeadbandType *out, SV *in);
 
@@ -15453,8 +14891,6 @@ unpack_UA_DeadbandType(UA_DeadbandType *out, SV *in)
 
 /* MonitoringFilter */
 #ifdef UA_TYPES_MONITORINGFILTER
-static void XS_pack_UA_MonitoringFilter(SV *out, UA_MonitoringFilter in)  __attribute__((unused));
-static UA_MonitoringFilter XS_unpack_UA_MonitoringFilter(SV *in)  __attribute__((unused));
 static void pack_UA_MonitoringFilter(SV *out, UA_MonitoringFilter *in);
 static void unpack_UA_MonitoringFilter(UA_MonitoringFilter *out, SV *in);
 
@@ -15475,8 +14911,6 @@ unpack_UA_MonitoringFilter(UA_MonitoringFilter *out, SV *in)
 
 /* DataChangeFilter */
 #ifdef UA_TYPES_DATACHANGEFILTER
-static void XS_pack_UA_DataChangeFilter(SV *out, UA_DataChangeFilter in)  __attribute__((unused));
-static UA_DataChangeFilter XS_unpack_UA_DataChangeFilter(SV *in)  __attribute__((unused));
 static void pack_UA_DataChangeFilter(SV *out, UA_DataChangeFilter *in);
 static void unpack_UA_DataChangeFilter(UA_DataChangeFilter *out, SV *in);
 
@@ -15485,57 +14919,57 @@ pack_UA_DataChangeFilter(SV *out, UA_DataChangeFilter *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_DataChangeTrigger(sv, in->trigger);
-	hv_stores(hv, "DataChangeFilter_trigger", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->deadbandType);
-	hv_stores(hv, "DataChangeFilter_deadbandType", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->deadbandValue);
-	hv_stores(hv, "DataChangeFilter_deadbandValue", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "DataChangeFilter_trigger", sv);
+	pack_UA_DataChangeTrigger(sv, &in->trigger);
+
+	sv = newSV(0);
+	hv_stores(hv, "DataChangeFilter_deadbandType", sv);
+	pack_UA_UInt32(sv, &in->deadbandType);
+
+	sv = newSV(0);
+	hv_stores(hv, "DataChangeFilter_deadbandValue", sv);
+	pack_UA_Double(sv, &in->deadbandValue);
+
+	return;
 }
 
 static void
 unpack_UA_DataChangeFilter(UA_DataChangeFilter *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DataChangeFilter_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DataChangeFilter_trigger", 0);
 	if (svp != NULL)
-		out->trigger = XS_unpack_UA_DataChangeTrigger(*svp);
+		unpack_UA_DataChangeTrigger(&out->trigger, *svp);
 
 	svp = hv_fetchs(hv, "DataChangeFilter_deadbandType", 0);
 	if (svp != NULL)
-		out->deadbandType = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->deadbandType, *svp);
 
 	svp = hv_fetchs(hv, "DataChangeFilter_deadbandValue", 0);
 	if (svp != NULL)
-		out->deadbandValue = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->deadbandValue, *svp);
 
-
+	return;
 }
 #endif
 
 /* EventFilter */
 #ifdef UA_TYPES_EVENTFILTER
-static void XS_pack_UA_EventFilter(SV *out, UA_EventFilter in)  __attribute__((unused));
-static UA_EventFilter XS_unpack_UA_EventFilter(SV *in)  __attribute__((unused));
 static void pack_UA_EventFilter(SV *out, UA_EventFilter *in);
 static void unpack_UA_EventFilter(UA_EventFilter *out, SV *in);
 
@@ -15546,72 +14980,69 @@ pack_UA_EventFilter(SV *out, UA_EventFilter *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "EventFilter_selectClauses", newRV_noinc((SV*)av));
 	av_extend(av, in->selectClausesSize);
 	for (i = 0; i < in->selectClausesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_SimpleAttributeOperand(sv, in->selectClauses[i]);
 		av_push(av, sv);
+		pack_UA_SimpleAttributeOperand(sv, &in->selectClauses[i]);
 	}
-	hv_stores(hv, "EventFilter_selectClauses", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ContentFilter(sv, in->whereClause);
 	hv_stores(hv, "EventFilter_whereClause", sv);
+	pack_UA_ContentFilter(sv, &in->whereClause);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_EventFilter(UA_EventFilter *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EventFilter_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EventFilter_selectClauses", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for EventFilter_selectClauses");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->selectClauses = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIMPLEATTRIBUTEOPERAND]);
-		if (out->selectClauses == NULL) {
+		if (out->selectClauses == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->selectClausesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->selectClauses[i] = XS_unpack_UA_SimpleAttributeOperand(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_SimpleAttributeOperand(&out->selectClauses[i], *svp);
 		}
-		out->selectClausesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "EventFilter_whereClause", 0);
 	if (svp != NULL)
-		out->whereClause = XS_unpack_UA_ContentFilter(*svp);
+		unpack_UA_ContentFilter(&out->whereClause, *svp);
 
-
+	return;
 }
 #endif
 
 /* AggregateConfiguration */
 #ifdef UA_TYPES_AGGREGATECONFIGURATION
-static void XS_pack_UA_AggregateConfiguration(SV *out, UA_AggregateConfiguration in)  __attribute__((unused));
-static UA_AggregateConfiguration XS_unpack_UA_AggregateConfiguration(SV *in)  __attribute__((unused));
 static void pack_UA_AggregateConfiguration(SV *out, UA_AggregateConfiguration *in);
 static void unpack_UA_AggregateConfiguration(UA_AggregateConfiguration *out, SV *in);
 
@@ -15620,73 +15051,73 @@ pack_UA_AggregateConfiguration(SV *out, UA_AggregateConfiguration *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->useServerCapabilitiesDefaults);
-	hv_stores(hv, "AggregateConfiguration_useServerCapabilitiesDefaults", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->treatUncertainAsBad);
-	hv_stores(hv, "AggregateConfiguration_treatUncertainAsBad", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->percentDataBad);
-	hv_stores(hv, "AggregateConfiguration_percentDataBad", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->percentDataGood);
-	hv_stores(hv, "AggregateConfiguration_percentDataGood", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->useSlopedExtrapolation);
-	hv_stores(hv, "AggregateConfiguration_useSlopedExtrapolation", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateConfiguration_useServerCapabilitiesDefaults", sv);
+	pack_UA_Boolean(sv, &in->useServerCapabilitiesDefaults);
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateConfiguration_treatUncertainAsBad", sv);
+	pack_UA_Boolean(sv, &in->treatUncertainAsBad);
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateConfiguration_percentDataBad", sv);
+	pack_UA_Byte(sv, &in->percentDataBad);
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateConfiguration_percentDataGood", sv);
+	pack_UA_Byte(sv, &in->percentDataGood);
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateConfiguration_useSlopedExtrapolation", sv);
+	pack_UA_Boolean(sv, &in->useSlopedExtrapolation);
+
+	return;
 }
 
 static void
 unpack_UA_AggregateConfiguration(UA_AggregateConfiguration *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AggregateConfiguration_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AggregateConfiguration_useServerCapabilitiesDefaults", 0);
 	if (svp != NULL)
-		out->useServerCapabilitiesDefaults = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->useServerCapabilitiesDefaults, *svp);
 
 	svp = hv_fetchs(hv, "AggregateConfiguration_treatUncertainAsBad", 0);
 	if (svp != NULL)
-		out->treatUncertainAsBad = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->treatUncertainAsBad, *svp);
 
 	svp = hv_fetchs(hv, "AggregateConfiguration_percentDataBad", 0);
 	if (svp != NULL)
-		out->percentDataBad = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->percentDataBad, *svp);
 
 	svp = hv_fetchs(hv, "AggregateConfiguration_percentDataGood", 0);
 	if (svp != NULL)
-		out->percentDataGood = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->percentDataGood, *svp);
 
 	svp = hv_fetchs(hv, "AggregateConfiguration_useSlopedExtrapolation", 0);
 	if (svp != NULL)
-		out->useSlopedExtrapolation = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->useSlopedExtrapolation, *svp);
 
-
+	return;
 }
 #endif
 
 /* AggregateFilter */
 #ifdef UA_TYPES_AGGREGATEFILTER
-static void XS_pack_UA_AggregateFilter(SV *out, UA_AggregateFilter in)  __attribute__((unused));
-static UA_AggregateFilter XS_unpack_UA_AggregateFilter(SV *in)  __attribute__((unused));
 static void pack_UA_AggregateFilter(SV *out, UA_AggregateFilter *in);
 static void unpack_UA_AggregateFilter(UA_AggregateFilter *out, SV *in);
 
@@ -15695,65 +15126,65 @@ pack_UA_AggregateFilter(SV *out, UA_AggregateFilter *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->startTime);
-	hv_stores(hv, "AggregateFilter_startTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->aggregateType);
-	hv_stores(hv, "AggregateFilter_aggregateType", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->processingInterval);
-	hv_stores(hv, "AggregateFilter_processingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_AggregateConfiguration(sv, in->aggregateConfiguration);
-	hv_stores(hv, "AggregateFilter_aggregateConfiguration", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateFilter_startTime", sv);
+	pack_UA_DateTime(sv, &in->startTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateFilter_aggregateType", sv);
+	pack_UA_NodeId(sv, &in->aggregateType);
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateFilter_processingInterval", sv);
+	pack_UA_Double(sv, &in->processingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateFilter_aggregateConfiguration", sv);
+	pack_UA_AggregateConfiguration(sv, &in->aggregateConfiguration);
+
+	return;
 }
 
 static void
 unpack_UA_AggregateFilter(UA_AggregateFilter *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AggregateFilter_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AggregateFilter_startTime", 0);
 	if (svp != NULL)
-		out->startTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->startTime, *svp);
 
 	svp = hv_fetchs(hv, "AggregateFilter_aggregateType", 0);
 	if (svp != NULL)
-		out->aggregateType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->aggregateType, *svp);
 
 	svp = hv_fetchs(hv, "AggregateFilter_processingInterval", 0);
 	if (svp != NULL)
-		out->processingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->processingInterval, *svp);
 
 	svp = hv_fetchs(hv, "AggregateFilter_aggregateConfiguration", 0);
 	if (svp != NULL)
-		out->aggregateConfiguration = XS_unpack_UA_AggregateConfiguration(*svp);
+		unpack_UA_AggregateConfiguration(&out->aggregateConfiguration, *svp);
 
-
+	return;
 }
 #endif
 
 /* MonitoringFilterResult */
 #ifdef UA_TYPES_MONITORINGFILTERRESULT
-static void XS_pack_UA_MonitoringFilterResult(SV *out, UA_MonitoringFilterResult in)  __attribute__((unused));
-static UA_MonitoringFilterResult XS_unpack_UA_MonitoringFilterResult(SV *in)  __attribute__((unused));
 static void pack_UA_MonitoringFilterResult(SV *out, UA_MonitoringFilterResult *in);
 static void unpack_UA_MonitoringFilterResult(UA_MonitoringFilterResult *out, SV *in);
 
@@ -15774,8 +15205,6 @@ unpack_UA_MonitoringFilterResult(UA_MonitoringFilterResult *out, SV *in)
 
 /* EventFilterResult */
 #ifdef UA_TYPES_EVENTFILTERRESULT
-static void XS_pack_UA_EventFilterResult(SV *out, UA_EventFilterResult in)  __attribute__((unused));
-static UA_EventFilterResult XS_unpack_UA_EventFilterResult(SV *in)  __attribute__((unused));
 static void pack_UA_EventFilterResult(SV *out, UA_EventFilterResult *in);
 static void unpack_UA_EventFilterResult(UA_EventFilterResult *out, SV *in);
 
@@ -15786,101 +15215,95 @@ pack_UA_EventFilterResult(SV *out, UA_EventFilterResult *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "EventFilterResult_selectClauseResults", newRV_noinc((SV*)av));
 	av_extend(av, in->selectClauseResultsSize);
 	for (i = 0; i < in->selectClauseResultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->selectClauseResults[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->selectClauseResults[i]);
 	}
-	hv_stores(hv, "EventFilterResult_selectClauseResults", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "EventFilterResult_selectClauseDiagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->selectClauseDiagnosticInfosSize);
 	for (i = 0; i < in->selectClauseDiagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->selectClauseDiagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->selectClauseDiagnosticInfos[i]);
 	}
-	hv_stores(hv, "EventFilterResult_selectClauseDiagnosticInfos", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ContentFilterResult(sv, in->whereClauseResult);
 	hv_stores(hv, "EventFilterResult_whereClauseResult", sv);
+	pack_UA_ContentFilterResult(sv, &in->whereClauseResult);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_EventFilterResult(UA_EventFilterResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EventFilterResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EventFilterResult_selectClauseResults", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for EventFilterResult_selectClauseResults");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->selectClauseResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->selectClauseResults == NULL) {
+		if (out->selectClauseResults == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->selectClauseResultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->selectClauseResults[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->selectClauseResults[i], *svp);
 		}
-		out->selectClauseResultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "EventFilterResult_selectClauseDiagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for EventFilterResult_selectClauseDiagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->selectClauseDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->selectClauseDiagnosticInfos == NULL) {
+		if (out->selectClauseDiagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->selectClauseDiagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->selectClauseDiagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->selectClauseDiagnosticInfos[i], *svp);
 		}
-		out->selectClauseDiagnosticInfosSize = i;
 	}
 
 	svp = hv_fetchs(hv, "EventFilterResult_whereClauseResult", 0);
 	if (svp != NULL)
-		out->whereClauseResult = XS_unpack_UA_ContentFilterResult(*svp);
+		unpack_UA_ContentFilterResult(&out->whereClauseResult, *svp);
 
-
+	return;
 }
 #endif
 
 /* AggregateFilterResult */
 #ifdef UA_TYPES_AGGREGATEFILTERRESULT
-static void XS_pack_UA_AggregateFilterResult(SV *out, UA_AggregateFilterResult in)  __attribute__((unused));
-static UA_AggregateFilterResult XS_unpack_UA_AggregateFilterResult(SV *in)  __attribute__((unused));
 static void pack_UA_AggregateFilterResult(SV *out, UA_AggregateFilterResult *in);
 static void unpack_UA_AggregateFilterResult(UA_AggregateFilterResult *out, SV *in);
 
@@ -15889,57 +15312,57 @@ pack_UA_AggregateFilterResult(SV *out, UA_AggregateFilterResult *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->revisedStartTime);
-	hv_stores(hv, "AggregateFilterResult_revisedStartTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->revisedProcessingInterval);
-	hv_stores(hv, "AggregateFilterResult_revisedProcessingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_AggregateConfiguration(sv, in->revisedAggregateConfiguration);
-	hv_stores(hv, "AggregateFilterResult_revisedAggregateConfiguration", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateFilterResult_revisedStartTime", sv);
+	pack_UA_DateTime(sv, &in->revisedStartTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateFilterResult_revisedProcessingInterval", sv);
+	pack_UA_Double(sv, &in->revisedProcessingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "AggregateFilterResult_revisedAggregateConfiguration", sv);
+	pack_UA_AggregateConfiguration(sv, &in->revisedAggregateConfiguration);
+
+	return;
 }
 
 static void
 unpack_UA_AggregateFilterResult(UA_AggregateFilterResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AggregateFilterResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AggregateFilterResult_revisedStartTime", 0);
 	if (svp != NULL)
-		out->revisedStartTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->revisedStartTime, *svp);
 
 	svp = hv_fetchs(hv, "AggregateFilterResult_revisedProcessingInterval", 0);
 	if (svp != NULL)
-		out->revisedProcessingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->revisedProcessingInterval, *svp);
 
 	svp = hv_fetchs(hv, "AggregateFilterResult_revisedAggregateConfiguration", 0);
 	if (svp != NULL)
-		out->revisedAggregateConfiguration = XS_unpack_UA_AggregateConfiguration(*svp);
+		unpack_UA_AggregateConfiguration(&out->revisedAggregateConfiguration, *svp);
 
-
+	return;
 }
 #endif
 
 /* MonitoringParameters */
 #ifdef UA_TYPES_MONITORINGPARAMETERS
-static void XS_pack_UA_MonitoringParameters(SV *out, UA_MonitoringParameters in)  __attribute__((unused));
-static UA_MonitoringParameters XS_unpack_UA_MonitoringParameters(SV *in)  __attribute__((unused));
 static void pack_UA_MonitoringParameters(SV *out, UA_MonitoringParameters *in);
 static void unpack_UA_MonitoringParameters(UA_MonitoringParameters *out, SV *in);
 
@@ -15948,73 +15371,73 @@ pack_UA_MonitoringParameters(SV *out, UA_MonitoringParameters *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->clientHandle);
-	hv_stores(hv, "MonitoringParameters_clientHandle", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->samplingInterval);
-	hv_stores(hv, "MonitoringParameters_samplingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->filter);
-	hv_stores(hv, "MonitoringParameters_filter", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->queueSize);
-	hv_stores(hv, "MonitoringParameters_queueSize", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->discardOldest);
-	hv_stores(hv, "MonitoringParameters_discardOldest", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoringParameters_clientHandle", sv);
+	pack_UA_UInt32(sv, &in->clientHandle);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoringParameters_samplingInterval", sv);
+	pack_UA_Double(sv, &in->samplingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoringParameters_filter", sv);
+	pack_UA_ExtensionObject(sv, &in->filter);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoringParameters_queueSize", sv);
+	pack_UA_UInt32(sv, &in->queueSize);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoringParameters_discardOldest", sv);
+	pack_UA_Boolean(sv, &in->discardOldest);
+
+	return;
 }
 
 static void
 unpack_UA_MonitoringParameters(UA_MonitoringParameters *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_MonitoringParameters_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "MonitoringParameters_clientHandle", 0);
 	if (svp != NULL)
-		out->clientHandle = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->clientHandle, *svp);
 
 	svp = hv_fetchs(hv, "MonitoringParameters_samplingInterval", 0);
 	if (svp != NULL)
-		out->samplingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->samplingInterval, *svp);
 
 	svp = hv_fetchs(hv, "MonitoringParameters_filter", 0);
 	if (svp != NULL)
-		out->filter = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->filter, *svp);
 
 	svp = hv_fetchs(hv, "MonitoringParameters_queueSize", 0);
 	if (svp != NULL)
-		out->queueSize = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->queueSize, *svp);
 
 	svp = hv_fetchs(hv, "MonitoringParameters_discardOldest", 0);
 	if (svp != NULL)
-		out->discardOldest = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->discardOldest, *svp);
 
-
+	return;
 }
 #endif
 
 /* MonitoredItemCreateRequest */
 #ifdef UA_TYPES_MONITOREDITEMCREATEREQUEST
-static void XS_pack_UA_MonitoredItemCreateRequest(SV *out, UA_MonitoredItemCreateRequest in)  __attribute__((unused));
-static UA_MonitoredItemCreateRequest XS_unpack_UA_MonitoredItemCreateRequest(SV *in)  __attribute__((unused));
 static void pack_UA_MonitoredItemCreateRequest(SV *out, UA_MonitoredItemCreateRequest *in);
 static void unpack_UA_MonitoredItemCreateRequest(UA_MonitoredItemCreateRequest *out, SV *in);
 
@@ -16023,57 +15446,57 @@ pack_UA_MonitoredItemCreateRequest(SV *out, UA_MonitoredItemCreateRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ReadValueId(sv, in->itemToMonitor);
-	hv_stores(hv, "MonitoredItemCreateRequest_itemToMonitor", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_MonitoringMode(sv, in->monitoringMode);
-	hv_stores(hv, "MonitoredItemCreateRequest_monitoringMode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_MonitoringParameters(sv, in->requestedParameters);
-	hv_stores(hv, "MonitoredItemCreateRequest_requestedParameters", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemCreateRequest_itemToMonitor", sv);
+	pack_UA_ReadValueId(sv, &in->itemToMonitor);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemCreateRequest_monitoringMode", sv);
+	pack_UA_MonitoringMode(sv, &in->monitoringMode);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemCreateRequest_requestedParameters", sv);
+	pack_UA_MonitoringParameters(sv, &in->requestedParameters);
+
+	return;
 }
 
 static void
 unpack_UA_MonitoredItemCreateRequest(UA_MonitoredItemCreateRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_MonitoredItemCreateRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "MonitoredItemCreateRequest_itemToMonitor", 0);
 	if (svp != NULL)
-		out->itemToMonitor = XS_unpack_UA_ReadValueId(*svp);
+		unpack_UA_ReadValueId(&out->itemToMonitor, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemCreateRequest_monitoringMode", 0);
 	if (svp != NULL)
-		out->monitoringMode = XS_unpack_UA_MonitoringMode(*svp);
+		unpack_UA_MonitoringMode(&out->monitoringMode, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemCreateRequest_requestedParameters", 0);
 	if (svp != NULL)
-		out->requestedParameters = XS_unpack_UA_MonitoringParameters(*svp);
+		unpack_UA_MonitoringParameters(&out->requestedParameters, *svp);
 
-
+	return;
 }
 #endif
 
 /* MonitoredItemCreateResult */
 #ifdef UA_TYPES_MONITOREDITEMCREATERESULT
-static void XS_pack_UA_MonitoredItemCreateResult(SV *out, UA_MonitoredItemCreateResult in)  __attribute__((unused));
-static UA_MonitoredItemCreateResult XS_unpack_UA_MonitoredItemCreateResult(SV *in)  __attribute__((unused));
 static void pack_UA_MonitoredItemCreateResult(SV *out, UA_MonitoredItemCreateResult *in);
 static void unpack_UA_MonitoredItemCreateResult(UA_MonitoredItemCreateResult *out, SV *in);
 
@@ -16082,73 +15505,73 @@ pack_UA_MonitoredItemCreateResult(SV *out, UA_MonitoredItemCreateResult *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
-	hv_stores(hv, "MonitoredItemCreateResult_statusCode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->monitoredItemId);
-	hv_stores(hv, "MonitoredItemCreateResult_monitoredItemId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->revisedSamplingInterval);
-	hv_stores(hv, "MonitoredItemCreateResult_revisedSamplingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->revisedQueueSize);
-	hv_stores(hv, "MonitoredItemCreateResult_revisedQueueSize", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->filterResult);
-	hv_stores(hv, "MonitoredItemCreateResult_filterResult", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemCreateResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemCreateResult_monitoredItemId", sv);
+	pack_UA_UInt32(sv, &in->monitoredItemId);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemCreateResult_revisedSamplingInterval", sv);
+	pack_UA_Double(sv, &in->revisedSamplingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemCreateResult_revisedQueueSize", sv);
+	pack_UA_UInt32(sv, &in->revisedQueueSize);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemCreateResult_filterResult", sv);
+	pack_UA_ExtensionObject(sv, &in->filterResult);
+
+	return;
 }
 
 static void
 unpack_UA_MonitoredItemCreateResult(UA_MonitoredItemCreateResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_MonitoredItemCreateResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "MonitoredItemCreateResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemCreateResult_monitoredItemId", 0);
 	if (svp != NULL)
-		out->monitoredItemId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->monitoredItemId, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemCreateResult_revisedSamplingInterval", 0);
 	if (svp != NULL)
-		out->revisedSamplingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->revisedSamplingInterval, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemCreateResult_revisedQueueSize", 0);
 	if (svp != NULL)
-		out->revisedQueueSize = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->revisedQueueSize, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemCreateResult_filterResult", 0);
 	if (svp != NULL)
-		out->filterResult = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->filterResult, *svp);
 
-
+	return;
 }
 #endif
 
 /* CreateMonitoredItemsRequest */
 #ifdef UA_TYPES_CREATEMONITOREDITEMSREQUEST
-static void XS_pack_UA_CreateMonitoredItemsRequest(SV *out, UA_CreateMonitoredItemsRequest in)  __attribute__((unused));
-static UA_CreateMonitoredItemsRequest XS_unpack_UA_CreateMonitoredItemsRequest(SV *in)  __attribute__((unused));
 static void pack_UA_CreateMonitoredItemsRequest(SV *out, UA_CreateMonitoredItemsRequest *in);
 static void unpack_UA_CreateMonitoredItemsRequest(UA_CreateMonitoredItemsRequest *out, SV *in);
 
@@ -16159,88 +15582,85 @@ pack_UA_CreateMonitoredItemsRequest(SV *out, UA_CreateMonitoredItemsRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "CreateMonitoredItemsRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
 	hv_stores(hv, "CreateMonitoredItemsRequest_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
 
 	sv = newSV(0);
-	XS_pack_UA_TimestampsToReturn(sv, in->timestampsToReturn);
 	hv_stores(hv, "CreateMonitoredItemsRequest_timestampsToReturn", sv);
+	pack_UA_TimestampsToReturn(sv, &in->timestampsToReturn);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CreateMonitoredItemsRequest_itemsToCreate", newRV_noinc((SV*)av));
 	av_extend(av, in->itemsToCreateSize);
 	for (i = 0; i < in->itemsToCreateSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_MonitoredItemCreateRequest(sv, in->itemsToCreate[i]);
 		av_push(av, sv);
+		pack_UA_MonitoredItemCreateRequest(sv, &in->itemsToCreate[i]);
 	}
-	hv_stores(hv, "CreateMonitoredItemsRequest_itemsToCreate", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CreateMonitoredItemsRequest(UA_CreateMonitoredItemsRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CreateMonitoredItemsRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CreateMonitoredItemsRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "CreateMonitoredItemsRequest_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "CreateMonitoredItemsRequest_timestampsToReturn", 0);
 	if (svp != NULL)
-		out->timestampsToReturn = XS_unpack_UA_TimestampsToReturn(*svp);
+		unpack_UA_TimestampsToReturn(&out->timestampsToReturn, *svp);
 
 	svp = hv_fetchs(hv, "CreateMonitoredItemsRequest_itemsToCreate", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CreateMonitoredItemsRequest_itemsToCreate");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->itemsToCreate = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMCREATEREQUEST]);
-		if (out->itemsToCreate == NULL) {
+		if (out->itemsToCreate == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->itemsToCreateSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->itemsToCreate[i] = XS_unpack_UA_MonitoredItemCreateRequest(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_MonitoredItemCreateRequest(&out->itemsToCreate[i], *svp);
 		}
-		out->itemsToCreateSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* CreateMonitoredItemsResponse */
 #ifdef UA_TYPES_CREATEMONITOREDITEMSRESPONSE
-static void XS_pack_UA_CreateMonitoredItemsResponse(SV *out, UA_CreateMonitoredItemsResponse in)  __attribute__((unused));
-static UA_CreateMonitoredItemsResponse XS_unpack_UA_CreateMonitoredItemsResponse(SV *in)  __attribute__((unused));
 static void pack_UA_CreateMonitoredItemsResponse(SV *out, UA_CreateMonitoredItemsResponse *in);
 static void unpack_UA_CreateMonitoredItemsResponse(UA_CreateMonitoredItemsResponse *out, SV *in);
 
@@ -16251,101 +15671,95 @@ pack_UA_CreateMonitoredItemsResponse(SV *out, UA_CreateMonitoredItemsResponse *i
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "CreateMonitoredItemsResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CreateMonitoredItemsResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_MonitoredItemCreateResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_MonitoredItemCreateResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "CreateMonitoredItemsResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "CreateMonitoredItemsResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "CreateMonitoredItemsResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_CreateMonitoredItemsResponse(UA_CreateMonitoredItemsResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CreateMonitoredItemsResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CreateMonitoredItemsResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "CreateMonitoredItemsResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CreateMonitoredItemsResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMCREATERESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_MonitoredItemCreateResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_MonitoredItemCreateResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "CreateMonitoredItemsResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for CreateMonitoredItemsResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* MonitoredItemModifyRequest */
 #ifdef UA_TYPES_MONITOREDITEMMODIFYREQUEST
-static void XS_pack_UA_MonitoredItemModifyRequest(SV *out, UA_MonitoredItemModifyRequest in)  __attribute__((unused));
-static UA_MonitoredItemModifyRequest XS_unpack_UA_MonitoredItemModifyRequest(SV *in)  __attribute__((unused));
 static void pack_UA_MonitoredItemModifyRequest(SV *out, UA_MonitoredItemModifyRequest *in);
 static void unpack_UA_MonitoredItemModifyRequest(UA_MonitoredItemModifyRequest *out, SV *in);
 
@@ -16354,49 +15768,49 @@ pack_UA_MonitoredItemModifyRequest(SV *out, UA_MonitoredItemModifyRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->monitoredItemId);
-	hv_stores(hv, "MonitoredItemModifyRequest_monitoredItemId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_MonitoringParameters(sv, in->requestedParameters);
-	hv_stores(hv, "MonitoredItemModifyRequest_requestedParameters", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemModifyRequest_monitoredItemId", sv);
+	pack_UA_UInt32(sv, &in->monitoredItemId);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemModifyRequest_requestedParameters", sv);
+	pack_UA_MonitoringParameters(sv, &in->requestedParameters);
+
+	return;
 }
 
 static void
 unpack_UA_MonitoredItemModifyRequest(UA_MonitoredItemModifyRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_MonitoredItemModifyRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "MonitoredItemModifyRequest_monitoredItemId", 0);
 	if (svp != NULL)
-		out->monitoredItemId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->monitoredItemId, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemModifyRequest_requestedParameters", 0);
 	if (svp != NULL)
-		out->requestedParameters = XS_unpack_UA_MonitoringParameters(*svp);
+		unpack_UA_MonitoringParameters(&out->requestedParameters, *svp);
 
-
+	return;
 }
 #endif
 
 /* MonitoredItemModifyResult */
 #ifdef UA_TYPES_MONITOREDITEMMODIFYRESULT
-static void XS_pack_UA_MonitoredItemModifyResult(SV *out, UA_MonitoredItemModifyResult in)  __attribute__((unused));
-static UA_MonitoredItemModifyResult XS_unpack_UA_MonitoredItemModifyResult(SV *in)  __attribute__((unused));
 static void pack_UA_MonitoredItemModifyResult(SV *out, UA_MonitoredItemModifyResult *in);
 static void unpack_UA_MonitoredItemModifyResult(UA_MonitoredItemModifyResult *out, SV *in);
 
@@ -16405,65 +15819,65 @@ pack_UA_MonitoredItemModifyResult(SV *out, UA_MonitoredItemModifyResult *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
-	hv_stores(hv, "MonitoredItemModifyResult_statusCode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->revisedSamplingInterval);
-	hv_stores(hv, "MonitoredItemModifyResult_revisedSamplingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->revisedQueueSize);
-	hv_stores(hv, "MonitoredItemModifyResult_revisedQueueSize", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->filterResult);
-	hv_stores(hv, "MonitoredItemModifyResult_filterResult", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemModifyResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemModifyResult_revisedSamplingInterval", sv);
+	pack_UA_Double(sv, &in->revisedSamplingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemModifyResult_revisedQueueSize", sv);
+	pack_UA_UInt32(sv, &in->revisedQueueSize);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemModifyResult_filterResult", sv);
+	pack_UA_ExtensionObject(sv, &in->filterResult);
+
+	return;
 }
 
 static void
 unpack_UA_MonitoredItemModifyResult(UA_MonitoredItemModifyResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_MonitoredItemModifyResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "MonitoredItemModifyResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemModifyResult_revisedSamplingInterval", 0);
 	if (svp != NULL)
-		out->revisedSamplingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->revisedSamplingInterval, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemModifyResult_revisedQueueSize", 0);
 	if (svp != NULL)
-		out->revisedQueueSize = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->revisedQueueSize, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemModifyResult_filterResult", 0);
 	if (svp != NULL)
-		out->filterResult = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->filterResult, *svp);
 
-
+	return;
 }
 #endif
 
 /* ModifyMonitoredItemsRequest */
 #ifdef UA_TYPES_MODIFYMONITOREDITEMSREQUEST
-static void XS_pack_UA_ModifyMonitoredItemsRequest(SV *out, UA_ModifyMonitoredItemsRequest in)  __attribute__((unused));
-static UA_ModifyMonitoredItemsRequest XS_unpack_UA_ModifyMonitoredItemsRequest(SV *in)  __attribute__((unused));
 static void pack_UA_ModifyMonitoredItemsRequest(SV *out, UA_ModifyMonitoredItemsRequest *in);
 static void unpack_UA_ModifyMonitoredItemsRequest(UA_ModifyMonitoredItemsRequest *out, SV *in);
 
@@ -16474,88 +15888,85 @@ pack_UA_ModifyMonitoredItemsRequest(SV *out, UA_ModifyMonitoredItemsRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "ModifyMonitoredItemsRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
 	hv_stores(hv, "ModifyMonitoredItemsRequest_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
 
 	sv = newSV(0);
-	XS_pack_UA_TimestampsToReturn(sv, in->timestampsToReturn);
 	hv_stores(hv, "ModifyMonitoredItemsRequest_timestampsToReturn", sv);
+	pack_UA_TimestampsToReturn(sv, &in->timestampsToReturn);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ModifyMonitoredItemsRequest_itemsToModify", newRV_noinc((SV*)av));
 	av_extend(av, in->itemsToModifySize);
 	for (i = 0; i < in->itemsToModifySize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_MonitoredItemModifyRequest(sv, in->itemsToModify[i]);
 		av_push(av, sv);
+		pack_UA_MonitoredItemModifyRequest(sv, &in->itemsToModify[i]);
 	}
-	hv_stores(hv, "ModifyMonitoredItemsRequest_itemsToModify", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ModifyMonitoredItemsRequest(UA_ModifyMonitoredItemsRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ModifyMonitoredItemsRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ModifyMonitoredItemsRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "ModifyMonitoredItemsRequest_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "ModifyMonitoredItemsRequest_timestampsToReturn", 0);
 	if (svp != NULL)
-		out->timestampsToReturn = XS_unpack_UA_TimestampsToReturn(*svp);
+		unpack_UA_TimestampsToReturn(&out->timestampsToReturn, *svp);
 
 	svp = hv_fetchs(hv, "ModifyMonitoredItemsRequest_itemsToModify", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ModifyMonitoredItemsRequest_itemsToModify");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->itemsToModify = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMMODIFYREQUEST]);
-		if (out->itemsToModify == NULL) {
+		if (out->itemsToModify == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->itemsToModifySize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->itemsToModify[i] = XS_unpack_UA_MonitoredItemModifyRequest(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_MonitoredItemModifyRequest(&out->itemsToModify[i], *svp);
 		}
-		out->itemsToModifySize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ModifyMonitoredItemsResponse */
 #ifdef UA_TYPES_MODIFYMONITOREDITEMSRESPONSE
-static void XS_pack_UA_ModifyMonitoredItemsResponse(SV *out, UA_ModifyMonitoredItemsResponse in)  __attribute__((unused));
-static UA_ModifyMonitoredItemsResponse XS_unpack_UA_ModifyMonitoredItemsResponse(SV *in)  __attribute__((unused));
 static void pack_UA_ModifyMonitoredItemsResponse(SV *out, UA_ModifyMonitoredItemsResponse *in);
 static void unpack_UA_ModifyMonitoredItemsResponse(UA_ModifyMonitoredItemsResponse *out, SV *in);
 
@@ -16566,101 +15977,95 @@ pack_UA_ModifyMonitoredItemsResponse(SV *out, UA_ModifyMonitoredItemsResponse *i
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "ModifyMonitoredItemsResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ModifyMonitoredItemsResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_MonitoredItemModifyResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_MonitoredItemModifyResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "ModifyMonitoredItemsResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ModifyMonitoredItemsResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "ModifyMonitoredItemsResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ModifyMonitoredItemsResponse(UA_ModifyMonitoredItemsResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ModifyMonitoredItemsResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ModifyMonitoredItemsResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "ModifyMonitoredItemsResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ModifyMonitoredItemsResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMMODIFYRESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_MonitoredItemModifyResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_MonitoredItemModifyResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ModifyMonitoredItemsResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ModifyMonitoredItemsResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* SetMonitoringModeRequest */
 #ifdef UA_TYPES_SETMONITORINGMODEREQUEST
-static void XS_pack_UA_SetMonitoringModeRequest(SV *out, UA_SetMonitoringModeRequest in)  __attribute__((unused));
-static UA_SetMonitoringModeRequest XS_unpack_UA_SetMonitoringModeRequest(SV *in)  __attribute__((unused));
 static void pack_UA_SetMonitoringModeRequest(SV *out, UA_SetMonitoringModeRequest *in);
 static void unpack_UA_SetMonitoringModeRequest(UA_SetMonitoringModeRequest *out, SV *in);
 
@@ -16671,88 +16076,85 @@ pack_UA_SetMonitoringModeRequest(SV *out, UA_SetMonitoringModeRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "SetMonitoringModeRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
 	hv_stores(hv, "SetMonitoringModeRequest_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
 
 	sv = newSV(0);
-	XS_pack_UA_MonitoringMode(sv, in->monitoringMode);
 	hv_stores(hv, "SetMonitoringModeRequest_monitoringMode", sv);
+	pack_UA_MonitoringMode(sv, &in->monitoringMode);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetMonitoringModeRequest_monitoredItemIds", newRV_noinc((SV*)av));
 	av_extend(av, in->monitoredItemIdsSize);
 	for (i = 0; i < in->monitoredItemIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->monitoredItemIds[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->monitoredItemIds[i]);
 	}
-	hv_stores(hv, "SetMonitoringModeRequest_monitoredItemIds", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SetMonitoringModeRequest(UA_SetMonitoringModeRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SetMonitoringModeRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SetMonitoringModeRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "SetMonitoringModeRequest_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "SetMonitoringModeRequest_monitoringMode", 0);
 	if (svp != NULL)
-		out->monitoringMode = XS_unpack_UA_MonitoringMode(*svp);
+		unpack_UA_MonitoringMode(&out->monitoringMode, *svp);
 
 	svp = hv_fetchs(hv, "SetMonitoringModeRequest_monitoredItemIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetMonitoringModeRequest_monitoredItemIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->monitoredItemIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->monitoredItemIds == NULL) {
+		if (out->monitoredItemIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->monitoredItemIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->monitoredItemIds[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->monitoredItemIds[i], *svp);
 		}
-		out->monitoredItemIdsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* SetMonitoringModeResponse */
 #ifdef UA_TYPES_SETMONITORINGMODERESPONSE
-static void XS_pack_UA_SetMonitoringModeResponse(SV *out, UA_SetMonitoringModeResponse in)  __attribute__((unused));
-static UA_SetMonitoringModeResponse XS_unpack_UA_SetMonitoringModeResponse(SV *in)  __attribute__((unused));
 static void pack_UA_SetMonitoringModeResponse(SV *out, UA_SetMonitoringModeResponse *in);
 static void unpack_UA_SetMonitoringModeResponse(UA_SetMonitoringModeResponse *out, SV *in);
 
@@ -16763,101 +16165,95 @@ pack_UA_SetMonitoringModeResponse(SV *out, UA_SetMonitoringModeResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "SetMonitoringModeResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetMonitoringModeResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "SetMonitoringModeResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetMonitoringModeResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "SetMonitoringModeResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SetMonitoringModeResponse(UA_SetMonitoringModeResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SetMonitoringModeResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SetMonitoringModeResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "SetMonitoringModeResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetMonitoringModeResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SetMonitoringModeResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetMonitoringModeResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* SetTriggeringRequest */
 #ifdef UA_TYPES_SETTRIGGERINGREQUEST
-static void XS_pack_UA_SetTriggeringRequest(SV *out, UA_SetTriggeringRequest in)  __attribute__((unused));
-static UA_SetTriggeringRequest XS_unpack_UA_SetTriggeringRequest(SV *in)  __attribute__((unused));
 static void pack_UA_SetTriggeringRequest(SV *out, UA_SetTriggeringRequest *in);
 static void unpack_UA_SetTriggeringRequest(UA_SetTriggeringRequest *out, SV *in);
 
@@ -16868,117 +16264,111 @@ pack_UA_SetTriggeringRequest(SV *out, UA_SetTriggeringRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "SetTriggeringRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
 	hv_stores(hv, "SetTriggeringRequest_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->triggeringItemId);
 	hv_stores(hv, "SetTriggeringRequest_triggeringItemId", sv);
+	pack_UA_UInt32(sv, &in->triggeringItemId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetTriggeringRequest_linksToAdd", newRV_noinc((SV*)av));
 	av_extend(av, in->linksToAddSize);
 	for (i = 0; i < in->linksToAddSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->linksToAdd[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->linksToAdd[i]);
 	}
-	hv_stores(hv, "SetTriggeringRequest_linksToAdd", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetTriggeringRequest_linksToRemove", newRV_noinc((SV*)av));
 	av_extend(av, in->linksToRemoveSize);
 	for (i = 0; i < in->linksToRemoveSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->linksToRemove[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->linksToRemove[i]);
 	}
-	hv_stores(hv, "SetTriggeringRequest_linksToRemove", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SetTriggeringRequest(UA_SetTriggeringRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SetTriggeringRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SetTriggeringRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "SetTriggeringRequest_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "SetTriggeringRequest_triggeringItemId", 0);
 	if (svp != NULL)
-		out->triggeringItemId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->triggeringItemId, *svp);
 
 	svp = hv_fetchs(hv, "SetTriggeringRequest_linksToAdd", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetTriggeringRequest_linksToAdd");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->linksToAdd = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->linksToAdd == NULL) {
+		if (out->linksToAdd == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->linksToAddSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->linksToAdd[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->linksToAdd[i], *svp);
 		}
-		out->linksToAddSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SetTriggeringRequest_linksToRemove", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetTriggeringRequest_linksToRemove");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->linksToRemove = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->linksToRemove == NULL) {
+		if (out->linksToRemove == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->linksToRemoveSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->linksToRemove[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->linksToRemove[i], *svp);
 		}
-		out->linksToRemoveSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* SetTriggeringResponse */
 #ifdef UA_TYPES_SETTRIGGERINGRESPONSE
-static void XS_pack_UA_SetTriggeringResponse(SV *out, UA_SetTriggeringResponse in)  __attribute__((unused));
-static UA_SetTriggeringResponse XS_unpack_UA_SetTriggeringResponse(SV *in)  __attribute__((unused));
 static void pack_UA_SetTriggeringResponse(SV *out, UA_SetTriggeringResponse *in);
 static void unpack_UA_SetTriggeringResponse(UA_SetTriggeringResponse *out, SV *in);
 
@@ -16989,159 +16379,147 @@ pack_UA_SetTriggeringResponse(SV *out, UA_SetTriggeringResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "SetTriggeringResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetTriggeringResponse_addResults", newRV_noinc((SV*)av));
 	av_extend(av, in->addResultsSize);
 	for (i = 0; i < in->addResultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->addResults[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->addResults[i]);
 	}
-	hv_stores(hv, "SetTriggeringResponse_addResults", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetTriggeringResponse_addDiagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->addDiagnosticInfosSize);
 	for (i = 0; i < in->addDiagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->addDiagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->addDiagnosticInfos[i]);
 	}
-	hv_stores(hv, "SetTriggeringResponse_addDiagnosticInfos", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetTriggeringResponse_removeResults", newRV_noinc((SV*)av));
 	av_extend(av, in->removeResultsSize);
 	for (i = 0; i < in->removeResultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->removeResults[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->removeResults[i]);
 	}
-	hv_stores(hv, "SetTriggeringResponse_removeResults", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetTriggeringResponse_removeDiagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->removeDiagnosticInfosSize);
 	for (i = 0; i < in->removeDiagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->removeDiagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->removeDiagnosticInfos[i]);
 	}
-	hv_stores(hv, "SetTriggeringResponse_removeDiagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SetTriggeringResponse(UA_SetTriggeringResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SetTriggeringResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SetTriggeringResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "SetTriggeringResponse_addResults", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetTriggeringResponse_addResults");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->addResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->addResults == NULL) {
+		if (out->addResults == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->addResultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->addResults[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->addResults[i], *svp);
 		}
-		out->addResultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SetTriggeringResponse_addDiagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetTriggeringResponse_addDiagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->addDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->addDiagnosticInfos == NULL) {
+		if (out->addDiagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->addDiagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->addDiagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->addDiagnosticInfos[i], *svp);
 		}
-		out->addDiagnosticInfosSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SetTriggeringResponse_removeResults", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetTriggeringResponse_removeResults");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->removeResults = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->removeResults == NULL) {
+		if (out->removeResults == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->removeResultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->removeResults[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->removeResults[i], *svp);
 		}
-		out->removeResultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SetTriggeringResponse_removeDiagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetTriggeringResponse_removeDiagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->removeDiagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->removeDiagnosticInfos == NULL) {
+		if (out->removeDiagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->removeDiagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->removeDiagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->removeDiagnosticInfos[i], *svp);
 		}
-		out->removeDiagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteMonitoredItemsRequest */
 #ifdef UA_TYPES_DELETEMONITOREDITEMSREQUEST
-static void XS_pack_UA_DeleteMonitoredItemsRequest(SV *out, UA_DeleteMonitoredItemsRequest in)  __attribute__((unused));
-static UA_DeleteMonitoredItemsRequest XS_unpack_UA_DeleteMonitoredItemsRequest(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteMonitoredItemsRequest(SV *out, UA_DeleteMonitoredItemsRequest *in);
 static void unpack_UA_DeleteMonitoredItemsRequest(UA_DeleteMonitoredItemsRequest *out, SV *in);
 
@@ -17152,80 +16530,77 @@ pack_UA_DeleteMonitoredItemsRequest(SV *out, UA_DeleteMonitoredItemsRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "DeleteMonitoredItemsRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
 	hv_stores(hv, "DeleteMonitoredItemsRequest_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteMonitoredItemsRequest_monitoredItemIds", newRV_noinc((SV*)av));
 	av_extend(av, in->monitoredItemIdsSize);
 	for (i = 0; i < in->monitoredItemIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->monitoredItemIds[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->monitoredItemIds[i]);
 	}
-	hv_stores(hv, "DeleteMonitoredItemsRequest_monitoredItemIds", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteMonitoredItemsRequest(UA_DeleteMonitoredItemsRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteMonitoredItemsRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteMonitoredItemsRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "DeleteMonitoredItemsRequest_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "DeleteMonitoredItemsRequest_monitoredItemIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteMonitoredItemsRequest_monitoredItemIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->monitoredItemIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->monitoredItemIds == NULL) {
+		if (out->monitoredItemIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->monitoredItemIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->monitoredItemIds[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->monitoredItemIds[i], *svp);
 		}
-		out->monitoredItemIdsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteMonitoredItemsResponse */
 #ifdef UA_TYPES_DELETEMONITOREDITEMSRESPONSE
-static void XS_pack_UA_DeleteMonitoredItemsResponse(SV *out, UA_DeleteMonitoredItemsResponse in)  __attribute__((unused));
-static UA_DeleteMonitoredItemsResponse XS_unpack_UA_DeleteMonitoredItemsResponse(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteMonitoredItemsResponse(SV *out, UA_DeleteMonitoredItemsResponse *in);
 static void unpack_UA_DeleteMonitoredItemsResponse(UA_DeleteMonitoredItemsResponse *out, SV *in);
 
@@ -17236,101 +16611,95 @@ pack_UA_DeleteMonitoredItemsResponse(SV *out, UA_DeleteMonitoredItemsResponse *i
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "DeleteMonitoredItemsResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteMonitoredItemsResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "DeleteMonitoredItemsResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteMonitoredItemsResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "DeleteMonitoredItemsResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteMonitoredItemsResponse(UA_DeleteMonitoredItemsResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteMonitoredItemsResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteMonitoredItemsResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "DeleteMonitoredItemsResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteMonitoredItemsResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DeleteMonitoredItemsResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteMonitoredItemsResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* CreateSubscriptionRequest */
 #ifdef UA_TYPES_CREATESUBSCRIPTIONREQUEST
-static void XS_pack_UA_CreateSubscriptionRequest(SV *out, UA_CreateSubscriptionRequest in)  __attribute__((unused));
-static UA_CreateSubscriptionRequest XS_unpack_UA_CreateSubscriptionRequest(SV *in)  __attribute__((unused));
 static void pack_UA_CreateSubscriptionRequest(SV *out, UA_CreateSubscriptionRequest *in);
 static void unpack_UA_CreateSubscriptionRequest(UA_CreateSubscriptionRequest *out, SV *in);
 
@@ -17339,89 +16708,89 @@ pack_UA_CreateSubscriptionRequest(SV *out, UA_CreateSubscriptionRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
-	hv_stores(hv, "CreateSubscriptionRequest_requestHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->requestedPublishingInterval);
-	hv_stores(hv, "CreateSubscriptionRequest_requestedPublishingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->requestedLifetimeCount);
-	hv_stores(hv, "CreateSubscriptionRequest_requestedLifetimeCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->requestedMaxKeepAliveCount);
-	hv_stores(hv, "CreateSubscriptionRequest_requestedMaxKeepAliveCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxNotificationsPerPublish);
-	hv_stores(hv, "CreateSubscriptionRequest_maxNotificationsPerPublish", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->publishingEnabled);
-	hv_stores(hv, "CreateSubscriptionRequest_publishingEnabled", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->priority);
-	hv_stores(hv, "CreateSubscriptionRequest_priority", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionRequest_requestedPublishingInterval", sv);
+	pack_UA_Double(sv, &in->requestedPublishingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionRequest_requestedLifetimeCount", sv);
+	pack_UA_UInt32(sv, &in->requestedLifetimeCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionRequest_requestedMaxKeepAliveCount", sv);
+	pack_UA_UInt32(sv, &in->requestedMaxKeepAliveCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionRequest_maxNotificationsPerPublish", sv);
+	pack_UA_UInt32(sv, &in->maxNotificationsPerPublish);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionRequest_publishingEnabled", sv);
+	pack_UA_Boolean(sv, &in->publishingEnabled);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionRequest_priority", sv);
+	pack_UA_Byte(sv, &in->priority);
+
+	return;
 }
 
 static void
 unpack_UA_CreateSubscriptionRequest(UA_CreateSubscriptionRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CreateSubscriptionRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionRequest_requestedPublishingInterval", 0);
 	if (svp != NULL)
-		out->requestedPublishingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->requestedPublishingInterval, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionRequest_requestedLifetimeCount", 0);
 	if (svp != NULL)
-		out->requestedLifetimeCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->requestedLifetimeCount, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionRequest_requestedMaxKeepAliveCount", 0);
 	if (svp != NULL)
-		out->requestedMaxKeepAliveCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->requestedMaxKeepAliveCount, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionRequest_maxNotificationsPerPublish", 0);
 	if (svp != NULL)
-		out->maxNotificationsPerPublish = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxNotificationsPerPublish, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionRequest_publishingEnabled", 0);
 	if (svp != NULL)
-		out->publishingEnabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->publishingEnabled, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionRequest_priority", 0);
 	if (svp != NULL)
-		out->priority = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->priority, *svp);
 
-
+	return;
 }
 #endif
 
 /* CreateSubscriptionResponse */
 #ifdef UA_TYPES_CREATESUBSCRIPTIONRESPONSE
-static void XS_pack_UA_CreateSubscriptionResponse(SV *out, UA_CreateSubscriptionResponse in)  __attribute__((unused));
-static UA_CreateSubscriptionResponse XS_unpack_UA_CreateSubscriptionResponse(SV *in)  __attribute__((unused));
 static void pack_UA_CreateSubscriptionResponse(SV *out, UA_CreateSubscriptionResponse *in);
 static void unpack_UA_CreateSubscriptionResponse(UA_CreateSubscriptionResponse *out, SV *in);
 
@@ -17430,73 +16799,73 @@ pack_UA_CreateSubscriptionResponse(SV *out, UA_CreateSubscriptionResponse *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
-	hv_stores(hv, "CreateSubscriptionResponse_responseHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
-	hv_stores(hv, "CreateSubscriptionResponse_subscriptionId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->revisedPublishingInterval);
-	hv_stores(hv, "CreateSubscriptionResponse_revisedPublishingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->revisedLifetimeCount);
-	hv_stores(hv, "CreateSubscriptionResponse_revisedLifetimeCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->revisedMaxKeepAliveCount);
-	hv_stores(hv, "CreateSubscriptionResponse_revisedMaxKeepAliveCount", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionResponse_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionResponse_revisedPublishingInterval", sv);
+	pack_UA_Double(sv, &in->revisedPublishingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionResponse_revisedLifetimeCount", sv);
+	pack_UA_UInt32(sv, &in->revisedLifetimeCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "CreateSubscriptionResponse_revisedMaxKeepAliveCount", sv);
+	pack_UA_UInt32(sv, &in->revisedMaxKeepAliveCount);
+
+	return;
 }
 
 static void
 unpack_UA_CreateSubscriptionResponse(UA_CreateSubscriptionResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_CreateSubscriptionResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionResponse_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionResponse_revisedPublishingInterval", 0);
 	if (svp != NULL)
-		out->revisedPublishingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->revisedPublishingInterval, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionResponse_revisedLifetimeCount", 0);
 	if (svp != NULL)
-		out->revisedLifetimeCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->revisedLifetimeCount, *svp);
 
 	svp = hv_fetchs(hv, "CreateSubscriptionResponse_revisedMaxKeepAliveCount", 0);
 	if (svp != NULL)
-		out->revisedMaxKeepAliveCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->revisedMaxKeepAliveCount, *svp);
 
-
+	return;
 }
 #endif
 
 /* ModifySubscriptionRequest */
 #ifdef UA_TYPES_MODIFYSUBSCRIPTIONREQUEST
-static void XS_pack_UA_ModifySubscriptionRequest(SV *out, UA_ModifySubscriptionRequest in)  __attribute__((unused));
-static UA_ModifySubscriptionRequest XS_unpack_UA_ModifySubscriptionRequest(SV *in)  __attribute__((unused));
 static void pack_UA_ModifySubscriptionRequest(SV *out, UA_ModifySubscriptionRequest *in);
 static void unpack_UA_ModifySubscriptionRequest(UA_ModifySubscriptionRequest *out, SV *in);
 
@@ -17505,89 +16874,89 @@ pack_UA_ModifySubscriptionRequest(SV *out, UA_ModifySubscriptionRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
-	hv_stores(hv, "ModifySubscriptionRequest_requestHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
-	hv_stores(hv, "ModifySubscriptionRequest_subscriptionId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->requestedPublishingInterval);
-	hv_stores(hv, "ModifySubscriptionRequest_requestedPublishingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->requestedLifetimeCount);
-	hv_stores(hv, "ModifySubscriptionRequest_requestedLifetimeCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->requestedMaxKeepAliveCount);
-	hv_stores(hv, "ModifySubscriptionRequest_requestedMaxKeepAliveCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxNotificationsPerPublish);
-	hv_stores(hv, "ModifySubscriptionRequest_maxNotificationsPerPublish", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->priority);
-	hv_stores(hv, "ModifySubscriptionRequest_priority", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionRequest_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionRequest_requestedPublishingInterval", sv);
+	pack_UA_Double(sv, &in->requestedPublishingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionRequest_requestedLifetimeCount", sv);
+	pack_UA_UInt32(sv, &in->requestedLifetimeCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionRequest_requestedMaxKeepAliveCount", sv);
+	pack_UA_UInt32(sv, &in->requestedMaxKeepAliveCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionRequest_maxNotificationsPerPublish", sv);
+	pack_UA_UInt32(sv, &in->maxNotificationsPerPublish);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionRequest_priority", sv);
+	pack_UA_Byte(sv, &in->priority);
+
+	return;
 }
 
 static void
 unpack_UA_ModifySubscriptionRequest(UA_ModifySubscriptionRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ModifySubscriptionRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionRequest_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionRequest_requestedPublishingInterval", 0);
 	if (svp != NULL)
-		out->requestedPublishingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->requestedPublishingInterval, *svp);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionRequest_requestedLifetimeCount", 0);
 	if (svp != NULL)
-		out->requestedLifetimeCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->requestedLifetimeCount, *svp);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionRequest_requestedMaxKeepAliveCount", 0);
 	if (svp != NULL)
-		out->requestedMaxKeepAliveCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->requestedMaxKeepAliveCount, *svp);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionRequest_maxNotificationsPerPublish", 0);
 	if (svp != NULL)
-		out->maxNotificationsPerPublish = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxNotificationsPerPublish, *svp);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionRequest_priority", 0);
 	if (svp != NULL)
-		out->priority = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->priority, *svp);
 
-
+	return;
 }
 #endif
 
 /* ModifySubscriptionResponse */
 #ifdef UA_TYPES_MODIFYSUBSCRIPTIONRESPONSE
-static void XS_pack_UA_ModifySubscriptionResponse(SV *out, UA_ModifySubscriptionResponse in)  __attribute__((unused));
-static UA_ModifySubscriptionResponse XS_unpack_UA_ModifySubscriptionResponse(SV *in)  __attribute__((unused));
 static void pack_UA_ModifySubscriptionResponse(SV *out, UA_ModifySubscriptionResponse *in);
 static void unpack_UA_ModifySubscriptionResponse(UA_ModifySubscriptionResponse *out, SV *in);
 
@@ -17596,65 +16965,65 @@ pack_UA_ModifySubscriptionResponse(SV *out, UA_ModifySubscriptionResponse *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
-	hv_stores(hv, "ModifySubscriptionResponse_responseHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->revisedPublishingInterval);
-	hv_stores(hv, "ModifySubscriptionResponse_revisedPublishingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->revisedLifetimeCount);
-	hv_stores(hv, "ModifySubscriptionResponse_revisedLifetimeCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->revisedMaxKeepAliveCount);
-	hv_stores(hv, "ModifySubscriptionResponse_revisedMaxKeepAliveCount", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionResponse_revisedPublishingInterval", sv);
+	pack_UA_Double(sv, &in->revisedPublishingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionResponse_revisedLifetimeCount", sv);
+	pack_UA_UInt32(sv, &in->revisedLifetimeCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModifySubscriptionResponse_revisedMaxKeepAliveCount", sv);
+	pack_UA_UInt32(sv, &in->revisedMaxKeepAliveCount);
+
+	return;
 }
 
 static void
 unpack_UA_ModifySubscriptionResponse(UA_ModifySubscriptionResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ModifySubscriptionResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionResponse_revisedPublishingInterval", 0);
 	if (svp != NULL)
-		out->revisedPublishingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->revisedPublishingInterval, *svp);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionResponse_revisedLifetimeCount", 0);
 	if (svp != NULL)
-		out->revisedLifetimeCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->revisedLifetimeCount, *svp);
 
 	svp = hv_fetchs(hv, "ModifySubscriptionResponse_revisedMaxKeepAliveCount", 0);
 	if (svp != NULL)
-		out->revisedMaxKeepAliveCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->revisedMaxKeepAliveCount, *svp);
 
-
+	return;
 }
 #endif
 
 /* SetPublishingModeRequest */
 #ifdef UA_TYPES_SETPUBLISHINGMODEREQUEST
-static void XS_pack_UA_SetPublishingModeRequest(SV *out, UA_SetPublishingModeRequest in)  __attribute__((unused));
-static UA_SetPublishingModeRequest XS_unpack_UA_SetPublishingModeRequest(SV *in)  __attribute__((unused));
 static void pack_UA_SetPublishingModeRequest(SV *out, UA_SetPublishingModeRequest *in);
 static void unpack_UA_SetPublishingModeRequest(UA_SetPublishingModeRequest *out, SV *in);
 
@@ -17665,80 +17034,77 @@ pack_UA_SetPublishingModeRequest(SV *out, UA_SetPublishingModeRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "SetPublishingModeRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->publishingEnabled);
 	hv_stores(hv, "SetPublishingModeRequest_publishingEnabled", sv);
+	pack_UA_Boolean(sv, &in->publishingEnabled);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetPublishingModeRequest_subscriptionIds", newRV_noinc((SV*)av));
 	av_extend(av, in->subscriptionIdsSize);
 	for (i = 0; i < in->subscriptionIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->subscriptionIds[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->subscriptionIds[i]);
 	}
-	hv_stores(hv, "SetPublishingModeRequest_subscriptionIds", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SetPublishingModeRequest(UA_SetPublishingModeRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SetPublishingModeRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SetPublishingModeRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "SetPublishingModeRequest_publishingEnabled", 0);
 	if (svp != NULL)
-		out->publishingEnabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->publishingEnabled, *svp);
 
 	svp = hv_fetchs(hv, "SetPublishingModeRequest_subscriptionIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetPublishingModeRequest_subscriptionIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->subscriptionIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->subscriptionIds == NULL) {
+		if (out->subscriptionIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->subscriptionIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->subscriptionIds[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->subscriptionIds[i], *svp);
 		}
-		out->subscriptionIdsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* SetPublishingModeResponse */
 #ifdef UA_TYPES_SETPUBLISHINGMODERESPONSE
-static void XS_pack_UA_SetPublishingModeResponse(SV *out, UA_SetPublishingModeResponse in)  __attribute__((unused));
-static UA_SetPublishingModeResponse XS_unpack_UA_SetPublishingModeResponse(SV *in)  __attribute__((unused));
 static void pack_UA_SetPublishingModeResponse(SV *out, UA_SetPublishingModeResponse *in);
 static void unpack_UA_SetPublishingModeResponse(UA_SetPublishingModeResponse *out, SV *in);
 
@@ -17749,101 +17115,95 @@ pack_UA_SetPublishingModeResponse(SV *out, UA_SetPublishingModeResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "SetPublishingModeResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetPublishingModeResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "SetPublishingModeResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SetPublishingModeResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "SetPublishingModeResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SetPublishingModeResponse(UA_SetPublishingModeResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SetPublishingModeResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SetPublishingModeResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "SetPublishingModeResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetPublishingModeResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SetPublishingModeResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SetPublishingModeResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* NotificationMessage */
 #ifdef UA_TYPES_NOTIFICATIONMESSAGE
-static void XS_pack_UA_NotificationMessage(SV *out, UA_NotificationMessage in)  __attribute__((unused));
-static UA_NotificationMessage XS_unpack_UA_NotificationMessage(SV *in)  __attribute__((unused));
 static void pack_UA_NotificationMessage(SV *out, UA_NotificationMessage *in);
 static void unpack_UA_NotificationMessage(UA_NotificationMessage *out, SV *in);
 
@@ -17854,80 +17214,77 @@ pack_UA_NotificationMessage(SV *out, UA_NotificationMessage *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->sequenceNumber);
 	hv_stores(hv, "NotificationMessage_sequenceNumber", sv);
+	pack_UA_UInt32(sv, &in->sequenceNumber);
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->publishTime);
 	hv_stores(hv, "NotificationMessage_publishTime", sv);
+	pack_UA_DateTime(sv, &in->publishTime);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "NotificationMessage_notificationData", newRV_noinc((SV*)av));
 	av_extend(av, in->notificationDataSize);
 	for (i = 0; i < in->notificationDataSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ExtensionObject(sv, in->notificationData[i]);
 		av_push(av, sv);
+		pack_UA_ExtensionObject(sv, &in->notificationData[i]);
 	}
-	hv_stores(hv, "NotificationMessage_notificationData", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_NotificationMessage(UA_NotificationMessage *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_NotificationMessage_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "NotificationMessage_sequenceNumber", 0);
 	if (svp != NULL)
-		out->sequenceNumber = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->sequenceNumber, *svp);
 
 	svp = hv_fetchs(hv, "NotificationMessage_publishTime", 0);
 	if (svp != NULL)
-		out->publishTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->publishTime, *svp);
 
 	svp = hv_fetchs(hv, "NotificationMessage_notificationData", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for NotificationMessage_notificationData");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->notificationData = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_EXTENSIONOBJECT]);
-		if (out->notificationData == NULL) {
+		if (out->notificationData == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->notificationDataSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->notificationData[i] = XS_unpack_UA_ExtensionObject(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ExtensionObject(&out->notificationData[i], *svp);
 		}
-		out->notificationDataSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* NotificationData */
 #ifdef UA_TYPES_NOTIFICATIONDATA
-static void XS_pack_UA_NotificationData(SV *out, UA_NotificationData in)  __attribute__((unused));
-static UA_NotificationData XS_unpack_UA_NotificationData(SV *in)  __attribute__((unused));
 static void pack_UA_NotificationData(SV *out, UA_NotificationData *in);
 static void unpack_UA_NotificationData(UA_NotificationData *out, SV *in);
 
@@ -17948,8 +17305,6 @@ unpack_UA_NotificationData(UA_NotificationData *out, SV *in)
 
 /* MonitoredItemNotification */
 #ifdef UA_TYPES_MONITOREDITEMNOTIFICATION
-static void XS_pack_UA_MonitoredItemNotification(SV *out, UA_MonitoredItemNotification in)  __attribute__((unused));
-static UA_MonitoredItemNotification XS_unpack_UA_MonitoredItemNotification(SV *in)  __attribute__((unused));
 static void pack_UA_MonitoredItemNotification(SV *out, UA_MonitoredItemNotification *in);
 static void unpack_UA_MonitoredItemNotification(UA_MonitoredItemNotification *out, SV *in);
 
@@ -17958,49 +17313,49 @@ pack_UA_MonitoredItemNotification(SV *out, UA_MonitoredItemNotification *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->clientHandle);
-	hv_stores(hv, "MonitoredItemNotification_clientHandle", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DataValue(sv, in->value);
-	hv_stores(hv, "MonitoredItemNotification_value", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemNotification_clientHandle", sv);
+	pack_UA_UInt32(sv, &in->clientHandle);
+
+	sv = newSV(0);
+	hv_stores(hv, "MonitoredItemNotification_value", sv);
+	pack_UA_DataValue(sv, &in->value);
+
+	return;
 }
 
 static void
 unpack_UA_MonitoredItemNotification(UA_MonitoredItemNotification *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_MonitoredItemNotification_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "MonitoredItemNotification_clientHandle", 0);
 	if (svp != NULL)
-		out->clientHandle = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->clientHandle, *svp);
 
 	svp = hv_fetchs(hv, "MonitoredItemNotification_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_DataValue(*svp);
+		unpack_UA_DataValue(&out->value, *svp);
 
-
+	return;
 }
 #endif
 
 /* EventFieldList */
 #ifdef UA_TYPES_EVENTFIELDLIST
-static void XS_pack_UA_EventFieldList(SV *out, UA_EventFieldList in)  __attribute__((unused));
-static UA_EventFieldList XS_unpack_UA_EventFieldList(SV *in)  __attribute__((unused));
 static void pack_UA_EventFieldList(SV *out, UA_EventFieldList *in);
 static void unpack_UA_EventFieldList(UA_EventFieldList *out, SV *in);
 
@@ -18011,72 +17366,69 @@ pack_UA_EventFieldList(SV *out, UA_EventFieldList *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->clientHandle);
 	hv_stores(hv, "EventFieldList_clientHandle", sv);
+	pack_UA_UInt32(sv, &in->clientHandle);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "EventFieldList_eventFields", newRV_noinc((SV*)av));
 	av_extend(av, in->eventFieldsSize);
 	for (i = 0; i < in->eventFieldsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Variant(sv, in->eventFields[i]);
 		av_push(av, sv);
+		pack_UA_Variant(sv, &in->eventFields[i]);
 	}
-	hv_stores(hv, "EventFieldList_eventFields", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_EventFieldList(UA_EventFieldList *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EventFieldList_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EventFieldList_clientHandle", 0);
 	if (svp != NULL)
-		out->clientHandle = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->clientHandle, *svp);
 
 	svp = hv_fetchs(hv, "EventFieldList_eventFields", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for EventFieldList_eventFields");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->eventFields = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
-		if (out->eventFields == NULL) {
+		if (out->eventFields == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->eventFieldsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->eventFields[i] = XS_unpack_UA_Variant(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Variant(&out->eventFields[i], *svp);
 		}
-		out->eventFieldsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryEventFieldList */
 #ifdef UA_TYPES_HISTORYEVENTFIELDLIST
-static void XS_pack_UA_HistoryEventFieldList(SV *out, UA_HistoryEventFieldList in)  __attribute__((unused));
-static UA_HistoryEventFieldList XS_unpack_UA_HistoryEventFieldList(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryEventFieldList(SV *out, UA_HistoryEventFieldList *in);
 static void unpack_UA_HistoryEventFieldList(UA_HistoryEventFieldList *out, SV *in);
 
@@ -18087,64 +17439,61 @@ pack_UA_HistoryEventFieldList(SV *out, UA_HistoryEventFieldList *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "HistoryEventFieldList_eventFields", newRV_noinc((SV*)av));
 	av_extend(av, in->eventFieldsSize);
 	for (i = 0; i < in->eventFieldsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Variant(sv, in->eventFields[i]);
 		av_push(av, sv);
+		pack_UA_Variant(sv, &in->eventFields[i]);
 	}
-	hv_stores(hv, "HistoryEventFieldList_eventFields", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryEventFieldList(UA_HistoryEventFieldList *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryEventFieldList_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryEventFieldList_eventFields", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryEventFieldList_eventFields");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->eventFields = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
-		if (out->eventFields == NULL) {
+		if (out->eventFields == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->eventFieldsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->eventFields[i] = XS_unpack_UA_Variant(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Variant(&out->eventFields[i], *svp);
 		}
-		out->eventFieldsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* StatusChangeNotification */
 #ifdef UA_TYPES_STATUSCHANGENOTIFICATION
-static void XS_pack_UA_StatusChangeNotification(SV *out, UA_StatusChangeNotification in)  __attribute__((unused));
-static UA_StatusChangeNotification XS_unpack_UA_StatusChangeNotification(SV *in)  __attribute__((unused));
 static void pack_UA_StatusChangeNotification(SV *out, UA_StatusChangeNotification *in);
 static void unpack_UA_StatusChangeNotification(UA_StatusChangeNotification *out, SV *in);
 
@@ -18153,49 +17502,49 @@ pack_UA_StatusChangeNotification(SV *out, UA_StatusChangeNotification *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->status);
-	hv_stores(hv, "StatusChangeNotification_status", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfo);
-	hv_stores(hv, "StatusChangeNotification_diagnosticInfo", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "StatusChangeNotification_status", sv);
+	pack_UA_StatusCode(sv, &in->status);
+
+	sv = newSV(0);
+	hv_stores(hv, "StatusChangeNotification_diagnosticInfo", sv);
+	pack_UA_DiagnosticInfo(sv, &in->diagnosticInfo);
+
+	return;
 }
 
 static void
 unpack_UA_StatusChangeNotification(UA_StatusChangeNotification *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_StatusChangeNotification_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "StatusChangeNotification_status", 0);
 	if (svp != NULL)
-		out->status = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->status, *svp);
 
 	svp = hv_fetchs(hv, "StatusChangeNotification_diagnosticInfo", 0);
 	if (svp != NULL)
-		out->diagnosticInfo = XS_unpack_UA_DiagnosticInfo(*svp);
+		unpack_UA_DiagnosticInfo(&out->diagnosticInfo, *svp);
 
-
+	return;
 }
 #endif
 
 /* SubscriptionAcknowledgement */
 #ifdef UA_TYPES_SUBSCRIPTIONACKNOWLEDGEMENT
-static void XS_pack_UA_SubscriptionAcknowledgement(SV *out, UA_SubscriptionAcknowledgement in)  __attribute__((unused));
-static UA_SubscriptionAcknowledgement XS_unpack_UA_SubscriptionAcknowledgement(SV *in)  __attribute__((unused));
 static void pack_UA_SubscriptionAcknowledgement(SV *out, UA_SubscriptionAcknowledgement *in);
 static void unpack_UA_SubscriptionAcknowledgement(UA_SubscriptionAcknowledgement *out, SV *in);
 
@@ -18204,49 +17553,49 @@ pack_UA_SubscriptionAcknowledgement(SV *out, UA_SubscriptionAcknowledgement *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
-	hv_stores(hv, "SubscriptionAcknowledgement_subscriptionId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->sequenceNumber);
-	hv_stores(hv, "SubscriptionAcknowledgement_sequenceNumber", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionAcknowledgement_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionAcknowledgement_sequenceNumber", sv);
+	pack_UA_UInt32(sv, &in->sequenceNumber);
+
+	return;
 }
 
 static void
 unpack_UA_SubscriptionAcknowledgement(UA_SubscriptionAcknowledgement *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SubscriptionAcknowledgement_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SubscriptionAcknowledgement_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionAcknowledgement_sequenceNumber", 0);
 	if (svp != NULL)
-		out->sequenceNumber = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->sequenceNumber, *svp);
 
-
+	return;
 }
 #endif
 
 /* PublishRequest */
 #ifdef UA_TYPES_PUBLISHREQUEST
-static void XS_pack_UA_PublishRequest(SV *out, UA_PublishRequest in)  __attribute__((unused));
-static UA_PublishRequest XS_unpack_UA_PublishRequest(SV *in)  __attribute__((unused));
 static void pack_UA_PublishRequest(SV *out, UA_PublishRequest *in);
 static void unpack_UA_PublishRequest(UA_PublishRequest *out, SV *in);
 
@@ -18257,72 +17606,69 @@ pack_UA_PublishRequest(SV *out, UA_PublishRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "PublishRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PublishRequest_subscriptionAcknowledgements", newRV_noinc((SV*)av));
 	av_extend(av, in->subscriptionAcknowledgementsSize);
 	for (i = 0; i < in->subscriptionAcknowledgementsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_SubscriptionAcknowledgement(sv, in->subscriptionAcknowledgements[i]);
 		av_push(av, sv);
+		pack_UA_SubscriptionAcknowledgement(sv, &in->subscriptionAcknowledgements[i]);
 	}
-	hv_stores(hv, "PublishRequest_subscriptionAcknowledgements", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_PublishRequest(UA_PublishRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_PublishRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "PublishRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "PublishRequest_subscriptionAcknowledgements", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PublishRequest_subscriptionAcknowledgements");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->subscriptionAcknowledgements = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SUBSCRIPTIONACKNOWLEDGEMENT]);
-		if (out->subscriptionAcknowledgements == NULL) {
+		if (out->subscriptionAcknowledgements == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->subscriptionAcknowledgementsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->subscriptionAcknowledgements[i] = XS_unpack_UA_SubscriptionAcknowledgement(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_SubscriptionAcknowledgement(&out->subscriptionAcknowledgements[i], *svp);
 		}
-		out->subscriptionAcknowledgementsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* PublishResponse */
 #ifdef UA_TYPES_PUBLISHRESPONSE
-static void XS_pack_UA_PublishResponse(SV *out, UA_PublishResponse in)  __attribute__((unused));
-static UA_PublishResponse XS_unpack_UA_PublishResponse(SV *in)  __attribute__((unused));
 static void pack_UA_PublishResponse(SV *out, UA_PublishResponse *in);
 static void unpack_UA_PublishResponse(UA_PublishResponse *out, SV *in);
 
@@ -18333,154 +17679,145 @@ pack_UA_PublishResponse(SV *out, UA_PublishResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "PublishResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
 	hv_stores(hv, "PublishResponse_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PublishResponse_availableSequenceNumbers", newRV_noinc((SV*)av));
 	av_extend(av, in->availableSequenceNumbersSize);
 	for (i = 0; i < in->availableSequenceNumbersSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->availableSequenceNumbers[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->availableSequenceNumbers[i]);
 	}
-	hv_stores(hv, "PublishResponse_availableSequenceNumbers", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->moreNotifications);
 	hv_stores(hv, "PublishResponse_moreNotifications", sv);
+	pack_UA_Boolean(sv, &in->moreNotifications);
 
 	sv = newSV(0);
-	XS_pack_UA_NotificationMessage(sv, in->notificationMessage);
 	hv_stores(hv, "PublishResponse_notificationMessage", sv);
+	pack_UA_NotificationMessage(sv, &in->notificationMessage);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PublishResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "PublishResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PublishResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "PublishResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_PublishResponse(UA_PublishResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_PublishResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "PublishResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "PublishResponse_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "PublishResponse_availableSequenceNumbers", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PublishResponse_availableSequenceNumbers");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->availableSequenceNumbers = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->availableSequenceNumbers == NULL) {
+		if (out->availableSequenceNumbers == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->availableSequenceNumbersSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->availableSequenceNumbers[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->availableSequenceNumbers[i], *svp);
 		}
-		out->availableSequenceNumbersSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PublishResponse_moreNotifications", 0);
 	if (svp != NULL)
-		out->moreNotifications = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->moreNotifications, *svp);
 
 	svp = hv_fetchs(hv, "PublishResponse_notificationMessage", 0);
 	if (svp != NULL)
-		out->notificationMessage = XS_unpack_UA_NotificationMessage(*svp);
+		unpack_UA_NotificationMessage(&out->notificationMessage, *svp);
 
 	svp = hv_fetchs(hv, "PublishResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PublishResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PublishResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PublishResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* RepublishRequest */
 #ifdef UA_TYPES_REPUBLISHREQUEST
-static void XS_pack_UA_RepublishRequest(SV *out, UA_RepublishRequest in)  __attribute__((unused));
-static UA_RepublishRequest XS_unpack_UA_RepublishRequest(SV *in)  __attribute__((unused));
 static void pack_UA_RepublishRequest(SV *out, UA_RepublishRequest *in);
 static void unpack_UA_RepublishRequest(UA_RepublishRequest *out, SV *in);
 
@@ -18489,57 +17826,57 @@ pack_UA_RepublishRequest(SV *out, UA_RepublishRequest *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
-	hv_stores(hv, "RepublishRequest_requestHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
-	hv_stores(hv, "RepublishRequest_subscriptionId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->retransmitSequenceNumber);
-	hv_stores(hv, "RepublishRequest_retransmitSequenceNumber", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "RepublishRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "RepublishRequest_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
+
+	sv = newSV(0);
+	hv_stores(hv, "RepublishRequest_retransmitSequenceNumber", sv);
+	pack_UA_UInt32(sv, &in->retransmitSequenceNumber);
+
+	return;
 }
 
 static void
 unpack_UA_RepublishRequest(UA_RepublishRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RepublishRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RepublishRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "RepublishRequest_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "RepublishRequest_retransmitSequenceNumber", 0);
 	if (svp != NULL)
-		out->retransmitSequenceNumber = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->retransmitSequenceNumber, *svp);
 
-
+	return;
 }
 #endif
 
 /* RepublishResponse */
 #ifdef UA_TYPES_REPUBLISHRESPONSE
-static void XS_pack_UA_RepublishResponse(SV *out, UA_RepublishResponse in)  __attribute__((unused));
-static UA_RepublishResponse XS_unpack_UA_RepublishResponse(SV *in)  __attribute__((unused));
 static void pack_UA_RepublishResponse(SV *out, UA_RepublishResponse *in);
 static void unpack_UA_RepublishResponse(UA_RepublishResponse *out, SV *in);
 
@@ -18548,49 +17885,49 @@ pack_UA_RepublishResponse(SV *out, UA_RepublishResponse *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
-	hv_stores(hv, "RepublishResponse_responseHeader", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NotificationMessage(sv, in->notificationMessage);
-	hv_stores(hv, "RepublishResponse_notificationMessage", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "RepublishResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
+
+	sv = newSV(0);
+	hv_stores(hv, "RepublishResponse_notificationMessage", sv);
+	pack_UA_NotificationMessage(sv, &in->notificationMessage);
+
+	return;
 }
 
 static void
 unpack_UA_RepublishResponse(UA_RepublishResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RepublishResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RepublishResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "RepublishResponse_notificationMessage", 0);
 	if (svp != NULL)
-		out->notificationMessage = XS_unpack_UA_NotificationMessage(*svp);
+		unpack_UA_NotificationMessage(&out->notificationMessage, *svp);
 
-
+	return;
 }
 #endif
 
 /* TransferResult */
 #ifdef UA_TYPES_TRANSFERRESULT
-static void XS_pack_UA_TransferResult(SV *out, UA_TransferResult in)  __attribute__((unused));
-static UA_TransferResult XS_unpack_UA_TransferResult(SV *in)  __attribute__((unused));
 static void pack_UA_TransferResult(SV *out, UA_TransferResult *in);
 static void unpack_UA_TransferResult(UA_TransferResult *out, SV *in);
 
@@ -18601,72 +17938,69 @@ pack_UA_TransferResult(SV *out, UA_TransferResult *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
 	hv_stores(hv, "TransferResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TransferResult_availableSequenceNumbers", newRV_noinc((SV*)av));
 	av_extend(av, in->availableSequenceNumbersSize);
 	for (i = 0; i < in->availableSequenceNumbersSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->availableSequenceNumbers[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->availableSequenceNumbers[i]);
 	}
-	hv_stores(hv, "TransferResult_availableSequenceNumbers", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_TransferResult(UA_TransferResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_TransferResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "TransferResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "TransferResult_availableSequenceNumbers", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TransferResult_availableSequenceNumbers");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->availableSequenceNumbers = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->availableSequenceNumbers == NULL) {
+		if (out->availableSequenceNumbers == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->availableSequenceNumbersSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->availableSequenceNumbers[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->availableSequenceNumbers[i], *svp);
 		}
-		out->availableSequenceNumbersSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* TransferSubscriptionsRequest */
 #ifdef UA_TYPES_TRANSFERSUBSCRIPTIONSREQUEST
-static void XS_pack_UA_TransferSubscriptionsRequest(SV *out, UA_TransferSubscriptionsRequest in)  __attribute__((unused));
-static UA_TransferSubscriptionsRequest XS_unpack_UA_TransferSubscriptionsRequest(SV *in)  __attribute__((unused));
 static void pack_UA_TransferSubscriptionsRequest(SV *out, UA_TransferSubscriptionsRequest *in);
 static void unpack_UA_TransferSubscriptionsRequest(UA_TransferSubscriptionsRequest *out, SV *in);
 
@@ -18677,80 +18011,77 @@ pack_UA_TransferSubscriptionsRequest(SV *out, UA_TransferSubscriptionsRequest *i
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "TransferSubscriptionsRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TransferSubscriptionsRequest_subscriptionIds", newRV_noinc((SV*)av));
 	av_extend(av, in->subscriptionIdsSize);
 	for (i = 0; i < in->subscriptionIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->subscriptionIds[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->subscriptionIds[i]);
 	}
-	hv_stores(hv, "TransferSubscriptionsRequest_subscriptionIds", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->sendInitialValues);
 	hv_stores(hv, "TransferSubscriptionsRequest_sendInitialValues", sv);
+	pack_UA_Boolean(sv, &in->sendInitialValues);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_TransferSubscriptionsRequest(UA_TransferSubscriptionsRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_TransferSubscriptionsRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "TransferSubscriptionsRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "TransferSubscriptionsRequest_subscriptionIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TransferSubscriptionsRequest_subscriptionIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->subscriptionIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->subscriptionIds == NULL) {
+		if (out->subscriptionIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->subscriptionIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->subscriptionIds[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->subscriptionIds[i], *svp);
 		}
-		out->subscriptionIdsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "TransferSubscriptionsRequest_sendInitialValues", 0);
 	if (svp != NULL)
-		out->sendInitialValues = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->sendInitialValues, *svp);
 
-
+	return;
 }
 #endif
 
 /* TransferSubscriptionsResponse */
 #ifdef UA_TYPES_TRANSFERSUBSCRIPTIONSRESPONSE
-static void XS_pack_UA_TransferSubscriptionsResponse(SV *out, UA_TransferSubscriptionsResponse in)  __attribute__((unused));
-static UA_TransferSubscriptionsResponse XS_unpack_UA_TransferSubscriptionsResponse(SV *in)  __attribute__((unused));
 static void pack_UA_TransferSubscriptionsResponse(SV *out, UA_TransferSubscriptionsResponse *in);
 static void unpack_UA_TransferSubscriptionsResponse(UA_TransferSubscriptionsResponse *out, SV *in);
 
@@ -18761,101 +18092,95 @@ pack_UA_TransferSubscriptionsResponse(SV *out, UA_TransferSubscriptionsResponse 
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "TransferSubscriptionsResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TransferSubscriptionsResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_TransferResult(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_TransferResult(sv, &in->results[i]);
 	}
-	hv_stores(hv, "TransferSubscriptionsResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "TransferSubscriptionsResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "TransferSubscriptionsResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_TransferSubscriptionsResponse(UA_TransferSubscriptionsResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_TransferSubscriptionsResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "TransferSubscriptionsResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "TransferSubscriptionsResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TransferSubscriptionsResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_TRANSFERRESULT]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_TransferResult(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_TransferResult(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "TransferSubscriptionsResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TransferSubscriptionsResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteSubscriptionsRequest */
 #ifdef UA_TYPES_DELETESUBSCRIPTIONSREQUEST
-static void XS_pack_UA_DeleteSubscriptionsRequest(SV *out, UA_DeleteSubscriptionsRequest in)  __attribute__((unused));
-static UA_DeleteSubscriptionsRequest XS_unpack_UA_DeleteSubscriptionsRequest(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteSubscriptionsRequest(SV *out, UA_DeleteSubscriptionsRequest *in);
 static void unpack_UA_DeleteSubscriptionsRequest(UA_DeleteSubscriptionsRequest *out, SV *in);
 
@@ -18866,72 +18191,69 @@ pack_UA_DeleteSubscriptionsRequest(SV *out, UA_DeleteSubscriptionsRequest *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_RequestHeader(sv, in->requestHeader);
 	hv_stores(hv, "DeleteSubscriptionsRequest_requestHeader", sv);
+	pack_UA_RequestHeader(sv, &in->requestHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteSubscriptionsRequest_subscriptionIds", newRV_noinc((SV*)av));
 	av_extend(av, in->subscriptionIdsSize);
 	for (i = 0; i < in->subscriptionIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->subscriptionIds[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->subscriptionIds[i]);
 	}
-	hv_stores(hv, "DeleteSubscriptionsRequest_subscriptionIds", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteSubscriptionsRequest(UA_DeleteSubscriptionsRequest *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteSubscriptionsRequest_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteSubscriptionsRequest_requestHeader", 0);
 	if (svp != NULL)
-		out->requestHeader = XS_unpack_UA_RequestHeader(*svp);
+		unpack_UA_RequestHeader(&out->requestHeader, *svp);
 
 	svp = hv_fetchs(hv, "DeleteSubscriptionsRequest_subscriptionIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteSubscriptionsRequest_subscriptionIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->subscriptionIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->subscriptionIds == NULL) {
+		if (out->subscriptionIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->subscriptionIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->subscriptionIds[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->subscriptionIds[i], *svp);
 		}
-		out->subscriptionIdsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DeleteSubscriptionsResponse */
 #ifdef UA_TYPES_DELETESUBSCRIPTIONSRESPONSE
-static void XS_pack_UA_DeleteSubscriptionsResponse(SV *out, UA_DeleteSubscriptionsResponse in)  __attribute__((unused));
-static UA_DeleteSubscriptionsResponse XS_unpack_UA_DeleteSubscriptionsResponse(SV *in)  __attribute__((unused));
 static void pack_UA_DeleteSubscriptionsResponse(SV *out, UA_DeleteSubscriptionsResponse *in);
 static void unpack_UA_DeleteSubscriptionsResponse(UA_DeleteSubscriptionsResponse *out, SV *in);
 
@@ -18942,101 +18264,95 @@ pack_UA_DeleteSubscriptionsResponse(SV *out, UA_DeleteSubscriptionsResponse *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_ResponseHeader(sv, in->responseHeader);
 	hv_stores(hv, "DeleteSubscriptionsResponse_responseHeader", sv);
+	pack_UA_ResponseHeader(sv, &in->responseHeader);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteSubscriptionsResponse_results", newRV_noinc((SV*)av));
 	av_extend(av, in->resultsSize);
 	for (i = 0; i < in->resultsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StatusCode(sv, in->results[i]);
 		av_push(av, sv);
+		pack_UA_StatusCode(sv, &in->results[i]);
 	}
-	hv_stores(hv, "DeleteSubscriptionsResponse_results", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DeleteSubscriptionsResponse_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "DeleteSubscriptionsResponse_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DeleteSubscriptionsResponse(UA_DeleteSubscriptionsResponse *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DeleteSubscriptionsResponse_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DeleteSubscriptionsResponse_responseHeader", 0);
 	if (svp != NULL)
-		out->responseHeader = XS_unpack_UA_ResponseHeader(*svp);
+		unpack_UA_ResponseHeader(&out->responseHeader, *svp);
 
 	svp = hv_fetchs(hv, "DeleteSubscriptionsResponse_results", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteSubscriptionsResponse_results");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->results = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STATUSCODE]);
-		if (out->results == NULL) {
+		if (out->results == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->resultsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->results[i] = XS_unpack_UA_StatusCode(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StatusCode(&out->results[i], *svp);
 		}
-		out->resultsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DeleteSubscriptionsResponse_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DeleteSubscriptionsResponse_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* BuildInfo */
 #ifdef UA_TYPES_BUILDINFO
-static void XS_pack_UA_BuildInfo(SV *out, UA_BuildInfo in)  __attribute__((unused));
-static UA_BuildInfo XS_unpack_UA_BuildInfo(SV *in)  __attribute__((unused));
 static void pack_UA_BuildInfo(SV *out, UA_BuildInfo *in);
 static void unpack_UA_BuildInfo(UA_BuildInfo *out, SV *in);
 
@@ -19045,81 +18361,81 @@ pack_UA_BuildInfo(SV *out, UA_BuildInfo *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->productUri);
-	hv_stores(hv, "BuildInfo_productUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->manufacturerName);
-	hv_stores(hv, "BuildInfo_manufacturerName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->productName);
-	hv_stores(hv, "BuildInfo_productName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->softwareVersion);
-	hv_stores(hv, "BuildInfo_softwareVersion", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->buildNumber);
-	hv_stores(hv, "BuildInfo_buildNumber", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->buildDate);
-	hv_stores(hv, "BuildInfo_buildDate", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "BuildInfo_productUri", sv);
+	pack_UA_String(sv, &in->productUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "BuildInfo_manufacturerName", sv);
+	pack_UA_String(sv, &in->manufacturerName);
+
+	sv = newSV(0);
+	hv_stores(hv, "BuildInfo_productName", sv);
+	pack_UA_String(sv, &in->productName);
+
+	sv = newSV(0);
+	hv_stores(hv, "BuildInfo_softwareVersion", sv);
+	pack_UA_String(sv, &in->softwareVersion);
+
+	sv = newSV(0);
+	hv_stores(hv, "BuildInfo_buildNumber", sv);
+	pack_UA_String(sv, &in->buildNumber);
+
+	sv = newSV(0);
+	hv_stores(hv, "BuildInfo_buildDate", sv);
+	pack_UA_DateTime(sv, &in->buildDate);
+
+	return;
 }
 
 static void
 unpack_UA_BuildInfo(UA_BuildInfo *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_BuildInfo_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "BuildInfo_productUri", 0);
 	if (svp != NULL)
-		out->productUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->productUri, *svp);
 
 	svp = hv_fetchs(hv, "BuildInfo_manufacturerName", 0);
 	if (svp != NULL)
-		out->manufacturerName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->manufacturerName, *svp);
 
 	svp = hv_fetchs(hv, "BuildInfo_productName", 0);
 	if (svp != NULL)
-		out->productName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->productName, *svp);
 
 	svp = hv_fetchs(hv, "BuildInfo_softwareVersion", 0);
 	if (svp != NULL)
-		out->softwareVersion = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->softwareVersion, *svp);
 
 	svp = hv_fetchs(hv, "BuildInfo_buildNumber", 0);
 	if (svp != NULL)
-		out->buildNumber = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->buildNumber, *svp);
 
 	svp = hv_fetchs(hv, "BuildInfo_buildDate", 0);
 	if (svp != NULL)
-		out->buildDate = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->buildDate, *svp);
 
-
+	return;
 }
 #endif
 
 /* RedundancySupport */
 #ifdef UA_TYPES_REDUNDANCYSUPPORT
-static void XS_pack_UA_RedundancySupport(SV *out, UA_RedundancySupport in)  __attribute__((unused));
-static UA_RedundancySupport XS_unpack_UA_RedundancySupport(SV *in)  __attribute__((unused));
 static void pack_UA_RedundancySupport(SV *out, UA_RedundancySupport *in);
 static void unpack_UA_RedundancySupport(UA_RedundancySupport *out, SV *in);
 
@@ -19140,8 +18456,6 @@ unpack_UA_RedundancySupport(UA_RedundancySupport *out, SV *in)
 
 /* ServerState */
 #ifdef UA_TYPES_SERVERSTATE
-static void XS_pack_UA_ServerState(SV *out, UA_ServerState in)  __attribute__((unused));
-static UA_ServerState XS_unpack_UA_ServerState(SV *in)  __attribute__((unused));
 static void pack_UA_ServerState(SV *out, UA_ServerState *in);
 static void unpack_UA_ServerState(UA_ServerState *out, SV *in);
 
@@ -19162,8 +18476,6 @@ unpack_UA_ServerState(UA_ServerState *out, SV *in)
 
 /* RedundantServerDataType */
 #ifdef UA_TYPES_REDUNDANTSERVERDATATYPE
-static void XS_pack_UA_RedundantServerDataType(SV *out, UA_RedundantServerDataType in)  __attribute__((unused));
-static UA_RedundantServerDataType XS_unpack_UA_RedundantServerDataType(SV *in)  __attribute__((unused));
 static void pack_UA_RedundantServerDataType(SV *out, UA_RedundantServerDataType *in);
 static void unpack_UA_RedundantServerDataType(UA_RedundantServerDataType *out, SV *in);
 
@@ -19172,57 +18484,57 @@ pack_UA_RedundantServerDataType(SV *out, UA_RedundantServerDataType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->serverId);
-	hv_stores(hv, "RedundantServerDataType_serverId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->serviceLevel);
-	hv_stores(hv, "RedundantServerDataType_serviceLevel", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ServerState(sv, in->serverState);
-	hv_stores(hv, "RedundantServerDataType_serverState", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "RedundantServerDataType_serverId", sv);
+	pack_UA_String(sv, &in->serverId);
+
+	sv = newSV(0);
+	hv_stores(hv, "RedundantServerDataType_serviceLevel", sv);
+	pack_UA_Byte(sv, &in->serviceLevel);
+
+	sv = newSV(0);
+	hv_stores(hv, "RedundantServerDataType_serverState", sv);
+	pack_UA_ServerState(sv, &in->serverState);
+
+	return;
 }
 
 static void
 unpack_UA_RedundantServerDataType(UA_RedundantServerDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_RedundantServerDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "RedundantServerDataType_serverId", 0);
 	if (svp != NULL)
-		out->serverId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->serverId, *svp);
 
 	svp = hv_fetchs(hv, "RedundantServerDataType_serviceLevel", 0);
 	if (svp != NULL)
-		out->serviceLevel = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->serviceLevel, *svp);
 
 	svp = hv_fetchs(hv, "RedundantServerDataType_serverState", 0);
 	if (svp != NULL)
-		out->serverState = XS_unpack_UA_ServerState(*svp);
+		unpack_UA_ServerState(&out->serverState, *svp);
 
-
+	return;
 }
 #endif
 
 /* EndpointUrlListDataType */
 #ifdef UA_TYPES_ENDPOINTURLLISTDATATYPE
-static void XS_pack_UA_EndpointUrlListDataType(SV *out, UA_EndpointUrlListDataType in)  __attribute__((unused));
-static UA_EndpointUrlListDataType XS_unpack_UA_EndpointUrlListDataType(SV *in)  __attribute__((unused));
 static void pack_UA_EndpointUrlListDataType(SV *out, UA_EndpointUrlListDataType *in);
 static void unpack_UA_EndpointUrlListDataType(UA_EndpointUrlListDataType *out, SV *in);
 
@@ -19233,64 +18545,61 @@ pack_UA_EndpointUrlListDataType(SV *out, UA_EndpointUrlListDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "EndpointUrlListDataType_endpointUrlList", newRV_noinc((SV*)av));
 	av_extend(av, in->endpointUrlListSize);
 	for (i = 0; i < in->endpointUrlListSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->endpointUrlList[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->endpointUrlList[i]);
 	}
-	hv_stores(hv, "EndpointUrlListDataType_endpointUrlList", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_EndpointUrlListDataType(UA_EndpointUrlListDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EndpointUrlListDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EndpointUrlListDataType_endpointUrlList", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for EndpointUrlListDataType_endpointUrlList");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->endpointUrlList = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->endpointUrlList == NULL) {
+		if (out->endpointUrlList == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->endpointUrlListSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->endpointUrlList[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->endpointUrlList[i], *svp);
 		}
-		out->endpointUrlListSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* NetworkGroupDataType */
 #ifdef UA_TYPES_NETWORKGROUPDATATYPE
-static void XS_pack_UA_NetworkGroupDataType(SV *out, UA_NetworkGroupDataType in)  __attribute__((unused));
-static UA_NetworkGroupDataType XS_unpack_UA_NetworkGroupDataType(SV *in)  __attribute__((unused));
 static void pack_UA_NetworkGroupDataType(SV *out, UA_NetworkGroupDataType *in);
 static void unpack_UA_NetworkGroupDataType(UA_NetworkGroupDataType *out, SV *in);
 
@@ -19301,72 +18610,69 @@ pack_UA_NetworkGroupDataType(SV *out, UA_NetworkGroupDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->serverUri);
 	hv_stores(hv, "NetworkGroupDataType_serverUri", sv);
+	pack_UA_String(sv, &in->serverUri);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "NetworkGroupDataType_networkPaths", newRV_noinc((SV*)av));
 	av_extend(av, in->networkPathsSize);
 	for (i = 0; i < in->networkPathsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EndpointUrlListDataType(sv, in->networkPaths[i]);
 		av_push(av, sv);
+		pack_UA_EndpointUrlListDataType(sv, &in->networkPaths[i]);
 	}
-	hv_stores(hv, "NetworkGroupDataType_networkPaths", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_NetworkGroupDataType(UA_NetworkGroupDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_NetworkGroupDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "NetworkGroupDataType_serverUri", 0);
 	if (svp != NULL)
-		out->serverUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->serverUri, *svp);
 
 	svp = hv_fetchs(hv, "NetworkGroupDataType_networkPaths", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for NetworkGroupDataType_networkPaths");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->networkPaths = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENDPOINTURLLISTDATATYPE]);
-		if (out->networkPaths == NULL) {
+		if (out->networkPaths == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->networkPathsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->networkPaths[i] = XS_unpack_UA_EndpointUrlListDataType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EndpointUrlListDataType(&out->networkPaths[i], *svp);
 		}
-		out->networkPathsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* SamplingIntervalDiagnosticsDataType */
 #ifdef UA_TYPES_SAMPLINGINTERVALDIAGNOSTICSDATATYPE
-static void XS_pack_UA_SamplingIntervalDiagnosticsDataType(SV *out, UA_SamplingIntervalDiagnosticsDataType in)  __attribute__((unused));
-static UA_SamplingIntervalDiagnosticsDataType XS_unpack_UA_SamplingIntervalDiagnosticsDataType(SV *in)  __attribute__((unused));
 static void pack_UA_SamplingIntervalDiagnosticsDataType(SV *out, UA_SamplingIntervalDiagnosticsDataType *in);
 static void unpack_UA_SamplingIntervalDiagnosticsDataType(UA_SamplingIntervalDiagnosticsDataType *out, SV *in);
 
@@ -19375,65 +18681,65 @@ pack_UA_SamplingIntervalDiagnosticsDataType(SV *out, UA_SamplingIntervalDiagnost
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->samplingInterval);
-	hv_stores(hv, "SamplingIntervalDiagnosticsDataType_samplingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->monitoredItemCount);
-	hv_stores(hv, "SamplingIntervalDiagnosticsDataType_monitoredItemCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxMonitoredItemCount);
-	hv_stores(hv, "SamplingIntervalDiagnosticsDataType_maxMonitoredItemCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->disabledMonitoredItemCount);
-	hv_stores(hv, "SamplingIntervalDiagnosticsDataType_disabledMonitoredItemCount", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "SamplingIntervalDiagnosticsDataType_samplingInterval", sv);
+	pack_UA_Double(sv, &in->samplingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "SamplingIntervalDiagnosticsDataType_monitoredItemCount", sv);
+	pack_UA_UInt32(sv, &in->monitoredItemCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SamplingIntervalDiagnosticsDataType_maxMonitoredItemCount", sv);
+	pack_UA_UInt32(sv, &in->maxMonitoredItemCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SamplingIntervalDiagnosticsDataType_disabledMonitoredItemCount", sv);
+	pack_UA_UInt32(sv, &in->disabledMonitoredItemCount);
+
+	return;
 }
 
 static void
 unpack_UA_SamplingIntervalDiagnosticsDataType(UA_SamplingIntervalDiagnosticsDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SamplingIntervalDiagnosticsDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SamplingIntervalDiagnosticsDataType_samplingInterval", 0);
 	if (svp != NULL)
-		out->samplingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->samplingInterval, *svp);
 
 	svp = hv_fetchs(hv, "SamplingIntervalDiagnosticsDataType_monitoredItemCount", 0);
 	if (svp != NULL)
-		out->monitoredItemCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->monitoredItemCount, *svp);
 
 	svp = hv_fetchs(hv, "SamplingIntervalDiagnosticsDataType_maxMonitoredItemCount", 0);
 	if (svp != NULL)
-		out->maxMonitoredItemCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxMonitoredItemCount, *svp);
 
 	svp = hv_fetchs(hv, "SamplingIntervalDiagnosticsDataType_disabledMonitoredItemCount", 0);
 	if (svp != NULL)
-		out->disabledMonitoredItemCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->disabledMonitoredItemCount, *svp);
 
-
+	return;
 }
 #endif
 
 /* ServerDiagnosticsSummaryDataType */
 #ifdef UA_TYPES_SERVERDIAGNOSTICSSUMMARYDATATYPE
-static void XS_pack_UA_ServerDiagnosticsSummaryDataType(SV *out, UA_ServerDiagnosticsSummaryDataType in)  __attribute__((unused));
-static UA_ServerDiagnosticsSummaryDataType XS_unpack_UA_ServerDiagnosticsSummaryDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ServerDiagnosticsSummaryDataType(SV *out, UA_ServerDiagnosticsSummaryDataType *in);
 static void unpack_UA_ServerDiagnosticsSummaryDataType(UA_ServerDiagnosticsSummaryDataType *out, SV *in);
 
@@ -19442,129 +18748,129 @@ pack_UA_ServerDiagnosticsSummaryDataType(SV *out, UA_ServerDiagnosticsSummaryDat
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->serverViewCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_serverViewCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->currentSessionCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_currentSessionCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->cumulatedSessionCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_cumulatedSessionCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->securityRejectedSessionCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_securityRejectedSessionCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->rejectedSessionCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_rejectedSessionCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->sessionTimeoutCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_sessionTimeoutCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->sessionAbortCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_sessionAbortCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->currentSubscriptionCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_currentSubscriptionCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->cumulatedSubscriptionCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_cumulatedSubscriptionCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->publishingIntervalCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_publishingIntervalCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->securityRejectedRequestsCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_securityRejectedRequestsCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->rejectedRequestsCount);
-	hv_stores(hv, "ServerDiagnosticsSummaryDataType_rejectedRequestsCount", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_serverViewCount", sv);
+	pack_UA_UInt32(sv, &in->serverViewCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_currentSessionCount", sv);
+	pack_UA_UInt32(sv, &in->currentSessionCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_cumulatedSessionCount", sv);
+	pack_UA_UInt32(sv, &in->cumulatedSessionCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_securityRejectedSessionCount", sv);
+	pack_UA_UInt32(sv, &in->securityRejectedSessionCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_rejectedSessionCount", sv);
+	pack_UA_UInt32(sv, &in->rejectedSessionCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_sessionTimeoutCount", sv);
+	pack_UA_UInt32(sv, &in->sessionTimeoutCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_sessionAbortCount", sv);
+	pack_UA_UInt32(sv, &in->sessionAbortCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_currentSubscriptionCount", sv);
+	pack_UA_UInt32(sv, &in->currentSubscriptionCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_cumulatedSubscriptionCount", sv);
+	pack_UA_UInt32(sv, &in->cumulatedSubscriptionCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_publishingIntervalCount", sv);
+	pack_UA_UInt32(sv, &in->publishingIntervalCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_securityRejectedRequestsCount", sv);
+	pack_UA_UInt32(sv, &in->securityRejectedRequestsCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerDiagnosticsSummaryDataType_rejectedRequestsCount", sv);
+	pack_UA_UInt32(sv, &in->rejectedRequestsCount);
+
+	return;
 }
 
 static void
 unpack_UA_ServerDiagnosticsSummaryDataType(UA_ServerDiagnosticsSummaryDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ServerDiagnosticsSummaryDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_serverViewCount", 0);
 	if (svp != NULL)
-		out->serverViewCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->serverViewCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_currentSessionCount", 0);
 	if (svp != NULL)
-		out->currentSessionCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->currentSessionCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_cumulatedSessionCount", 0);
 	if (svp != NULL)
-		out->cumulatedSessionCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->cumulatedSessionCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_securityRejectedSessionCount", 0);
 	if (svp != NULL)
-		out->securityRejectedSessionCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->securityRejectedSessionCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_rejectedSessionCount", 0);
 	if (svp != NULL)
-		out->rejectedSessionCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->rejectedSessionCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_sessionTimeoutCount", 0);
 	if (svp != NULL)
-		out->sessionTimeoutCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->sessionTimeoutCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_sessionAbortCount", 0);
 	if (svp != NULL)
-		out->sessionAbortCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->sessionAbortCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_currentSubscriptionCount", 0);
 	if (svp != NULL)
-		out->currentSubscriptionCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->currentSubscriptionCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_cumulatedSubscriptionCount", 0);
 	if (svp != NULL)
-		out->cumulatedSubscriptionCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->cumulatedSubscriptionCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_publishingIntervalCount", 0);
 	if (svp != NULL)
-		out->publishingIntervalCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->publishingIntervalCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_securityRejectedRequestsCount", 0);
 	if (svp != NULL)
-		out->securityRejectedRequestsCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->securityRejectedRequestsCount, *svp);
 
 	svp = hv_fetchs(hv, "ServerDiagnosticsSummaryDataType_rejectedRequestsCount", 0);
 	if (svp != NULL)
-		out->rejectedRequestsCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->rejectedRequestsCount, *svp);
 
-
+	return;
 }
 #endif
 
 /* ServerStatusDataType */
 #ifdef UA_TYPES_SERVERSTATUSDATATYPE
-static void XS_pack_UA_ServerStatusDataType(SV *out, UA_ServerStatusDataType in)  __attribute__((unused));
-static UA_ServerStatusDataType XS_unpack_UA_ServerStatusDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ServerStatusDataType(SV *out, UA_ServerStatusDataType *in);
 static void unpack_UA_ServerStatusDataType(UA_ServerStatusDataType *out, SV *in);
 
@@ -19573,81 +18879,81 @@ pack_UA_ServerStatusDataType(SV *out, UA_ServerStatusDataType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->startTime);
-	hv_stores(hv, "ServerStatusDataType_startTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->currentTime);
-	hv_stores(hv, "ServerStatusDataType_currentTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_ServerState(sv, in->state);
-	hv_stores(hv, "ServerStatusDataType_state", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_BuildInfo(sv, in->buildInfo);
-	hv_stores(hv, "ServerStatusDataType_buildInfo", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->secondsTillShutdown);
-	hv_stores(hv, "ServerStatusDataType_secondsTillShutdown", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->shutdownReason);
-	hv_stores(hv, "ServerStatusDataType_shutdownReason", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerStatusDataType_startTime", sv);
+	pack_UA_DateTime(sv, &in->startTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerStatusDataType_currentTime", sv);
+	pack_UA_DateTime(sv, &in->currentTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerStatusDataType_state", sv);
+	pack_UA_ServerState(sv, &in->state);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerStatusDataType_buildInfo", sv);
+	pack_UA_BuildInfo(sv, &in->buildInfo);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerStatusDataType_secondsTillShutdown", sv);
+	pack_UA_UInt32(sv, &in->secondsTillShutdown);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServerStatusDataType_shutdownReason", sv);
+	pack_UA_LocalizedText(sv, &in->shutdownReason);
+
+	return;
 }
 
 static void
 unpack_UA_ServerStatusDataType(UA_ServerStatusDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ServerStatusDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ServerStatusDataType_startTime", 0);
 	if (svp != NULL)
-		out->startTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->startTime, *svp);
 
 	svp = hv_fetchs(hv, "ServerStatusDataType_currentTime", 0);
 	if (svp != NULL)
-		out->currentTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->currentTime, *svp);
 
 	svp = hv_fetchs(hv, "ServerStatusDataType_state", 0);
 	if (svp != NULL)
-		out->state = XS_unpack_UA_ServerState(*svp);
+		unpack_UA_ServerState(&out->state, *svp);
 
 	svp = hv_fetchs(hv, "ServerStatusDataType_buildInfo", 0);
 	if (svp != NULL)
-		out->buildInfo = XS_unpack_UA_BuildInfo(*svp);
+		unpack_UA_BuildInfo(&out->buildInfo, *svp);
 
 	svp = hv_fetchs(hv, "ServerStatusDataType_secondsTillShutdown", 0);
 	if (svp != NULL)
-		out->secondsTillShutdown = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->secondsTillShutdown, *svp);
 
 	svp = hv_fetchs(hv, "ServerStatusDataType_shutdownReason", 0);
 	if (svp != NULL)
-		out->shutdownReason = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->shutdownReason, *svp);
 
-
+	return;
 }
 #endif
 
 /* SessionSecurityDiagnosticsDataType */
 #ifdef UA_TYPES_SESSIONSECURITYDIAGNOSTICSDATATYPE
-static void XS_pack_UA_SessionSecurityDiagnosticsDataType(SV *out, UA_SessionSecurityDiagnosticsDataType in)  __attribute__((unused));
-static UA_SessionSecurityDiagnosticsDataType XS_unpack_UA_SessionSecurityDiagnosticsDataType(SV *in)  __attribute__((unused));
 static void pack_UA_SessionSecurityDiagnosticsDataType(SV *out, UA_SessionSecurityDiagnosticsDataType *in);
 static void unpack_UA_SessionSecurityDiagnosticsDataType(UA_SessionSecurityDiagnosticsDataType *out, SV *in);
 
@@ -19658,128 +18964,125 @@ pack_UA_SessionSecurityDiagnosticsDataType(SV *out, UA_SessionSecurityDiagnostic
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->sessionId);
 	hv_stores(hv, "SessionSecurityDiagnosticsDataType_sessionId", sv);
+	pack_UA_NodeId(sv, &in->sessionId);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->clientUserIdOfSession);
 	hv_stores(hv, "SessionSecurityDiagnosticsDataType_clientUserIdOfSession", sv);
+	pack_UA_String(sv, &in->clientUserIdOfSession);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SessionSecurityDiagnosticsDataType_clientUserIdHistory", newRV_noinc((SV*)av));
 	av_extend(av, in->clientUserIdHistorySize);
 	for (i = 0; i < in->clientUserIdHistorySize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->clientUserIdHistory[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->clientUserIdHistory[i]);
 	}
-	hv_stores(hv, "SessionSecurityDiagnosticsDataType_clientUserIdHistory", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->authenticationMechanism);
 	hv_stores(hv, "SessionSecurityDiagnosticsDataType_authenticationMechanism", sv);
+	pack_UA_String(sv, &in->authenticationMechanism);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->encoding);
 	hv_stores(hv, "SessionSecurityDiagnosticsDataType_encoding", sv);
+	pack_UA_String(sv, &in->encoding);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->transportProtocol);
 	hv_stores(hv, "SessionSecurityDiagnosticsDataType_transportProtocol", sv);
+	pack_UA_String(sv, &in->transportProtocol);
 
 	sv = newSV(0);
-	XS_pack_UA_MessageSecurityMode(sv, in->securityMode);
 	hv_stores(hv, "SessionSecurityDiagnosticsDataType_securityMode", sv);
+	pack_UA_MessageSecurityMode(sv, &in->securityMode);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->securityPolicyUri);
 	hv_stores(hv, "SessionSecurityDiagnosticsDataType_securityPolicyUri", sv);
+	pack_UA_String(sv, &in->securityPolicyUri);
 
 	sv = newSV(0);
-	XS_pack_UA_ByteString(sv, in->clientCertificate);
 	hv_stores(hv, "SessionSecurityDiagnosticsDataType_clientCertificate", sv);
+	pack_UA_ByteString(sv, &in->clientCertificate);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SessionSecurityDiagnosticsDataType(UA_SessionSecurityDiagnosticsDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SessionSecurityDiagnosticsDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SessionSecurityDiagnosticsDataType_sessionId", 0);
 	if (svp != NULL)
-		out->sessionId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->sessionId, *svp);
 
 	svp = hv_fetchs(hv, "SessionSecurityDiagnosticsDataType_clientUserIdOfSession", 0);
 	if (svp != NULL)
-		out->clientUserIdOfSession = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->clientUserIdOfSession, *svp);
 
 	svp = hv_fetchs(hv, "SessionSecurityDiagnosticsDataType_clientUserIdHistory", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SessionSecurityDiagnosticsDataType_clientUserIdHistory");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->clientUserIdHistory = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->clientUserIdHistory == NULL) {
+		if (out->clientUserIdHistory == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->clientUserIdHistorySize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->clientUserIdHistory[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->clientUserIdHistory[i], *svp);
 		}
-		out->clientUserIdHistorySize = i;
 	}
 
 	svp = hv_fetchs(hv, "SessionSecurityDiagnosticsDataType_authenticationMechanism", 0);
 	if (svp != NULL)
-		out->authenticationMechanism = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->authenticationMechanism, *svp);
 
 	svp = hv_fetchs(hv, "SessionSecurityDiagnosticsDataType_encoding", 0);
 	if (svp != NULL)
-		out->encoding = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->encoding, *svp);
 
 	svp = hv_fetchs(hv, "SessionSecurityDiagnosticsDataType_transportProtocol", 0);
 	if (svp != NULL)
-		out->transportProtocol = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->transportProtocol, *svp);
 
 	svp = hv_fetchs(hv, "SessionSecurityDiagnosticsDataType_securityMode", 0);
 	if (svp != NULL)
-		out->securityMode = XS_unpack_UA_MessageSecurityMode(*svp);
+		unpack_UA_MessageSecurityMode(&out->securityMode, *svp);
 
 	svp = hv_fetchs(hv, "SessionSecurityDiagnosticsDataType_securityPolicyUri", 0);
 	if (svp != NULL)
-		out->securityPolicyUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->securityPolicyUri, *svp);
 
 	svp = hv_fetchs(hv, "SessionSecurityDiagnosticsDataType_clientCertificate", 0);
 	if (svp != NULL)
-		out->clientCertificate = XS_unpack_UA_ByteString(*svp);
+		unpack_UA_ByteString(&out->clientCertificate, *svp);
 
-
+	return;
 }
 #endif
 
 /* ServiceCounterDataType */
 #ifdef UA_TYPES_SERVICECOUNTERDATATYPE
-static void XS_pack_UA_ServiceCounterDataType(SV *out, UA_ServiceCounterDataType in)  __attribute__((unused));
-static UA_ServiceCounterDataType XS_unpack_UA_ServiceCounterDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ServiceCounterDataType(SV *out, UA_ServiceCounterDataType *in);
 static void unpack_UA_ServiceCounterDataType(UA_ServiceCounterDataType *out, SV *in);
 
@@ -19788,49 +19091,49 @@ pack_UA_ServiceCounterDataType(SV *out, UA_ServiceCounterDataType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->totalCount);
-	hv_stores(hv, "ServiceCounterDataType_totalCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->errorCount);
-	hv_stores(hv, "ServiceCounterDataType_errorCount", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ServiceCounterDataType_totalCount", sv);
+	pack_UA_UInt32(sv, &in->totalCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "ServiceCounterDataType_errorCount", sv);
+	pack_UA_UInt32(sv, &in->errorCount);
+
+	return;
 }
 
 static void
 unpack_UA_ServiceCounterDataType(UA_ServiceCounterDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ServiceCounterDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ServiceCounterDataType_totalCount", 0);
 	if (svp != NULL)
-		out->totalCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->totalCount, *svp);
 
 	svp = hv_fetchs(hv, "ServiceCounterDataType_errorCount", 0);
 	if (svp != NULL)
-		out->errorCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->errorCount, *svp);
 
-
+	return;
 }
 #endif
 
 /* StatusResult */
 #ifdef UA_TYPES_STATUSRESULT
-static void XS_pack_UA_StatusResult(SV *out, UA_StatusResult in)  __attribute__((unused));
-static UA_StatusResult XS_unpack_UA_StatusResult(SV *in)  __attribute__((unused));
 static void pack_UA_StatusResult(SV *out, UA_StatusResult *in);
 static void unpack_UA_StatusResult(UA_StatusResult *out, SV *in);
 
@@ -19839,49 +19142,49 @@ pack_UA_StatusResult(SV *out, UA_StatusResult *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->statusCode);
-	hv_stores(hv, "StatusResult_statusCode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfo);
-	hv_stores(hv, "StatusResult_diagnosticInfo", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "StatusResult_statusCode", sv);
+	pack_UA_StatusCode(sv, &in->statusCode);
+
+	sv = newSV(0);
+	hv_stores(hv, "StatusResult_diagnosticInfo", sv);
+	pack_UA_DiagnosticInfo(sv, &in->diagnosticInfo);
+
+	return;
 }
 
 static void
 unpack_UA_StatusResult(UA_StatusResult *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_StatusResult_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "StatusResult_statusCode", 0);
 	if (svp != NULL)
-		out->statusCode = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->statusCode, *svp);
 
 	svp = hv_fetchs(hv, "StatusResult_diagnosticInfo", 0);
 	if (svp != NULL)
-		out->diagnosticInfo = XS_unpack_UA_DiagnosticInfo(*svp);
+		unpack_UA_DiagnosticInfo(&out->diagnosticInfo, *svp);
 
-
+	return;
 }
 #endif
 
 /* SubscriptionDiagnosticsDataType */
 #ifdef UA_TYPES_SUBSCRIPTIONDIAGNOSTICSDATATYPE
-static void XS_pack_UA_SubscriptionDiagnosticsDataType(SV *out, UA_SubscriptionDiagnosticsDataType in)  __attribute__((unused));
-static UA_SubscriptionDiagnosticsDataType XS_unpack_UA_SubscriptionDiagnosticsDataType(SV *in)  __attribute__((unused));
 static void pack_UA_SubscriptionDiagnosticsDataType(SV *out, UA_SubscriptionDiagnosticsDataType *in);
 static void unpack_UA_SubscriptionDiagnosticsDataType(UA_SubscriptionDiagnosticsDataType *out, SV *in);
 
@@ -19890,281 +19193,281 @@ pack_UA_SubscriptionDiagnosticsDataType(SV *out, UA_SubscriptionDiagnosticsDataT
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->sessionId);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_sessionId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->subscriptionId);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_subscriptionId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->priority);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_priority", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->publishingInterval);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_publishingInterval", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxKeepAliveCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_maxKeepAliveCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxLifetimeCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_maxLifetimeCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxNotificationsPerPublish);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_maxNotificationsPerPublish", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->publishingEnabled);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_publishingEnabled", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->modifyCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_modifyCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->enableCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_enableCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->disableCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_disableCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->republishRequestCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_republishRequestCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->republishMessageRequestCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_republishMessageRequestCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->republishMessageCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_republishMessageCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->transferRequestCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_transferRequestCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->transferredToAltClientCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_transferredToAltClientCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->transferredToSameClientCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_transferredToSameClientCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->publishRequestCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_publishRequestCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->dataChangeNotificationsCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_dataChangeNotificationsCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->eventNotificationsCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_eventNotificationsCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->notificationsCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_notificationsCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->latePublishRequestCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_latePublishRequestCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->currentKeepAliveCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_currentKeepAliveCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->currentLifetimeCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_currentLifetimeCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->unacknowledgedMessageCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_unacknowledgedMessageCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->discardedMessageCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_discardedMessageCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->monitoredItemCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_monitoredItemCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->disabledMonitoredItemCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_disabledMonitoredItemCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->monitoringQueueOverflowCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_monitoringQueueOverflowCount", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->nextSequenceNumber);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_nextSequenceNumber", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->eventQueueOverFlowCount);
-	hv_stores(hv, "SubscriptionDiagnosticsDataType_eventQueueOverFlowCount", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_sessionId", sv);
+	pack_UA_NodeId(sv, &in->sessionId);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_subscriptionId", sv);
+	pack_UA_UInt32(sv, &in->subscriptionId);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_priority", sv);
+	pack_UA_Byte(sv, &in->priority);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_publishingInterval", sv);
+	pack_UA_Double(sv, &in->publishingInterval);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_maxKeepAliveCount", sv);
+	pack_UA_UInt32(sv, &in->maxKeepAliveCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_maxLifetimeCount", sv);
+	pack_UA_UInt32(sv, &in->maxLifetimeCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_maxNotificationsPerPublish", sv);
+	pack_UA_UInt32(sv, &in->maxNotificationsPerPublish);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_publishingEnabled", sv);
+	pack_UA_Boolean(sv, &in->publishingEnabled);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_modifyCount", sv);
+	pack_UA_UInt32(sv, &in->modifyCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_enableCount", sv);
+	pack_UA_UInt32(sv, &in->enableCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_disableCount", sv);
+	pack_UA_UInt32(sv, &in->disableCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_republishRequestCount", sv);
+	pack_UA_UInt32(sv, &in->republishRequestCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_republishMessageRequestCount", sv);
+	pack_UA_UInt32(sv, &in->republishMessageRequestCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_republishMessageCount", sv);
+	pack_UA_UInt32(sv, &in->republishMessageCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_transferRequestCount", sv);
+	pack_UA_UInt32(sv, &in->transferRequestCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_transferredToAltClientCount", sv);
+	pack_UA_UInt32(sv, &in->transferredToAltClientCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_transferredToSameClientCount", sv);
+	pack_UA_UInt32(sv, &in->transferredToSameClientCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_publishRequestCount", sv);
+	pack_UA_UInt32(sv, &in->publishRequestCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_dataChangeNotificationsCount", sv);
+	pack_UA_UInt32(sv, &in->dataChangeNotificationsCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_eventNotificationsCount", sv);
+	pack_UA_UInt32(sv, &in->eventNotificationsCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_notificationsCount", sv);
+	pack_UA_UInt32(sv, &in->notificationsCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_latePublishRequestCount", sv);
+	pack_UA_UInt32(sv, &in->latePublishRequestCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_currentKeepAliveCount", sv);
+	pack_UA_UInt32(sv, &in->currentKeepAliveCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_currentLifetimeCount", sv);
+	pack_UA_UInt32(sv, &in->currentLifetimeCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_unacknowledgedMessageCount", sv);
+	pack_UA_UInt32(sv, &in->unacknowledgedMessageCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_discardedMessageCount", sv);
+	pack_UA_UInt32(sv, &in->discardedMessageCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_monitoredItemCount", sv);
+	pack_UA_UInt32(sv, &in->monitoredItemCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_disabledMonitoredItemCount", sv);
+	pack_UA_UInt32(sv, &in->disabledMonitoredItemCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_monitoringQueueOverflowCount", sv);
+	pack_UA_UInt32(sv, &in->monitoringQueueOverflowCount);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_nextSequenceNumber", sv);
+	pack_UA_UInt32(sv, &in->nextSequenceNumber);
+
+	sv = newSV(0);
+	hv_stores(hv, "SubscriptionDiagnosticsDataType_eventQueueOverFlowCount", sv);
+	pack_UA_UInt32(sv, &in->eventQueueOverFlowCount);
+
+	return;
 }
 
 static void
 unpack_UA_SubscriptionDiagnosticsDataType(UA_SubscriptionDiagnosticsDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SubscriptionDiagnosticsDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_sessionId", 0);
 	if (svp != NULL)
-		out->sessionId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->sessionId, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_subscriptionId", 0);
 	if (svp != NULL)
-		out->subscriptionId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->subscriptionId, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_priority", 0);
 	if (svp != NULL)
-		out->priority = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->priority, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_publishingInterval", 0);
 	if (svp != NULL)
-		out->publishingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->publishingInterval, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_maxKeepAliveCount", 0);
 	if (svp != NULL)
-		out->maxKeepAliveCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxKeepAliveCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_maxLifetimeCount", 0);
 	if (svp != NULL)
-		out->maxLifetimeCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxLifetimeCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_maxNotificationsPerPublish", 0);
 	if (svp != NULL)
-		out->maxNotificationsPerPublish = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxNotificationsPerPublish, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_publishingEnabled", 0);
 	if (svp != NULL)
-		out->publishingEnabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->publishingEnabled, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_modifyCount", 0);
 	if (svp != NULL)
-		out->modifyCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->modifyCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_enableCount", 0);
 	if (svp != NULL)
-		out->enableCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->enableCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_disableCount", 0);
 	if (svp != NULL)
-		out->disableCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->disableCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_republishRequestCount", 0);
 	if (svp != NULL)
-		out->republishRequestCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->republishRequestCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_republishMessageRequestCount", 0);
 	if (svp != NULL)
-		out->republishMessageRequestCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->republishMessageRequestCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_republishMessageCount", 0);
 	if (svp != NULL)
-		out->republishMessageCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->republishMessageCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_transferRequestCount", 0);
 	if (svp != NULL)
-		out->transferRequestCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->transferRequestCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_transferredToAltClientCount", 0);
 	if (svp != NULL)
-		out->transferredToAltClientCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->transferredToAltClientCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_transferredToSameClientCount", 0);
 	if (svp != NULL)
-		out->transferredToSameClientCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->transferredToSameClientCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_publishRequestCount", 0);
 	if (svp != NULL)
-		out->publishRequestCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->publishRequestCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_dataChangeNotificationsCount", 0);
 	if (svp != NULL)
-		out->dataChangeNotificationsCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->dataChangeNotificationsCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_eventNotificationsCount", 0);
 	if (svp != NULL)
-		out->eventNotificationsCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->eventNotificationsCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_notificationsCount", 0);
 	if (svp != NULL)
-		out->notificationsCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->notificationsCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_latePublishRequestCount", 0);
 	if (svp != NULL)
-		out->latePublishRequestCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->latePublishRequestCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_currentKeepAliveCount", 0);
 	if (svp != NULL)
-		out->currentKeepAliveCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->currentKeepAliveCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_currentLifetimeCount", 0);
 	if (svp != NULL)
-		out->currentLifetimeCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->currentLifetimeCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_unacknowledgedMessageCount", 0);
 	if (svp != NULL)
-		out->unacknowledgedMessageCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->unacknowledgedMessageCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_discardedMessageCount", 0);
 	if (svp != NULL)
-		out->discardedMessageCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->discardedMessageCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_monitoredItemCount", 0);
 	if (svp != NULL)
-		out->monitoredItemCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->monitoredItemCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_disabledMonitoredItemCount", 0);
 	if (svp != NULL)
-		out->disabledMonitoredItemCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->disabledMonitoredItemCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_monitoringQueueOverflowCount", 0);
 	if (svp != NULL)
-		out->monitoringQueueOverflowCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->monitoringQueueOverflowCount, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_nextSequenceNumber", 0);
 	if (svp != NULL)
-		out->nextSequenceNumber = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->nextSequenceNumber, *svp);
 
 	svp = hv_fetchs(hv, "SubscriptionDiagnosticsDataType_eventQueueOverFlowCount", 0);
 	if (svp != NULL)
-		out->eventQueueOverFlowCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->eventQueueOverFlowCount, *svp);
 
-
+	return;
 }
 #endif
 
 /* ModelChangeStructureVerbMask */
 #ifdef UA_TYPES_MODELCHANGESTRUCTUREVERBMASK
-static void XS_pack_UA_ModelChangeStructureVerbMask(SV *out, UA_ModelChangeStructureVerbMask in)  __attribute__((unused));
-static UA_ModelChangeStructureVerbMask XS_unpack_UA_ModelChangeStructureVerbMask(SV *in)  __attribute__((unused));
 static void pack_UA_ModelChangeStructureVerbMask(SV *out, UA_ModelChangeStructureVerbMask *in);
 static void unpack_UA_ModelChangeStructureVerbMask(UA_ModelChangeStructureVerbMask *out, SV *in);
 
@@ -20185,8 +19488,6 @@ unpack_UA_ModelChangeStructureVerbMask(UA_ModelChangeStructureVerbMask *out, SV 
 
 /* ModelChangeStructureDataType */
 #ifdef UA_TYPES_MODELCHANGESTRUCTUREDATATYPE
-static void XS_pack_UA_ModelChangeStructureDataType(SV *out, UA_ModelChangeStructureDataType in)  __attribute__((unused));
-static UA_ModelChangeStructureDataType XS_unpack_UA_ModelChangeStructureDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ModelChangeStructureDataType(SV *out, UA_ModelChangeStructureDataType *in);
 static void unpack_UA_ModelChangeStructureDataType(UA_ModelChangeStructureDataType *out, SV *in);
 
@@ -20195,57 +19496,57 @@ pack_UA_ModelChangeStructureDataType(SV *out, UA_ModelChangeStructureDataType *i
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->affected);
-	hv_stores(hv, "ModelChangeStructureDataType_affected", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->affectedType);
-	hv_stores(hv, "ModelChangeStructureDataType_affectedType", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->verb);
-	hv_stores(hv, "ModelChangeStructureDataType_verb", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ModelChangeStructureDataType_affected", sv);
+	pack_UA_NodeId(sv, &in->affected);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModelChangeStructureDataType_affectedType", sv);
+	pack_UA_NodeId(sv, &in->affectedType);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModelChangeStructureDataType_verb", sv);
+	pack_UA_Byte(sv, &in->verb);
+
+	return;
 }
 
 static void
 unpack_UA_ModelChangeStructureDataType(UA_ModelChangeStructureDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ModelChangeStructureDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ModelChangeStructureDataType_affected", 0);
 	if (svp != NULL)
-		out->affected = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->affected, *svp);
 
 	svp = hv_fetchs(hv, "ModelChangeStructureDataType_affectedType", 0);
 	if (svp != NULL)
-		out->affectedType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->affectedType, *svp);
 
 	svp = hv_fetchs(hv, "ModelChangeStructureDataType_verb", 0);
 	if (svp != NULL)
-		out->verb = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->verb, *svp);
 
-
+	return;
 }
 #endif
 
 /* SemanticChangeStructureDataType */
 #ifdef UA_TYPES_SEMANTICCHANGESTRUCTUREDATATYPE
-static void XS_pack_UA_SemanticChangeStructureDataType(SV *out, UA_SemanticChangeStructureDataType in)  __attribute__((unused));
-static UA_SemanticChangeStructureDataType XS_unpack_UA_SemanticChangeStructureDataType(SV *in)  __attribute__((unused));
 static void pack_UA_SemanticChangeStructureDataType(SV *out, UA_SemanticChangeStructureDataType *in);
 static void unpack_UA_SemanticChangeStructureDataType(UA_SemanticChangeStructureDataType *out, SV *in);
 
@@ -20254,49 +19555,49 @@ pack_UA_SemanticChangeStructureDataType(SV *out, UA_SemanticChangeStructureDataT
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->affected);
-	hv_stores(hv, "SemanticChangeStructureDataType_affected", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->affectedType);
-	hv_stores(hv, "SemanticChangeStructureDataType_affectedType", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "SemanticChangeStructureDataType_affected", sv);
+	pack_UA_NodeId(sv, &in->affected);
+
+	sv = newSV(0);
+	hv_stores(hv, "SemanticChangeStructureDataType_affectedType", sv);
+	pack_UA_NodeId(sv, &in->affectedType);
+
+	return;
 }
 
 static void
 unpack_UA_SemanticChangeStructureDataType(UA_SemanticChangeStructureDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SemanticChangeStructureDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SemanticChangeStructureDataType_affected", 0);
 	if (svp != NULL)
-		out->affected = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->affected, *svp);
 
 	svp = hv_fetchs(hv, "SemanticChangeStructureDataType_affectedType", 0);
 	if (svp != NULL)
-		out->affectedType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->affectedType, *svp);
 
-
+	return;
 }
 #endif
 
 /* Range */
 #ifdef UA_TYPES_RANGE
-static void XS_pack_UA_Range(SV *out, UA_Range in)  __attribute__((unused));
-static UA_Range XS_unpack_UA_Range(SV *in)  __attribute__((unused));
 static void pack_UA_Range(SV *out, UA_Range *in);
 static void unpack_UA_Range(UA_Range *out, SV *in);
 
@@ -20305,49 +19606,49 @@ pack_UA_Range(SV *out, UA_Range *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->low);
-	hv_stores(hv, "Range_low", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->high);
-	hv_stores(hv, "Range_high", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "Range_low", sv);
+	pack_UA_Double(sv, &in->low);
+
+	sv = newSV(0);
+	hv_stores(hv, "Range_high", sv);
+	pack_UA_Double(sv, &in->high);
+
+	return;
 }
 
 static void
 unpack_UA_Range(UA_Range *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_Range_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "Range_low", 0);
 	if (svp != NULL)
-		out->low = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->low, *svp);
 
 	svp = hv_fetchs(hv, "Range_high", 0);
 	if (svp != NULL)
-		out->high = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->high, *svp);
 
-
+	return;
 }
 #endif
 
 /* EUInformation */
 #ifdef UA_TYPES_EUINFORMATION
-static void XS_pack_UA_EUInformation(SV *out, UA_EUInformation in)  __attribute__((unused));
-static UA_EUInformation XS_unpack_UA_EUInformation(SV *in)  __attribute__((unused));
 static void pack_UA_EUInformation(SV *out, UA_EUInformation *in);
 static void unpack_UA_EUInformation(UA_EUInformation *out, SV *in);
 
@@ -20356,65 +19657,65 @@ pack_UA_EUInformation(SV *out, UA_EUInformation *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->namespaceUri);
-	hv_stores(hv, "EUInformation_namespaceUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->unitId);
-	hv_stores(hv, "EUInformation_unitId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->displayName);
-	hv_stores(hv, "EUInformation_displayName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
-	hv_stores(hv, "EUInformation_description", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "EUInformation_namespaceUri", sv);
+	pack_UA_String(sv, &in->namespaceUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "EUInformation_unitId", sv);
+	pack_UA_Int32(sv, &in->unitId);
+
+	sv = newSV(0);
+	hv_stores(hv, "EUInformation_displayName", sv);
+	pack_UA_LocalizedText(sv, &in->displayName);
+
+	sv = newSV(0);
+	hv_stores(hv, "EUInformation_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
+
+	return;
 }
 
 static void
 unpack_UA_EUInformation(UA_EUInformation *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EUInformation_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EUInformation_namespaceUri", 0);
 	if (svp != NULL)
-		out->namespaceUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->namespaceUri, *svp);
 
 	svp = hv_fetchs(hv, "EUInformation_unitId", 0);
 	if (svp != NULL)
-		out->unitId = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->unitId, *svp);
 
 	svp = hv_fetchs(hv, "EUInformation_displayName", 0);
 	if (svp != NULL)
-		out->displayName = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->displayName, *svp);
 
 	svp = hv_fetchs(hv, "EUInformation_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
-
+	return;
 }
 #endif
 
 /* AxisScaleEnumeration */
 #ifdef UA_TYPES_AXISSCALEENUMERATION
-static void XS_pack_UA_AxisScaleEnumeration(SV *out, UA_AxisScaleEnumeration in)  __attribute__((unused));
-static UA_AxisScaleEnumeration XS_unpack_UA_AxisScaleEnumeration(SV *in)  __attribute__((unused));
 static void pack_UA_AxisScaleEnumeration(SV *out, UA_AxisScaleEnumeration *in);
 static void unpack_UA_AxisScaleEnumeration(UA_AxisScaleEnumeration *out, SV *in);
 
@@ -20435,8 +19736,6 @@ unpack_UA_AxisScaleEnumeration(UA_AxisScaleEnumeration *out, SV *in)
 
 /* ComplexNumberType */
 #ifdef UA_TYPES_COMPLEXNUMBERTYPE
-static void XS_pack_UA_ComplexNumberType(SV *out, UA_ComplexNumberType in)  __attribute__((unused));
-static UA_ComplexNumberType XS_unpack_UA_ComplexNumberType(SV *in)  __attribute__((unused));
 static void pack_UA_ComplexNumberType(SV *out, UA_ComplexNumberType *in);
 static void unpack_UA_ComplexNumberType(UA_ComplexNumberType *out, SV *in);
 
@@ -20445,49 +19744,49 @@ pack_UA_ComplexNumberType(SV *out, UA_ComplexNumberType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Float(sv, in->real);
-	hv_stores(hv, "ComplexNumberType_real", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Float(sv, in->imaginary);
-	hv_stores(hv, "ComplexNumberType_imaginary", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ComplexNumberType_real", sv);
+	pack_UA_Float(sv, &in->real);
+
+	sv = newSV(0);
+	hv_stores(hv, "ComplexNumberType_imaginary", sv);
+	pack_UA_Float(sv, &in->imaginary);
+
+	return;
 }
 
 static void
 unpack_UA_ComplexNumberType(UA_ComplexNumberType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ComplexNumberType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ComplexNumberType_real", 0);
 	if (svp != NULL)
-		out->real = XS_unpack_UA_Float(*svp);
+		unpack_UA_Float(&out->real, *svp);
 
 	svp = hv_fetchs(hv, "ComplexNumberType_imaginary", 0);
 	if (svp != NULL)
-		out->imaginary = XS_unpack_UA_Float(*svp);
+		unpack_UA_Float(&out->imaginary, *svp);
 
-
+	return;
 }
 #endif
 
 /* DoubleComplexNumberType */
 #ifdef UA_TYPES_DOUBLECOMPLEXNUMBERTYPE
-static void XS_pack_UA_DoubleComplexNumberType(SV *out, UA_DoubleComplexNumberType in)  __attribute__((unused));
-static UA_DoubleComplexNumberType XS_unpack_UA_DoubleComplexNumberType(SV *in)  __attribute__((unused));
 static void pack_UA_DoubleComplexNumberType(SV *out, UA_DoubleComplexNumberType *in);
 static void unpack_UA_DoubleComplexNumberType(UA_DoubleComplexNumberType *out, SV *in);
 
@@ -20496,49 +19795,49 @@ pack_UA_DoubleComplexNumberType(SV *out, UA_DoubleComplexNumberType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->real);
-	hv_stores(hv, "DoubleComplexNumberType_real", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->imaginary);
-	hv_stores(hv, "DoubleComplexNumberType_imaginary", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "DoubleComplexNumberType_real", sv);
+	pack_UA_Double(sv, &in->real);
+
+	sv = newSV(0);
+	hv_stores(hv, "DoubleComplexNumberType_imaginary", sv);
+	pack_UA_Double(sv, &in->imaginary);
+
+	return;
 }
 
 static void
 unpack_UA_DoubleComplexNumberType(UA_DoubleComplexNumberType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DoubleComplexNumberType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DoubleComplexNumberType_real", 0);
 	if (svp != NULL)
-		out->real = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->real, *svp);
 
 	svp = hv_fetchs(hv, "DoubleComplexNumberType_imaginary", 0);
 	if (svp != NULL)
-		out->imaginary = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->imaginary, *svp);
 
-
+	return;
 }
 #endif
 
 /* AxisInformation */
 #ifdef UA_TYPES_AXISINFORMATION
-static void XS_pack_UA_AxisInformation(SV *out, UA_AxisInformation in)  __attribute__((unused));
-static UA_AxisInformation XS_unpack_UA_AxisInformation(SV *in)  __attribute__((unused));
 static void pack_UA_AxisInformation(SV *out, UA_AxisInformation *in);
 static void unpack_UA_AxisInformation(UA_AxisInformation *out, SV *in);
 
@@ -20549,96 +19848,93 @@ pack_UA_AxisInformation(SV *out, UA_AxisInformation *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_EUInformation(sv, in->engineeringUnits);
 	hv_stores(hv, "AxisInformation_engineeringUnits", sv);
+	pack_UA_EUInformation(sv, &in->engineeringUnits);
 
 	sv = newSV(0);
-	XS_pack_UA_Range(sv, in->eURange);
 	hv_stores(hv, "AxisInformation_eURange", sv);
+	pack_UA_Range(sv, &in->eURange);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->title);
 	hv_stores(hv, "AxisInformation_title", sv);
+	pack_UA_LocalizedText(sv, &in->title);
 
 	sv = newSV(0);
-	XS_pack_UA_AxisScaleEnumeration(sv, in->axisScaleType);
 	hv_stores(hv, "AxisInformation_axisScaleType", sv);
+	pack_UA_AxisScaleEnumeration(sv, &in->axisScaleType);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "AxisInformation_axisSteps", newRV_noinc((SV*)av));
 	av_extend(av, in->axisStepsSize);
 	for (i = 0; i < in->axisStepsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Double(sv, in->axisSteps[i]);
 		av_push(av, sv);
+		pack_UA_Double(sv, &in->axisSteps[i]);
 	}
-	hv_stores(hv, "AxisInformation_axisSteps", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_AxisInformation(UA_AxisInformation *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_AxisInformation_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "AxisInformation_engineeringUnits", 0);
 	if (svp != NULL)
-		out->engineeringUnits = XS_unpack_UA_EUInformation(*svp);
+		unpack_UA_EUInformation(&out->engineeringUnits, *svp);
 
 	svp = hv_fetchs(hv, "AxisInformation_eURange", 0);
 	if (svp != NULL)
-		out->eURange = XS_unpack_UA_Range(*svp);
+		unpack_UA_Range(&out->eURange, *svp);
 
 	svp = hv_fetchs(hv, "AxisInformation_title", 0);
 	if (svp != NULL)
-		out->title = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->title, *svp);
 
 	svp = hv_fetchs(hv, "AxisInformation_axisScaleType", 0);
 	if (svp != NULL)
-		out->axisScaleType = XS_unpack_UA_AxisScaleEnumeration(*svp);
+		unpack_UA_AxisScaleEnumeration(&out->axisScaleType, *svp);
 
 	svp = hv_fetchs(hv, "AxisInformation_axisSteps", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for AxisInformation_axisSteps");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->axisSteps = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DOUBLE]);
-		if (out->axisSteps == NULL) {
+		if (out->axisSteps == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->axisStepsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->axisSteps[i] = XS_unpack_UA_Double(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Double(&out->axisSteps[i], *svp);
 		}
-		out->axisStepsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* XVType */
 #ifdef UA_TYPES_XVTYPE
-static void XS_pack_UA_XVType(SV *out, UA_XVType in)  __attribute__((unused));
-static UA_XVType XS_unpack_UA_XVType(SV *in)  __attribute__((unused));
 static void pack_UA_XVType(SV *out, UA_XVType *in);
 static void unpack_UA_XVType(UA_XVType *out, SV *in);
 
@@ -20647,49 +19943,49 @@ pack_UA_XVType(SV *out, UA_XVType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->x);
-	hv_stores(hv, "XVType_x", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Float(sv, in->value);
-	hv_stores(hv, "XVType_value", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "XVType_x", sv);
+	pack_UA_Double(sv, &in->x);
+
+	sv = newSV(0);
+	hv_stores(hv, "XVType_value", sv);
+	pack_UA_Float(sv, &in->value);
+
+	return;
 }
 
 static void
 unpack_UA_XVType(UA_XVType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_XVType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "XVType_x", 0);
 	if (svp != NULL)
-		out->x = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->x, *svp);
 
 	svp = hv_fetchs(hv, "XVType_value", 0);
 	if (svp != NULL)
-		out->value = XS_unpack_UA_Float(*svp);
+		unpack_UA_Float(&out->value, *svp);
 
-
+	return;
 }
 #endif
 
 /* ProgramDiagnosticDataType */
 #ifdef UA_TYPES_PROGRAMDIAGNOSTICDATATYPE
-static void XS_pack_UA_ProgramDiagnosticDataType(SV *out, UA_ProgramDiagnosticDataType in)  __attribute__((unused));
-static UA_ProgramDiagnosticDataType XS_unpack_UA_ProgramDiagnosticDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ProgramDiagnosticDataType(SV *out, UA_ProgramDiagnosticDataType *in);
 static void unpack_UA_ProgramDiagnosticDataType(UA_ProgramDiagnosticDataType *out, SV *in);
 
@@ -20700,157 +19996,151 @@ pack_UA_ProgramDiagnosticDataType(SV *out, UA_ProgramDiagnosticDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->createSessionId);
 	hv_stores(hv, "ProgramDiagnosticDataType_createSessionId", sv);
+	pack_UA_NodeId(sv, &in->createSessionId);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->createClientName);
 	hv_stores(hv, "ProgramDiagnosticDataType_createClientName", sv);
+	pack_UA_String(sv, &in->createClientName);
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->invocationCreationTime);
 	hv_stores(hv, "ProgramDiagnosticDataType_invocationCreationTime", sv);
+	pack_UA_DateTime(sv, &in->invocationCreationTime);
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->lastTransitionTime);
 	hv_stores(hv, "ProgramDiagnosticDataType_lastTransitionTime", sv);
+	pack_UA_DateTime(sv, &in->lastTransitionTime);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->lastMethodCall);
 	hv_stores(hv, "ProgramDiagnosticDataType_lastMethodCall", sv);
+	pack_UA_String(sv, &in->lastMethodCall);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->lastMethodSessionId);
 	hv_stores(hv, "ProgramDiagnosticDataType_lastMethodSessionId", sv);
+	pack_UA_NodeId(sv, &in->lastMethodSessionId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ProgramDiagnosticDataType_lastMethodInputArguments", newRV_noinc((SV*)av));
 	av_extend(av, in->lastMethodInputArgumentsSize);
 	for (i = 0; i < in->lastMethodInputArgumentsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Argument(sv, in->lastMethodInputArguments[i]);
 		av_push(av, sv);
+		pack_UA_Argument(sv, &in->lastMethodInputArguments[i]);
 	}
-	hv_stores(hv, "ProgramDiagnosticDataType_lastMethodInputArguments", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ProgramDiagnosticDataType_lastMethodOutputArguments", newRV_noinc((SV*)av));
 	av_extend(av, in->lastMethodOutputArgumentsSize);
 	for (i = 0; i < in->lastMethodOutputArgumentsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Argument(sv, in->lastMethodOutputArguments[i]);
 		av_push(av, sv);
+		pack_UA_Argument(sv, &in->lastMethodOutputArguments[i]);
 	}
-	hv_stores(hv, "ProgramDiagnosticDataType_lastMethodOutputArguments", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->lastMethodCallTime);
 	hv_stores(hv, "ProgramDiagnosticDataType_lastMethodCallTime", sv);
+	pack_UA_DateTime(sv, &in->lastMethodCallTime);
 
 	sv = newSV(0);
-	XS_pack_UA_StatusResult(sv, in->lastMethodReturnStatus);
 	hv_stores(hv, "ProgramDiagnosticDataType_lastMethodReturnStatus", sv);
+	pack_UA_StatusResult(sv, &in->lastMethodReturnStatus);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ProgramDiagnosticDataType(UA_ProgramDiagnosticDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ProgramDiagnosticDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_createSessionId", 0);
 	if (svp != NULL)
-		out->createSessionId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->createSessionId, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_createClientName", 0);
 	if (svp != NULL)
-		out->createClientName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->createClientName, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_invocationCreationTime", 0);
 	if (svp != NULL)
-		out->invocationCreationTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->invocationCreationTime, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_lastTransitionTime", 0);
 	if (svp != NULL)
-		out->lastTransitionTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->lastTransitionTime, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_lastMethodCall", 0);
 	if (svp != NULL)
-		out->lastMethodCall = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->lastMethodCall, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_lastMethodSessionId", 0);
 	if (svp != NULL)
-		out->lastMethodSessionId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->lastMethodSessionId, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_lastMethodInputArguments", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ProgramDiagnosticDataType_lastMethodInputArguments");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->lastMethodInputArguments = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ARGUMENT]);
-		if (out->lastMethodInputArguments == NULL) {
+		if (out->lastMethodInputArguments == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->lastMethodInputArgumentsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->lastMethodInputArguments[i] = XS_unpack_UA_Argument(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Argument(&out->lastMethodInputArguments[i], *svp);
 		}
-		out->lastMethodInputArgumentsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_lastMethodOutputArguments", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ProgramDiagnosticDataType_lastMethodOutputArguments");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->lastMethodOutputArguments = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ARGUMENT]);
-		if (out->lastMethodOutputArguments == NULL) {
+		if (out->lastMethodOutputArguments == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->lastMethodOutputArgumentsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->lastMethodOutputArguments[i] = XS_unpack_UA_Argument(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Argument(&out->lastMethodOutputArguments[i], *svp);
 		}
-		out->lastMethodOutputArgumentsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_lastMethodCallTime", 0);
 	if (svp != NULL)
-		out->lastMethodCallTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->lastMethodCallTime, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnosticDataType_lastMethodReturnStatus", 0);
 	if (svp != NULL)
-		out->lastMethodReturnStatus = XS_unpack_UA_StatusResult(*svp);
+		unpack_UA_StatusResult(&out->lastMethodReturnStatus, *svp);
 
-
+	return;
 }
 #endif
 
 /* ProgramDiagnostic2DataType */
 #ifdef UA_TYPES_PROGRAMDIAGNOSTIC2DATATYPE
-static void XS_pack_UA_ProgramDiagnostic2DataType(SV *out, UA_ProgramDiagnostic2DataType in)  __attribute__((unused));
-static UA_ProgramDiagnostic2DataType XS_unpack_UA_ProgramDiagnostic2DataType(SV *in)  __attribute__((unused));
 static void pack_UA_ProgramDiagnostic2DataType(SV *out, UA_ProgramDiagnostic2DataType *in);
 static void unpack_UA_ProgramDiagnostic2DataType(UA_ProgramDiagnostic2DataType *out, SV *in);
 
@@ -20861,227 +20151,215 @@ pack_UA_ProgramDiagnostic2DataType(SV *out, UA_ProgramDiagnostic2DataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->createSessionId);
 	hv_stores(hv, "ProgramDiagnostic2DataType_createSessionId", sv);
+	pack_UA_NodeId(sv, &in->createSessionId);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->createClientName);
 	hv_stores(hv, "ProgramDiagnostic2DataType_createClientName", sv);
+	pack_UA_String(sv, &in->createClientName);
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->invocationCreationTime);
 	hv_stores(hv, "ProgramDiagnostic2DataType_invocationCreationTime", sv);
+	pack_UA_DateTime(sv, &in->invocationCreationTime);
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->lastTransitionTime);
 	hv_stores(hv, "ProgramDiagnostic2DataType_lastTransitionTime", sv);
+	pack_UA_DateTime(sv, &in->lastTransitionTime);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->lastMethodCall);
 	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodCall", sv);
+	pack_UA_String(sv, &in->lastMethodCall);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->lastMethodSessionId);
 	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodSessionId", sv);
+	pack_UA_NodeId(sv, &in->lastMethodSessionId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodInputArguments", newRV_noinc((SV*)av));
 	av_extend(av, in->lastMethodInputArgumentsSize);
 	for (i = 0; i < in->lastMethodInputArgumentsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Argument(sv, in->lastMethodInputArguments[i]);
 		av_push(av, sv);
+		pack_UA_Argument(sv, &in->lastMethodInputArguments[i]);
 	}
-	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodInputArguments", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodOutputArguments", newRV_noinc((SV*)av));
 	av_extend(av, in->lastMethodOutputArgumentsSize);
 	for (i = 0; i < in->lastMethodOutputArgumentsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Argument(sv, in->lastMethodOutputArguments[i]);
 		av_push(av, sv);
+		pack_UA_Argument(sv, &in->lastMethodOutputArguments[i]);
 	}
-	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodOutputArguments", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodInputValues", newRV_noinc((SV*)av));
 	av_extend(av, in->lastMethodInputValuesSize);
 	for (i = 0; i < in->lastMethodInputValuesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Variant(sv, in->lastMethodInputValues[i]);
 		av_push(av, sv);
+		pack_UA_Variant(sv, &in->lastMethodInputValues[i]);
 	}
-	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodInputValues", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodOutputValues", newRV_noinc((SV*)av));
 	av_extend(av, in->lastMethodOutputValuesSize);
 	for (i = 0; i < in->lastMethodOutputValuesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_Variant(sv, in->lastMethodOutputValues[i]);
 		av_push(av, sv);
+		pack_UA_Variant(sv, &in->lastMethodOutputValues[i]);
 	}
-	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodOutputValues", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->lastMethodCallTime);
 	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodCallTime", sv);
+	pack_UA_DateTime(sv, &in->lastMethodCallTime);
 
 #ifdef HAVE_UA_PROGRAMDIAGNOSTIC2DATATYPE_STATUSRESULT
 	sv = newSV(0);
-	XS_pack_UA_StatusResult(sv, in->lastMethodReturnStatus);
 	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodReturnStatus", sv);
+	pack_UA_StatusResult(sv, &in->lastMethodReturnStatus);
 #else
 	sv = newSV(0);
-	XS_pack_UA_StatusCode(sv, in->lastMethodReturnStatus);
 	hv_stores(hv, "ProgramDiagnostic2DataType_lastMethodReturnStatus", sv);
+	pack_UA_StatusCode(sv, &in->lastMethodReturnStatus);
 #endif
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ProgramDiagnostic2DataType(UA_ProgramDiagnostic2DataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ProgramDiagnostic2DataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_createSessionId", 0);
 	if (svp != NULL)
-		out->createSessionId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->createSessionId, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_createClientName", 0);
 	if (svp != NULL)
-		out->createClientName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->createClientName, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_invocationCreationTime", 0);
 	if (svp != NULL)
-		out->invocationCreationTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->invocationCreationTime, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastTransitionTime", 0);
 	if (svp != NULL)
-		out->lastTransitionTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->lastTransitionTime, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastMethodCall", 0);
 	if (svp != NULL)
-		out->lastMethodCall = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->lastMethodCall, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastMethodSessionId", 0);
 	if (svp != NULL)
-		out->lastMethodSessionId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->lastMethodSessionId, *svp);
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastMethodInputArguments", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ProgramDiagnostic2DataType_lastMethodInputArguments");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->lastMethodInputArguments = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ARGUMENT]);
-		if (out->lastMethodInputArguments == NULL) {
+		if (out->lastMethodInputArguments == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->lastMethodInputArgumentsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->lastMethodInputArguments[i] = XS_unpack_UA_Argument(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Argument(&out->lastMethodInputArguments[i], *svp);
 		}
-		out->lastMethodInputArgumentsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastMethodOutputArguments", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ProgramDiagnostic2DataType_lastMethodOutputArguments");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->lastMethodOutputArguments = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ARGUMENT]);
-		if (out->lastMethodOutputArguments == NULL) {
+		if (out->lastMethodOutputArguments == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->lastMethodOutputArgumentsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->lastMethodOutputArguments[i] = XS_unpack_UA_Argument(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Argument(&out->lastMethodOutputArguments[i], *svp);
 		}
-		out->lastMethodOutputArgumentsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastMethodInputValues", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ProgramDiagnostic2DataType_lastMethodInputValues");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->lastMethodInputValues = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
-		if (out->lastMethodInputValues == NULL) {
+		if (out->lastMethodInputValues == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->lastMethodInputValuesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->lastMethodInputValues[i] = XS_unpack_UA_Variant(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Variant(&out->lastMethodInputValues[i], *svp);
 		}
-		out->lastMethodInputValuesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastMethodOutputValues", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ProgramDiagnostic2DataType_lastMethodOutputValues");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->lastMethodOutputValues = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_VARIANT]);
-		if (out->lastMethodOutputValues == NULL) {
+		if (out->lastMethodOutputValues == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->lastMethodOutputValuesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->lastMethodOutputValues[i] = XS_unpack_UA_Variant(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_Variant(&out->lastMethodOutputValues[i], *svp);
 		}
-		out->lastMethodOutputValuesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastMethodCallTime", 0);
 	if (svp != NULL)
-		out->lastMethodCallTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->lastMethodCallTime, *svp);
 
 #ifdef HAVE_UA_PROGRAMDIAGNOSTIC2DATATYPE_STATUSRESULT
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastMethodReturnStatus", 0);
 	if (svp != NULL)
-		out->lastMethodReturnStatus = XS_unpack_UA_StatusResult(*svp);
+		unpack_UA_StatusResult(&out->lastMethodReturnStatus, *svp);
 #else
 	svp = hv_fetchs(hv, "ProgramDiagnostic2DataType_lastMethodReturnStatus", 0);
 	if (svp != NULL)
-		out->lastMethodReturnStatus = XS_unpack_UA_StatusCode(*svp);
+		unpack_UA_StatusCode(&out->lastMethodReturnStatus, *svp);
 #endif
 
-
+	return;
 }
 #endif
 
 /* Annotation */
 #ifdef UA_TYPES_ANNOTATION
-static void XS_pack_UA_Annotation(SV *out, UA_Annotation in)  __attribute__((unused));
-static UA_Annotation XS_unpack_UA_Annotation(SV *in)  __attribute__((unused));
 static void pack_UA_Annotation(SV *out, UA_Annotation *in);
 static void unpack_UA_Annotation(UA_Annotation *out, SV *in);
 
@@ -21090,57 +20368,57 @@ pack_UA_Annotation(SV *out, UA_Annotation *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->message);
-	hv_stores(hv, "Annotation_message", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->userName);
-	hv_stores(hv, "Annotation_userName", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->annotationTime);
-	hv_stores(hv, "Annotation_annotationTime", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "Annotation_message", sv);
+	pack_UA_String(sv, &in->message);
+
+	sv = newSV(0);
+	hv_stores(hv, "Annotation_userName", sv);
+	pack_UA_String(sv, &in->userName);
+
+	sv = newSV(0);
+	hv_stores(hv, "Annotation_annotationTime", sv);
+	pack_UA_DateTime(sv, &in->annotationTime);
+
+	return;
 }
 
 static void
 unpack_UA_Annotation(UA_Annotation *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_Annotation_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "Annotation_message", 0);
 	if (svp != NULL)
-		out->message = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->message, *svp);
 
 	svp = hv_fetchs(hv, "Annotation_userName", 0);
 	if (svp != NULL)
-		out->userName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->userName, *svp);
 
 	svp = hv_fetchs(hv, "Annotation_annotationTime", 0);
 	if (svp != NULL)
-		out->annotationTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->annotationTime, *svp);
 
-
+	return;
 }
 #endif
 
 /* ExceptionDeviationFormat */
 #ifdef UA_TYPES_EXCEPTIONDEVIATIONFORMAT
-static void XS_pack_UA_ExceptionDeviationFormat(SV *out, UA_ExceptionDeviationFormat in)  __attribute__((unused));
-static UA_ExceptionDeviationFormat XS_unpack_UA_ExceptionDeviationFormat(SV *in)  __attribute__((unused));
 static void pack_UA_ExceptionDeviationFormat(SV *out, UA_ExceptionDeviationFormat *in);
 static void unpack_UA_ExceptionDeviationFormat(UA_ExceptionDeviationFormat *out, SV *in);
 
@@ -21161,8 +20439,6 @@ unpack_UA_ExceptionDeviationFormat(UA_ExceptionDeviationFormat *out, SV *in)
 
 /* EndpointType */
 #ifdef UA_TYPES_ENDPOINTTYPE
-static void XS_pack_UA_EndpointType(SV *out, UA_EndpointType in)  __attribute__((unused));
-static UA_EndpointType XS_unpack_UA_EndpointType(SV *in)  __attribute__((unused));
 static void pack_UA_EndpointType(SV *out, UA_EndpointType *in);
 static void unpack_UA_EndpointType(UA_EndpointType *out, SV *in);
 
@@ -21171,65 +20447,65 @@ pack_UA_EndpointType(SV *out, UA_EndpointType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->endpointUrl);
-	hv_stores(hv, "EndpointType_endpointUrl", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_MessageSecurityMode(sv, in->securityMode);
-	hv_stores(hv, "EndpointType_securityMode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->securityPolicyUri);
-	hv_stores(hv, "EndpointType_securityPolicyUri", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->transportProfileUri);
-	hv_stores(hv, "EndpointType_transportProfileUri", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointType_endpointUrl", sv);
+	pack_UA_String(sv, &in->endpointUrl);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointType_securityMode", sv);
+	pack_UA_MessageSecurityMode(sv, &in->securityMode);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointType_securityPolicyUri", sv);
+	pack_UA_String(sv, &in->securityPolicyUri);
+
+	sv = newSV(0);
+	hv_stores(hv, "EndpointType_transportProfileUri", sv);
+	pack_UA_String(sv, &in->transportProfileUri);
+
+	return;
 }
 
 static void
 unpack_UA_EndpointType(UA_EndpointType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EndpointType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EndpointType_endpointUrl", 0);
 	if (svp != NULL)
-		out->endpointUrl = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->endpointUrl, *svp);
 
 	svp = hv_fetchs(hv, "EndpointType_securityMode", 0);
 	if (svp != NULL)
-		out->securityMode = XS_unpack_UA_MessageSecurityMode(*svp);
+		unpack_UA_MessageSecurityMode(&out->securityMode, *svp);
 
 	svp = hv_fetchs(hv, "EndpointType_securityPolicyUri", 0);
 	if (svp != NULL)
-		out->securityPolicyUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->securityPolicyUri, *svp);
 
 	svp = hv_fetchs(hv, "EndpointType_transportProfileUri", 0);
 	if (svp != NULL)
-		out->transportProfileUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->transportProfileUri, *svp);
 
-
+	return;
 }
 #endif
 
 /* StructureDescription */
 #ifdef UA_TYPES_STRUCTUREDESCRIPTION
-static void XS_pack_UA_StructureDescription(SV *out, UA_StructureDescription in)  __attribute__((unused));
-static UA_StructureDescription XS_unpack_UA_StructureDescription(SV *in)  __attribute__((unused));
 static void pack_UA_StructureDescription(SV *out, UA_StructureDescription *in);
 static void unpack_UA_StructureDescription(UA_StructureDescription *out, SV *in);
 
@@ -21238,57 +20514,57 @@ pack_UA_StructureDescription(SV *out, UA_StructureDescription *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->dataTypeId);
-	hv_stores(hv, "StructureDescription_dataTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->name);
-	hv_stores(hv, "StructureDescription_name", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_StructureDefinition(sv, in->structureDefinition);
-	hv_stores(hv, "StructureDescription_structureDefinition", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "StructureDescription_dataTypeId", sv);
+	pack_UA_NodeId(sv, &in->dataTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "StructureDescription_name", sv);
+	pack_UA_QualifiedName(sv, &in->name);
+
+	sv = newSV(0);
+	hv_stores(hv, "StructureDescription_structureDefinition", sv);
+	pack_UA_StructureDefinition(sv, &in->structureDefinition);
+
+	return;
 }
 
 static void
 unpack_UA_StructureDescription(UA_StructureDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_StructureDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "StructureDescription_dataTypeId", 0);
 	if (svp != NULL)
-		out->dataTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->dataTypeId, *svp);
 
 	svp = hv_fetchs(hv, "StructureDescription_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "StructureDescription_structureDefinition", 0);
 	if (svp != NULL)
-		out->structureDefinition = XS_unpack_UA_StructureDefinition(*svp);
+		unpack_UA_StructureDefinition(&out->structureDefinition, *svp);
 
-
+	return;
 }
 #endif
 
 /* FieldMetaData */
 #ifdef UA_TYPES_FIELDMETADATA
-static void XS_pack_UA_FieldMetaData(SV *out, UA_FieldMetaData in)  __attribute__((unused));
-static UA_FieldMetaData XS_unpack_UA_FieldMetaData(SV *in)  __attribute__((unused));
 static void pack_UA_FieldMetaData(SV *out, UA_FieldMetaData *in);
 static void unpack_UA_FieldMetaData(UA_FieldMetaData *out, SV *in);
 
@@ -21299,157 +20575,151 @@ pack_UA_FieldMetaData(SV *out, UA_FieldMetaData *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "FieldMetaData_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
 	hv_stores(hv, "FieldMetaData_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
 
 	sv = newSV(0);
-	XS_pack_UA_DataSetFieldFlags(sv, in->fieldFlags);
 	hv_stores(hv, "FieldMetaData_fieldFlags", sv);
+	pack_UA_DataSetFieldFlags(sv, &in->fieldFlags);
 
 	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->builtInType);
 	hv_stores(hv, "FieldMetaData_builtInType", sv);
+	pack_UA_Byte(sv, &in->builtInType);
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->dataType);
 	hv_stores(hv, "FieldMetaData_dataType", sv);
+	pack_UA_NodeId(sv, &in->dataType);
 
 	sv = newSV(0);
-	XS_pack_UA_Int32(sv, in->valueRank);
 	hv_stores(hv, "FieldMetaData_valueRank", sv);
+	pack_UA_Int32(sv, &in->valueRank);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "FieldMetaData_arrayDimensions", newRV_noinc((SV*)av));
 	av_extend(av, in->arrayDimensionsSize);
 	for (i = 0; i < in->arrayDimensionsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_UInt32(sv, in->arrayDimensions[i]);
 		av_push(av, sv);
+		pack_UA_UInt32(sv, &in->arrayDimensions[i]);
 	}
-	hv_stores(hv, "FieldMetaData_arrayDimensions", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxStringLength);
 	hv_stores(hv, "FieldMetaData_maxStringLength", sv);
+	pack_UA_UInt32(sv, &in->maxStringLength);
 
 	sv = newSV(0);
-	XS_pack_UA_Guid(sv, in->dataSetFieldId);
 	hv_stores(hv, "FieldMetaData_dataSetFieldId", sv);
+	pack_UA_Guid(sv, &in->dataSetFieldId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "FieldMetaData_properties", newRV_noinc((SV*)av));
 	av_extend(av, in->propertiesSize);
 	for (i = 0; i < in->propertiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_KeyValuePair(sv, in->properties[i]);
 		av_push(av, sv);
+		pack_UA_KeyValuePair(sv, &in->properties[i]);
 	}
-	hv_stores(hv, "FieldMetaData_properties", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_FieldMetaData(UA_FieldMetaData *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_FieldMetaData_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "FieldMetaData_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "FieldMetaData_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "FieldMetaData_fieldFlags", 0);
 	if (svp != NULL)
-		out->fieldFlags = XS_unpack_UA_DataSetFieldFlags(*svp);
+		unpack_UA_DataSetFieldFlags(&out->fieldFlags, *svp);
 
 	svp = hv_fetchs(hv, "FieldMetaData_builtInType", 0);
 	if (svp != NULL)
-		out->builtInType = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->builtInType, *svp);
 
 	svp = hv_fetchs(hv, "FieldMetaData_dataType", 0);
 	if (svp != NULL)
-		out->dataType = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->dataType, *svp);
 
 	svp = hv_fetchs(hv, "FieldMetaData_valueRank", 0);
 	if (svp != NULL)
-		out->valueRank = XS_unpack_UA_Int32(*svp);
+		unpack_UA_Int32(&out->valueRank, *svp);
 
 	svp = hv_fetchs(hv, "FieldMetaData_arrayDimensions", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for FieldMetaData_arrayDimensions");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->arrayDimensions = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_UINT32]);
-		if (out->arrayDimensions == NULL) {
+		if (out->arrayDimensions == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->arrayDimensionsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->arrayDimensions[i] = XS_unpack_UA_UInt32(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_UInt32(&out->arrayDimensions[i], *svp);
 		}
-		out->arrayDimensionsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "FieldMetaData_maxStringLength", 0);
 	if (svp != NULL)
-		out->maxStringLength = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxStringLength, *svp);
 
 	svp = hv_fetchs(hv, "FieldMetaData_dataSetFieldId", 0);
 	if (svp != NULL)
-		out->dataSetFieldId = XS_unpack_UA_Guid(*svp);
+		unpack_UA_Guid(&out->dataSetFieldId, *svp);
 
 	svp = hv_fetchs(hv, "FieldMetaData_properties", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for FieldMetaData_properties");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->properties = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-		if (out->properties == NULL) {
+		if (out->properties == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->propertiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->properties[i] = XS_unpack_UA_KeyValuePair(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_KeyValuePair(&out->properties[i], *svp);
 		}
-		out->propertiesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* PublishedEventsDataType */
 #ifdef UA_TYPES_PUBLISHEDEVENTSDATATYPE
-static void XS_pack_UA_PublishedEventsDataType(SV *out, UA_PublishedEventsDataType in)  __attribute__((unused));
-static UA_PublishedEventsDataType XS_unpack_UA_PublishedEventsDataType(SV *in)  __attribute__((unused));
 static void pack_UA_PublishedEventsDataType(SV *out, UA_PublishedEventsDataType *in);
 static void unpack_UA_PublishedEventsDataType(UA_PublishedEventsDataType *out, SV *in);
 
@@ -21460,80 +20730,77 @@ pack_UA_PublishedEventsDataType(SV *out, UA_PublishedEventsDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->eventNotifier);
 	hv_stores(hv, "PublishedEventsDataType_eventNotifier", sv);
+	pack_UA_NodeId(sv, &in->eventNotifier);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PublishedEventsDataType_selectedFields", newRV_noinc((SV*)av));
 	av_extend(av, in->selectedFieldsSize);
 	for (i = 0; i < in->selectedFieldsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_SimpleAttributeOperand(sv, in->selectedFields[i]);
 		av_push(av, sv);
+		pack_UA_SimpleAttributeOperand(sv, &in->selectedFields[i]);
 	}
-	hv_stores(hv, "PublishedEventsDataType_selectedFields", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ContentFilter(sv, in->filter);
 	hv_stores(hv, "PublishedEventsDataType_filter", sv);
+	pack_UA_ContentFilter(sv, &in->filter);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_PublishedEventsDataType(UA_PublishedEventsDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_PublishedEventsDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "PublishedEventsDataType_eventNotifier", 0);
 	if (svp != NULL)
-		out->eventNotifier = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->eventNotifier, *svp);
 
 	svp = hv_fetchs(hv, "PublishedEventsDataType_selectedFields", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PublishedEventsDataType_selectedFields");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->selectedFields = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIMPLEATTRIBUTEOPERAND]);
-		if (out->selectedFields == NULL) {
+		if (out->selectedFields == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->selectedFieldsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->selectedFields[i] = XS_unpack_UA_SimpleAttributeOperand(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_SimpleAttributeOperand(&out->selectedFields[i], *svp);
 		}
-		out->selectedFieldsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PublishedEventsDataType_filter", 0);
 	if (svp != NULL)
-		out->filter = XS_unpack_UA_ContentFilter(*svp);
+		unpack_UA_ContentFilter(&out->filter, *svp);
 
-
+	return;
 }
 #endif
 
 /* PubSubGroupDataType */
 #ifdef UA_TYPES_PUBSUBGROUPDATATYPE
-static void XS_pack_UA_PubSubGroupDataType(SV *out, UA_PubSubGroupDataType in)  __attribute__((unused));
-static UA_PubSubGroupDataType XS_unpack_UA_PubSubGroupDataType(SV *in)  __attribute__((unused));
 static void pack_UA_PubSubGroupDataType(SV *out, UA_PubSubGroupDataType *in);
 static void unpack_UA_PubSubGroupDataType(UA_PubSubGroupDataType *out, SV *in);
 
@@ -21544,133 +20811,127 @@ pack_UA_PubSubGroupDataType(SV *out, UA_PubSubGroupDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "PubSubGroupDataType_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->enabled);
 	hv_stores(hv, "PubSubGroupDataType_enabled", sv);
+	pack_UA_Boolean(sv, &in->enabled);
 
 	sv = newSV(0);
-	XS_pack_UA_MessageSecurityMode(sv, in->securityMode);
 	hv_stores(hv, "PubSubGroupDataType_securityMode", sv);
+	pack_UA_MessageSecurityMode(sv, &in->securityMode);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->securityGroupId);
 	hv_stores(hv, "PubSubGroupDataType_securityGroupId", sv);
+	pack_UA_String(sv, &in->securityGroupId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PubSubGroupDataType_securityKeyServices", newRV_noinc((SV*)av));
 	av_extend(av, in->securityKeyServicesSize);
 	for (i = 0; i < in->securityKeyServicesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EndpointDescription(sv, in->securityKeyServices[i]);
 		av_push(av, sv);
+		pack_UA_EndpointDescription(sv, &in->securityKeyServices[i]);
 	}
-	hv_stores(hv, "PubSubGroupDataType_securityKeyServices", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxNetworkMessageSize);
 	hv_stores(hv, "PubSubGroupDataType_maxNetworkMessageSize", sv);
+	pack_UA_UInt32(sv, &in->maxNetworkMessageSize);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PubSubGroupDataType_groupProperties", newRV_noinc((SV*)av));
 	av_extend(av, in->groupPropertiesSize);
 	for (i = 0; i < in->groupPropertiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_KeyValuePair(sv, in->groupProperties[i]);
 		av_push(av, sv);
+		pack_UA_KeyValuePair(sv, &in->groupProperties[i]);
 	}
-	hv_stores(hv, "PubSubGroupDataType_groupProperties", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_PubSubGroupDataType(UA_PubSubGroupDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_PubSubGroupDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "PubSubGroupDataType_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "PubSubGroupDataType_enabled", 0);
 	if (svp != NULL)
-		out->enabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->enabled, *svp);
 
 	svp = hv_fetchs(hv, "PubSubGroupDataType_securityMode", 0);
 	if (svp != NULL)
-		out->securityMode = XS_unpack_UA_MessageSecurityMode(*svp);
+		unpack_UA_MessageSecurityMode(&out->securityMode, *svp);
 
 	svp = hv_fetchs(hv, "PubSubGroupDataType_securityGroupId", 0);
 	if (svp != NULL)
-		out->securityGroupId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->securityGroupId, *svp);
 
 	svp = hv_fetchs(hv, "PubSubGroupDataType_securityKeyServices", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PubSubGroupDataType_securityKeyServices");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->securityKeyServices = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
-		if (out->securityKeyServices == NULL) {
+		if (out->securityKeyServices == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->securityKeyServicesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->securityKeyServices[i] = XS_unpack_UA_EndpointDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EndpointDescription(&out->securityKeyServices[i], *svp);
 		}
-		out->securityKeyServicesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PubSubGroupDataType_maxNetworkMessageSize", 0);
 	if (svp != NULL)
-		out->maxNetworkMessageSize = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxNetworkMessageSize, *svp);
 
 	svp = hv_fetchs(hv, "PubSubGroupDataType_groupProperties", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PubSubGroupDataType_groupProperties");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->groupProperties = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-		if (out->groupProperties == NULL) {
+		if (out->groupProperties == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->groupPropertiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->groupProperties[i] = XS_unpack_UA_KeyValuePair(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_KeyValuePair(&out->groupProperties[i], *svp);
 		}
-		out->groupPropertiesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* WriterGroupDataType */
 #ifdef UA_TYPES_WRITERGROUPDATATYPE
-static void XS_pack_UA_WriterGroupDataType(SV *out, UA_WriterGroupDataType in)  __attribute__((unused));
-static UA_WriterGroupDataType XS_unpack_UA_WriterGroupDataType(SV *in)  __attribute__((unused));
 static void pack_UA_WriterGroupDataType(SV *out, UA_WriterGroupDataType *in);
 static void unpack_UA_WriterGroupDataType(UA_WriterGroupDataType *out, SV *in);
 
@@ -21681,247 +20942,235 @@ pack_UA_WriterGroupDataType(SV *out, UA_WriterGroupDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "WriterGroupDataType_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->enabled);
 	hv_stores(hv, "WriterGroupDataType_enabled", sv);
+	pack_UA_Boolean(sv, &in->enabled);
 
 	sv = newSV(0);
-	XS_pack_UA_MessageSecurityMode(sv, in->securityMode);
 	hv_stores(hv, "WriterGroupDataType_securityMode", sv);
+	pack_UA_MessageSecurityMode(sv, &in->securityMode);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->securityGroupId);
 	hv_stores(hv, "WriterGroupDataType_securityGroupId", sv);
+	pack_UA_String(sv, &in->securityGroupId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "WriterGroupDataType_securityKeyServices", newRV_noinc((SV*)av));
 	av_extend(av, in->securityKeyServicesSize);
 	for (i = 0; i < in->securityKeyServicesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EndpointDescription(sv, in->securityKeyServices[i]);
 		av_push(av, sv);
+		pack_UA_EndpointDescription(sv, &in->securityKeyServices[i]);
 	}
-	hv_stores(hv, "WriterGroupDataType_securityKeyServices", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxNetworkMessageSize);
 	hv_stores(hv, "WriterGroupDataType_maxNetworkMessageSize", sv);
+	pack_UA_UInt32(sv, &in->maxNetworkMessageSize);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "WriterGroupDataType_groupProperties", newRV_noinc((SV*)av));
 	av_extend(av, in->groupPropertiesSize);
 	for (i = 0; i < in->groupPropertiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_KeyValuePair(sv, in->groupProperties[i]);
 		av_push(av, sv);
+		pack_UA_KeyValuePair(sv, &in->groupProperties[i]);
 	}
-	hv_stores(hv, "WriterGroupDataType_groupProperties", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt16(sv, in->writerGroupId);
 	hv_stores(hv, "WriterGroupDataType_writerGroupId", sv);
+	pack_UA_UInt16(sv, &in->writerGroupId);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->publishingInterval);
 	hv_stores(hv, "WriterGroupDataType_publishingInterval", sv);
+	pack_UA_Double(sv, &in->publishingInterval);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->keepAliveTime);
 	hv_stores(hv, "WriterGroupDataType_keepAliveTime", sv);
+	pack_UA_Double(sv, &in->keepAliveTime);
 
 	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->priority);
 	hv_stores(hv, "WriterGroupDataType_priority", sv);
+	pack_UA_Byte(sv, &in->priority);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "WriterGroupDataType_localeIds", newRV_noinc((SV*)av));
 	av_extend(av, in->localeIdsSize);
 	for (i = 0; i < in->localeIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->localeIds[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->localeIds[i]);
 	}
-	hv_stores(hv, "WriterGroupDataType_localeIds", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->headerLayoutUri);
 	hv_stores(hv, "WriterGroupDataType_headerLayoutUri", sv);
+	pack_UA_String(sv, &in->headerLayoutUri);
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->transportSettings);
 	hv_stores(hv, "WriterGroupDataType_transportSettings", sv);
+	pack_UA_ExtensionObject(sv, &in->transportSettings);
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->messageSettings);
 	hv_stores(hv, "WriterGroupDataType_messageSettings", sv);
+	pack_UA_ExtensionObject(sv, &in->messageSettings);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "WriterGroupDataType_dataSetWriters", newRV_noinc((SV*)av));
 	av_extend(av, in->dataSetWritersSize);
 	for (i = 0; i < in->dataSetWritersSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DataSetWriterDataType(sv, in->dataSetWriters[i]);
 		av_push(av, sv);
+		pack_UA_DataSetWriterDataType(sv, &in->dataSetWriters[i]);
 	}
-	hv_stores(hv, "WriterGroupDataType_dataSetWriters", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_WriterGroupDataType(UA_WriterGroupDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_WriterGroupDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_enabled", 0);
 	if (svp != NULL)
-		out->enabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->enabled, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_securityMode", 0);
 	if (svp != NULL)
-		out->securityMode = XS_unpack_UA_MessageSecurityMode(*svp);
+		unpack_UA_MessageSecurityMode(&out->securityMode, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_securityGroupId", 0);
 	if (svp != NULL)
-		out->securityGroupId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->securityGroupId, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_securityKeyServices", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for WriterGroupDataType_securityKeyServices");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->securityKeyServices = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
-		if (out->securityKeyServices == NULL) {
+		if (out->securityKeyServices == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->securityKeyServicesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->securityKeyServices[i] = XS_unpack_UA_EndpointDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EndpointDescription(&out->securityKeyServices[i], *svp);
 		}
-		out->securityKeyServicesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_maxNetworkMessageSize", 0);
 	if (svp != NULL)
-		out->maxNetworkMessageSize = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxNetworkMessageSize, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_groupProperties", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for WriterGroupDataType_groupProperties");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->groupProperties = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-		if (out->groupProperties == NULL) {
+		if (out->groupProperties == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->groupPropertiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->groupProperties[i] = XS_unpack_UA_KeyValuePair(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_KeyValuePair(&out->groupProperties[i], *svp);
 		}
-		out->groupPropertiesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_writerGroupId", 0);
 	if (svp != NULL)
-		out->writerGroupId = XS_unpack_UA_UInt16(*svp);
+		unpack_UA_UInt16(&out->writerGroupId, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_publishingInterval", 0);
 	if (svp != NULL)
-		out->publishingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->publishingInterval, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_keepAliveTime", 0);
 	if (svp != NULL)
-		out->keepAliveTime = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->keepAliveTime, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_priority", 0);
 	if (svp != NULL)
-		out->priority = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->priority, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_localeIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for WriterGroupDataType_localeIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->localeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->localeIds == NULL) {
+		if (out->localeIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->localeIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->localeIds[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->localeIds[i], *svp);
 		}
-		out->localeIdsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_headerLayoutUri", 0);
 	if (svp != NULL)
-		out->headerLayoutUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->headerLayoutUri, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_transportSettings", 0);
 	if (svp != NULL)
-		out->transportSettings = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->transportSettings, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_messageSettings", 0);
 	if (svp != NULL)
-		out->messageSettings = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->messageSettings, *svp);
 
 	svp = hv_fetchs(hv, "WriterGroupDataType_dataSetWriters", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for WriterGroupDataType_dataSetWriters");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataSetWriters = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATASETWRITERDATATYPE]);
-		if (out->dataSetWriters == NULL) {
+		if (out->dataSetWriters == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataSetWritersSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataSetWriters[i] = XS_unpack_UA_DataSetWriterDataType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DataSetWriterDataType(&out->dataSetWriters[i], *svp);
 		}
-		out->dataSetWritersSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* FieldTargetDataType */
 #ifdef UA_TYPES_FIELDTARGETDATATYPE
-static void XS_pack_UA_FieldTargetDataType(SV *out, UA_FieldTargetDataType in)  __attribute__((unused));
-static UA_FieldTargetDataType XS_unpack_UA_FieldTargetDataType(SV *in)  __attribute__((unused));
 static void pack_UA_FieldTargetDataType(SV *out, UA_FieldTargetDataType *in);
 static void unpack_UA_FieldTargetDataType(UA_FieldTargetDataType *out, SV *in);
 
@@ -21930,89 +21179,89 @@ pack_UA_FieldTargetDataType(SV *out, UA_FieldTargetDataType *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_Guid(sv, in->dataSetFieldId);
-	hv_stores(hv, "FieldTargetDataType_dataSetFieldId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->receiverIndexRange);
-	hv_stores(hv, "FieldTargetDataType_receiverIndexRange", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->targetNodeId);
-	hv_stores(hv, "FieldTargetDataType_targetNodeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->attributeId);
-	hv_stores(hv, "FieldTargetDataType_attributeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->writeIndexRange);
-	hv_stores(hv, "FieldTargetDataType_writeIndexRange", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_OverrideValueHandling(sv, in->overrideValueHandling);
-	hv_stores(hv, "FieldTargetDataType_overrideValueHandling", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->overrideValue);
-	hv_stores(hv, "FieldTargetDataType_overrideValue", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "FieldTargetDataType_dataSetFieldId", sv);
+	pack_UA_Guid(sv, &in->dataSetFieldId);
+
+	sv = newSV(0);
+	hv_stores(hv, "FieldTargetDataType_receiverIndexRange", sv);
+	pack_UA_String(sv, &in->receiverIndexRange);
+
+	sv = newSV(0);
+	hv_stores(hv, "FieldTargetDataType_targetNodeId", sv);
+	pack_UA_NodeId(sv, &in->targetNodeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "FieldTargetDataType_attributeId", sv);
+	pack_UA_UInt32(sv, &in->attributeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "FieldTargetDataType_writeIndexRange", sv);
+	pack_UA_String(sv, &in->writeIndexRange);
+
+	sv = newSV(0);
+	hv_stores(hv, "FieldTargetDataType_overrideValueHandling", sv);
+	pack_UA_OverrideValueHandling(sv, &in->overrideValueHandling);
+
+	sv = newSV(0);
+	hv_stores(hv, "FieldTargetDataType_overrideValue", sv);
+	pack_UA_Variant(sv, &in->overrideValue);
+
+	return;
 }
 
 static void
 unpack_UA_FieldTargetDataType(UA_FieldTargetDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_FieldTargetDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "FieldTargetDataType_dataSetFieldId", 0);
 	if (svp != NULL)
-		out->dataSetFieldId = XS_unpack_UA_Guid(*svp);
+		unpack_UA_Guid(&out->dataSetFieldId, *svp);
 
 	svp = hv_fetchs(hv, "FieldTargetDataType_receiverIndexRange", 0);
 	if (svp != NULL)
-		out->receiverIndexRange = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->receiverIndexRange, *svp);
 
 	svp = hv_fetchs(hv, "FieldTargetDataType_targetNodeId", 0);
 	if (svp != NULL)
-		out->targetNodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->targetNodeId, *svp);
 
 	svp = hv_fetchs(hv, "FieldTargetDataType_attributeId", 0);
 	if (svp != NULL)
-		out->attributeId = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->attributeId, *svp);
 
 	svp = hv_fetchs(hv, "FieldTargetDataType_writeIndexRange", 0);
 	if (svp != NULL)
-		out->writeIndexRange = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->writeIndexRange, *svp);
 
 	svp = hv_fetchs(hv, "FieldTargetDataType_overrideValueHandling", 0);
 	if (svp != NULL)
-		out->overrideValueHandling = XS_unpack_UA_OverrideValueHandling(*svp);
+		unpack_UA_OverrideValueHandling(&out->overrideValueHandling, *svp);
 
 	svp = hv_fetchs(hv, "FieldTargetDataType_overrideValue", 0);
 	if (svp != NULL)
-		out->overrideValue = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->overrideValue, *svp);
 
-
+	return;
 }
 #endif
 
 /* SubscribedDataSetMirrorDataType */
 #ifdef UA_TYPES_SUBSCRIBEDDATASETMIRRORDATATYPE
-static void XS_pack_UA_SubscribedDataSetMirrorDataType(SV *out, UA_SubscribedDataSetMirrorDataType in)  __attribute__((unused));
-static UA_SubscribedDataSetMirrorDataType XS_unpack_UA_SubscribedDataSetMirrorDataType(SV *in)  __attribute__((unused));
 static void pack_UA_SubscribedDataSetMirrorDataType(SV *out, UA_SubscribedDataSetMirrorDataType *in);
 static void unpack_UA_SubscribedDataSetMirrorDataType(UA_SubscribedDataSetMirrorDataType *out, SV *in);
 
@@ -22023,72 +21272,69 @@ pack_UA_SubscribedDataSetMirrorDataType(SV *out, UA_SubscribedDataSetMirrorDataT
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->parentNodeName);
 	hv_stores(hv, "SubscribedDataSetMirrorDataType_parentNodeName", sv);
+	pack_UA_String(sv, &in->parentNodeName);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SubscribedDataSetMirrorDataType_rolePermissions", newRV_noinc((SV*)av));
 	av_extend(av, in->rolePermissionsSize);
 	for (i = 0; i < in->rolePermissionsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_RolePermissionType(sv, in->rolePermissions[i]);
 		av_push(av, sv);
+		pack_UA_RolePermissionType(sv, &in->rolePermissions[i]);
 	}
-	hv_stores(hv, "SubscribedDataSetMirrorDataType_rolePermissions", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SubscribedDataSetMirrorDataType(UA_SubscribedDataSetMirrorDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SubscribedDataSetMirrorDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SubscribedDataSetMirrorDataType_parentNodeName", 0);
 	if (svp != NULL)
-		out->parentNodeName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->parentNodeName, *svp);
 
 	svp = hv_fetchs(hv, "SubscribedDataSetMirrorDataType_rolePermissions", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SubscribedDataSetMirrorDataType_rolePermissions");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->rolePermissions = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ROLEPERMISSIONTYPE]);
-		if (out->rolePermissions == NULL) {
+		if (out->rolePermissions == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->rolePermissionsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->rolePermissions[i] = XS_unpack_UA_RolePermissionType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_RolePermissionType(&out->rolePermissions[i], *svp);
 		}
-		out->rolePermissionsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* EnumDefinition */
 #ifdef UA_TYPES_ENUMDEFINITION
-static void XS_pack_UA_EnumDefinition(SV *out, UA_EnumDefinition in)  __attribute__((unused));
-static UA_EnumDefinition XS_unpack_UA_EnumDefinition(SV *in)  __attribute__((unused));
 static void pack_UA_EnumDefinition(SV *out, UA_EnumDefinition *in);
 static void unpack_UA_EnumDefinition(UA_EnumDefinition *out, SV *in);
 
@@ -22099,64 +21345,61 @@ pack_UA_EnumDefinition(SV *out, UA_EnumDefinition *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "EnumDefinition_fields", newRV_noinc((SV*)av));
 	av_extend(av, in->fieldsSize);
 	for (i = 0; i < in->fieldsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EnumField(sv, in->fields[i]);
 		av_push(av, sv);
+		pack_UA_EnumField(sv, &in->fields[i]);
 	}
-	hv_stores(hv, "EnumDefinition_fields", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_EnumDefinition(UA_EnumDefinition *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EnumDefinition_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EnumDefinition_fields", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for EnumDefinition_fields");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->fields = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENUMFIELD]);
-		if (out->fields == NULL) {
+		if (out->fields == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->fieldsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->fields[i] = XS_unpack_UA_EnumField(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EnumField(&out->fields[i], *svp);
 		}
-		out->fieldsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ReadEventDetails */
 #ifdef UA_TYPES_READEVENTDETAILS
-static void XS_pack_UA_ReadEventDetails(SV *out, UA_ReadEventDetails in)  __attribute__((unused));
-static UA_ReadEventDetails XS_unpack_UA_ReadEventDetails(SV *in)  __attribute__((unused));
 static void pack_UA_ReadEventDetails(SV *out, UA_ReadEventDetails *in);
 static void unpack_UA_ReadEventDetails(UA_ReadEventDetails *out, SV *in);
 
@@ -22165,65 +21408,65 @@ pack_UA_ReadEventDetails(SV *out, UA_ReadEventDetails *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->numValuesPerNode);
-	hv_stores(hv, "ReadEventDetails_numValuesPerNode", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->startTime);
-	hv_stores(hv, "ReadEventDetails_startTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->endTime);
-	hv_stores(hv, "ReadEventDetails_endTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_EventFilter(sv, in->filter);
-	hv_stores(hv, "ReadEventDetails_filter", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadEventDetails_numValuesPerNode", sv);
+	pack_UA_UInt32(sv, &in->numValuesPerNode);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadEventDetails_startTime", sv);
+	pack_UA_DateTime(sv, &in->startTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadEventDetails_endTime", sv);
+	pack_UA_DateTime(sv, &in->endTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "ReadEventDetails_filter", sv);
+	pack_UA_EventFilter(sv, &in->filter);
+
+	return;
 }
 
 static void
 unpack_UA_ReadEventDetails(UA_ReadEventDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReadEventDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReadEventDetails_numValuesPerNode", 0);
 	if (svp != NULL)
-		out->numValuesPerNode = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->numValuesPerNode, *svp);
 
 	svp = hv_fetchs(hv, "ReadEventDetails_startTime", 0);
 	if (svp != NULL)
-		out->startTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->startTime, *svp);
 
 	svp = hv_fetchs(hv, "ReadEventDetails_endTime", 0);
 	if (svp != NULL)
-		out->endTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->endTime, *svp);
 
 	svp = hv_fetchs(hv, "ReadEventDetails_filter", 0);
 	if (svp != NULL)
-		out->filter = XS_unpack_UA_EventFilter(*svp);
+		unpack_UA_EventFilter(&out->filter, *svp);
 
-
+	return;
 }
 #endif
 
 /* ReadProcessedDetails */
 #ifdef UA_TYPES_READPROCESSEDDETAILS
-static void XS_pack_UA_ReadProcessedDetails(SV *out, UA_ReadProcessedDetails in)  __attribute__((unused));
-static UA_ReadProcessedDetails XS_unpack_UA_ReadProcessedDetails(SV *in)  __attribute__((unused));
 static void pack_UA_ReadProcessedDetails(SV *out, UA_ReadProcessedDetails *in);
 static void unpack_UA_ReadProcessedDetails(UA_ReadProcessedDetails *out, SV *in);
 
@@ -22234,96 +21477,93 @@ pack_UA_ReadProcessedDetails(SV *out, UA_ReadProcessedDetails *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->startTime);
 	hv_stores(hv, "ReadProcessedDetails_startTime", sv);
+	pack_UA_DateTime(sv, &in->startTime);
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->endTime);
 	hv_stores(hv, "ReadProcessedDetails_endTime", sv);
+	pack_UA_DateTime(sv, &in->endTime);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->processingInterval);
 	hv_stores(hv, "ReadProcessedDetails_processingInterval", sv);
+	pack_UA_Double(sv, &in->processingInterval);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ReadProcessedDetails_aggregateType", newRV_noinc((SV*)av));
 	av_extend(av, in->aggregateTypeSize);
 	for (i = 0; i < in->aggregateTypeSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_NodeId(sv, in->aggregateType[i]);
 		av_push(av, sv);
+		pack_UA_NodeId(sv, &in->aggregateType[i]);
 	}
-	hv_stores(hv, "ReadProcessedDetails_aggregateType", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_AggregateConfiguration(sv, in->aggregateConfiguration);
 	hv_stores(hv, "ReadProcessedDetails_aggregateConfiguration", sv);
+	pack_UA_AggregateConfiguration(sv, &in->aggregateConfiguration);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ReadProcessedDetails(UA_ReadProcessedDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReadProcessedDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReadProcessedDetails_startTime", 0);
 	if (svp != NULL)
-		out->startTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->startTime, *svp);
 
 	svp = hv_fetchs(hv, "ReadProcessedDetails_endTime", 0);
 	if (svp != NULL)
-		out->endTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->endTime, *svp);
 
 	svp = hv_fetchs(hv, "ReadProcessedDetails_processingInterval", 0);
 	if (svp != NULL)
-		out->processingInterval = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->processingInterval, *svp);
 
 	svp = hv_fetchs(hv, "ReadProcessedDetails_aggregateType", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ReadProcessedDetails_aggregateType");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->aggregateType = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_NODEID]);
-		if (out->aggregateType == NULL) {
+		if (out->aggregateType == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->aggregateTypeSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->aggregateType[i] = XS_unpack_UA_NodeId(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_NodeId(&out->aggregateType[i], *svp);
 		}
-		out->aggregateTypeSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ReadProcessedDetails_aggregateConfiguration", 0);
 	if (svp != NULL)
-		out->aggregateConfiguration = XS_unpack_UA_AggregateConfiguration(*svp);
+		unpack_UA_AggregateConfiguration(&out->aggregateConfiguration, *svp);
 
-
+	return;
 }
 #endif
 
 /* ModificationInfo */
 #ifdef UA_TYPES_MODIFICATIONINFO
-static void XS_pack_UA_ModificationInfo(SV *out, UA_ModificationInfo in)  __attribute__((unused));
-static UA_ModificationInfo XS_unpack_UA_ModificationInfo(SV *in)  __attribute__((unused));
 static void pack_UA_ModificationInfo(SV *out, UA_ModificationInfo *in);
 static void unpack_UA_ModificationInfo(UA_ModificationInfo *out, SV *in);
 
@@ -22332,57 +21572,57 @@ pack_UA_ModificationInfo(SV *out, UA_ModificationInfo *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->modificationTime);
-	hv_stores(hv, "ModificationInfo_modificationTime", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_HistoryUpdateType(sv, in->updateType);
-	hv_stores(hv, "ModificationInfo_updateType", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_String(sv, in->userName);
-	hv_stores(hv, "ModificationInfo_userName", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "ModificationInfo_modificationTime", sv);
+	pack_UA_DateTime(sv, &in->modificationTime);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModificationInfo_updateType", sv);
+	pack_UA_HistoryUpdateType(sv, &in->updateType);
+
+	sv = newSV(0);
+	hv_stores(hv, "ModificationInfo_userName", sv);
+	pack_UA_String(sv, &in->userName);
+
+	return;
 }
 
 static void
 unpack_UA_ModificationInfo(UA_ModificationInfo *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ModificationInfo_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ModificationInfo_modificationTime", 0);
 	if (svp != NULL)
-		out->modificationTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->modificationTime, *svp);
 
 	svp = hv_fetchs(hv, "ModificationInfo_updateType", 0);
 	if (svp != NULL)
-		out->updateType = XS_unpack_UA_HistoryUpdateType(*svp);
+		unpack_UA_HistoryUpdateType(&out->updateType, *svp);
 
 	svp = hv_fetchs(hv, "ModificationInfo_userName", 0);
 	if (svp != NULL)
-		out->userName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->userName, *svp);
 
-
+	return;
 }
 #endif
 
 /* HistoryModifiedData */
 #ifdef UA_TYPES_HISTORYMODIFIEDDATA
-static void XS_pack_UA_HistoryModifiedData(SV *out, UA_HistoryModifiedData in)  __attribute__((unused));
-static UA_HistoryModifiedData XS_unpack_UA_HistoryModifiedData(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryModifiedData(SV *out, UA_HistoryModifiedData *in);
 static void unpack_UA_HistoryModifiedData(UA_HistoryModifiedData *out, SV *in);
 
@@ -22393,93 +21633,87 @@ pack_UA_HistoryModifiedData(SV *out, UA_HistoryModifiedData *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "HistoryModifiedData_dataValues", newRV_noinc((SV*)av));
 	av_extend(av, in->dataValuesSize);
 	for (i = 0; i < in->dataValuesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DataValue(sv, in->dataValues[i]);
 		av_push(av, sv);
+		pack_UA_DataValue(sv, &in->dataValues[i]);
 	}
-	hv_stores(hv, "HistoryModifiedData_dataValues", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "HistoryModifiedData_modificationInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->modificationInfosSize);
 	for (i = 0; i < in->modificationInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ModificationInfo(sv, in->modificationInfos[i]);
 		av_push(av, sv);
+		pack_UA_ModificationInfo(sv, &in->modificationInfos[i]);
 	}
-	hv_stores(hv, "HistoryModifiedData_modificationInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryModifiedData(UA_HistoryModifiedData *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryModifiedData_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryModifiedData_dataValues", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryModifiedData_dataValues");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataValues = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATAVALUE]);
-		if (out->dataValues == NULL) {
+		if (out->dataValues == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataValuesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataValues[i] = XS_unpack_UA_DataValue(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DataValue(&out->dataValues[i], *svp);
 		}
-		out->dataValuesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "HistoryModifiedData_modificationInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryModifiedData_modificationInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->modificationInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MODIFICATIONINFO]);
-		if (out->modificationInfos == NULL) {
+		if (out->modificationInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->modificationInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->modificationInfos[i] = XS_unpack_UA_ModificationInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ModificationInfo(&out->modificationInfos[i], *svp);
 		}
-		out->modificationInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* HistoryEvent */
 #ifdef UA_TYPES_HISTORYEVENT
-static void XS_pack_UA_HistoryEvent(SV *out, UA_HistoryEvent in)  __attribute__((unused));
-static UA_HistoryEvent XS_unpack_UA_HistoryEvent(SV *in)  __attribute__((unused));
 static void pack_UA_HistoryEvent(SV *out, UA_HistoryEvent *in);
 static void unpack_UA_HistoryEvent(UA_HistoryEvent *out, SV *in);
 
@@ -22490,64 +21724,61 @@ pack_UA_HistoryEvent(SV *out, UA_HistoryEvent *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "HistoryEvent_events", newRV_noinc((SV*)av));
 	av_extend(av, in->eventsSize);
 	for (i = 0; i < in->eventsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_HistoryEventFieldList(sv, in->events[i]);
 		av_push(av, sv);
+		pack_UA_HistoryEventFieldList(sv, &in->events[i]);
 	}
-	hv_stores(hv, "HistoryEvent_events", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_HistoryEvent(UA_HistoryEvent *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_HistoryEvent_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "HistoryEvent_events", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for HistoryEvent_events");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->events = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_HISTORYEVENTFIELDLIST]);
-		if (out->events == NULL) {
+		if (out->events == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->eventsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->events[i] = XS_unpack_UA_HistoryEventFieldList(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_HistoryEventFieldList(&out->events[i], *svp);
 		}
-		out->eventsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* UpdateEventDetails */
 #ifdef UA_TYPES_UPDATEEVENTDETAILS
-static void XS_pack_UA_UpdateEventDetails(SV *out, UA_UpdateEventDetails in)  __attribute__((unused));
-static UA_UpdateEventDetails XS_unpack_UA_UpdateEventDetails(SV *in)  __attribute__((unused));
 static void pack_UA_UpdateEventDetails(SV *out, UA_UpdateEventDetails *in);
 static void unpack_UA_UpdateEventDetails(UA_UpdateEventDetails *out, SV *in);
 
@@ -22558,88 +21789,85 @@ pack_UA_UpdateEventDetails(SV *out, UA_UpdateEventDetails *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->nodeId);
 	hv_stores(hv, "UpdateEventDetails_nodeId", sv);
+	pack_UA_NodeId(sv, &in->nodeId);
 
 	sv = newSV(0);
-	XS_pack_UA_PerformUpdateType(sv, in->performInsertReplace);
 	hv_stores(hv, "UpdateEventDetails_performInsertReplace", sv);
+	pack_UA_PerformUpdateType(sv, &in->performInsertReplace);
 
 	sv = newSV(0);
-	XS_pack_UA_EventFilter(sv, in->filter);
 	hv_stores(hv, "UpdateEventDetails_filter", sv);
+	pack_UA_EventFilter(sv, &in->filter);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "UpdateEventDetails_eventData", newRV_noinc((SV*)av));
 	av_extend(av, in->eventDataSize);
 	for (i = 0; i < in->eventDataSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_HistoryEventFieldList(sv, in->eventData[i]);
 		av_push(av, sv);
+		pack_UA_HistoryEventFieldList(sv, &in->eventData[i]);
 	}
-	hv_stores(hv, "UpdateEventDetails_eventData", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_UpdateEventDetails(UA_UpdateEventDetails *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UpdateEventDetails_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UpdateEventDetails_nodeId", 0);
 	if (svp != NULL)
-		out->nodeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->nodeId, *svp);
 
 	svp = hv_fetchs(hv, "UpdateEventDetails_performInsertReplace", 0);
 	if (svp != NULL)
-		out->performInsertReplace = XS_unpack_UA_PerformUpdateType(*svp);
+		unpack_UA_PerformUpdateType(&out->performInsertReplace, *svp);
 
 	svp = hv_fetchs(hv, "UpdateEventDetails_filter", 0);
 	if (svp != NULL)
-		out->filter = XS_unpack_UA_EventFilter(*svp);
+		unpack_UA_EventFilter(&out->filter, *svp);
 
 	svp = hv_fetchs(hv, "UpdateEventDetails_eventData", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UpdateEventDetails_eventData");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->eventData = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_HISTORYEVENTFIELDLIST]);
-		if (out->eventData == NULL) {
+		if (out->eventData == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->eventDataSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->eventData[i] = XS_unpack_UA_HistoryEventFieldList(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_HistoryEventFieldList(&out->eventData[i], *svp);
 		}
-		out->eventDataSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DataChangeNotification */
 #ifdef UA_TYPES_DATACHANGENOTIFICATION
-static void XS_pack_UA_DataChangeNotification(SV *out, UA_DataChangeNotification in)  __attribute__((unused));
-static UA_DataChangeNotification XS_unpack_UA_DataChangeNotification(SV *in)  __attribute__((unused));
 static void pack_UA_DataChangeNotification(SV *out, UA_DataChangeNotification *in);
 static void unpack_UA_DataChangeNotification(UA_DataChangeNotification *out, SV *in);
 
@@ -22650,93 +21878,87 @@ pack_UA_DataChangeNotification(SV *out, UA_DataChangeNotification *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "DataChangeNotification_monitoredItems", newRV_noinc((SV*)av));
 	av_extend(av, in->monitoredItemsSize);
 	for (i = 0; i < in->monitoredItemsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_MonitoredItemNotification(sv, in->monitoredItems[i]);
 		av_push(av, sv);
+		pack_UA_MonitoredItemNotification(sv, &in->monitoredItems[i]);
 	}
-	hv_stores(hv, "DataChangeNotification_monitoredItems", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataChangeNotification_diagnosticInfos", newRV_noinc((SV*)av));
 	av_extend(av, in->diagnosticInfosSize);
 	for (i = 0; i < in->diagnosticInfosSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DiagnosticInfo(sv, in->diagnosticInfos[i]);
 		av_push(av, sv);
+		pack_UA_DiagnosticInfo(sv, &in->diagnosticInfos[i]);
 	}
-	hv_stores(hv, "DataChangeNotification_diagnosticInfos", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DataChangeNotification(UA_DataChangeNotification *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DataChangeNotification_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DataChangeNotification_monitoredItems", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataChangeNotification_monitoredItems");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->monitoredItems = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_MONITOREDITEMNOTIFICATION]);
-		if (out->monitoredItems == NULL) {
+		if (out->monitoredItems == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->monitoredItemsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->monitoredItems[i] = XS_unpack_UA_MonitoredItemNotification(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_MonitoredItemNotification(&out->monitoredItems[i], *svp);
 		}
-		out->monitoredItemsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataChangeNotification_diagnosticInfos", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataChangeNotification_diagnosticInfos");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->diagnosticInfos = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DIAGNOSTICINFO]);
-		if (out->diagnosticInfos == NULL) {
+		if (out->diagnosticInfos == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->diagnosticInfosSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->diagnosticInfos[i] = XS_unpack_UA_DiagnosticInfo(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DiagnosticInfo(&out->diagnosticInfos[i], *svp);
 		}
-		out->diagnosticInfosSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* EventNotificationList */
 #ifdef UA_TYPES_EVENTNOTIFICATIONLIST
-static void XS_pack_UA_EventNotificationList(SV *out, UA_EventNotificationList in)  __attribute__((unused));
-static UA_EventNotificationList XS_unpack_UA_EventNotificationList(SV *in)  __attribute__((unused));
 static void pack_UA_EventNotificationList(SV *out, UA_EventNotificationList *in);
 static void unpack_UA_EventNotificationList(UA_EventNotificationList *out, SV *in);
 
@@ -22747,64 +21969,61 @@ pack_UA_EventNotificationList(SV *out, UA_EventNotificationList *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "EventNotificationList_events", newRV_noinc((SV*)av));
 	av_extend(av, in->eventsSize);
 	for (i = 0; i < in->eventsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EventFieldList(sv, in->events[i]);
 		av_push(av, sv);
+		pack_UA_EventFieldList(sv, &in->events[i]);
 	}
-	hv_stores(hv, "EventNotificationList_events", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_EventNotificationList(UA_EventNotificationList *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EventNotificationList_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EventNotificationList_events", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for EventNotificationList_events");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->events = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_EVENTFIELDLIST]);
-		if (out->events == NULL) {
+		if (out->events == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->eventsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->events[i] = XS_unpack_UA_EventFieldList(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EventFieldList(&out->events[i], *svp);
 		}
-		out->eventsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* SessionDiagnosticsDataType */
 #ifdef UA_TYPES_SESSIONDIAGNOSTICSDATATYPE
-static void XS_pack_UA_SessionDiagnosticsDataType(SV *out, UA_SessionDiagnosticsDataType in)  __attribute__((unused));
-static UA_SessionDiagnosticsDataType XS_unpack_UA_SessionDiagnosticsDataType(SV *in)  __attribute__((unused));
 static void pack_UA_SessionDiagnosticsDataType(SV *out, UA_SessionDiagnosticsDataType *in);
 static void unpack_UA_SessionDiagnosticsDataType(UA_SessionDiagnosticsDataType *out, SV *in);
 
@@ -22815,400 +22034,397 @@ pack_UA_SessionDiagnosticsDataType(SV *out, UA_SessionDiagnosticsDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->sessionId);
 	hv_stores(hv, "SessionDiagnosticsDataType_sessionId", sv);
+	pack_UA_NodeId(sv, &in->sessionId);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->sessionName);
 	hv_stores(hv, "SessionDiagnosticsDataType_sessionName", sv);
+	pack_UA_String(sv, &in->sessionName);
 
 	sv = newSV(0);
-	XS_pack_UA_ApplicationDescription(sv, in->clientDescription);
 	hv_stores(hv, "SessionDiagnosticsDataType_clientDescription", sv);
+	pack_UA_ApplicationDescription(sv, &in->clientDescription);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->serverUri);
 	hv_stores(hv, "SessionDiagnosticsDataType_serverUri", sv);
+	pack_UA_String(sv, &in->serverUri);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->endpointUrl);
 	hv_stores(hv, "SessionDiagnosticsDataType_endpointUrl", sv);
+	pack_UA_String(sv, &in->endpointUrl);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "SessionDiagnosticsDataType_localeIds", newRV_noinc((SV*)av));
 	av_extend(av, in->localeIdsSize);
 	for (i = 0; i < in->localeIdsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->localeIds[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->localeIds[i]);
 	}
-	hv_stores(hv, "SessionDiagnosticsDataType_localeIds", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->actualSessionTimeout);
 	hv_stores(hv, "SessionDiagnosticsDataType_actualSessionTimeout", sv);
+	pack_UA_Double(sv, &in->actualSessionTimeout);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxResponseMessageSize);
 	hv_stores(hv, "SessionDiagnosticsDataType_maxResponseMessageSize", sv);
+	pack_UA_UInt32(sv, &in->maxResponseMessageSize);
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->clientConnectionTime);
 	hv_stores(hv, "SessionDiagnosticsDataType_clientConnectionTime", sv);
+	pack_UA_DateTime(sv, &in->clientConnectionTime);
 
 	sv = newSV(0);
-	XS_pack_UA_DateTime(sv, in->clientLastContactTime);
 	hv_stores(hv, "SessionDiagnosticsDataType_clientLastContactTime", sv);
+	pack_UA_DateTime(sv, &in->clientLastContactTime);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->currentSubscriptionsCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_currentSubscriptionsCount", sv);
+	pack_UA_UInt32(sv, &in->currentSubscriptionsCount);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->currentMonitoredItemsCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_currentMonitoredItemsCount", sv);
+	pack_UA_UInt32(sv, &in->currentMonitoredItemsCount);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->currentPublishRequestsInQueue);
 	hv_stores(hv, "SessionDiagnosticsDataType_currentPublishRequestsInQueue", sv);
+	pack_UA_UInt32(sv, &in->currentPublishRequestsInQueue);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->totalRequestCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_totalRequestCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->totalRequestCount);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->unauthorizedRequestCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_unauthorizedRequestCount", sv);
+	pack_UA_UInt32(sv, &in->unauthorizedRequestCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->readCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_readCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->readCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->historyReadCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_historyReadCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->historyReadCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->writeCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_writeCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->writeCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->historyUpdateCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_historyUpdateCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->historyUpdateCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->callCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_callCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->callCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->createMonitoredItemsCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_createMonitoredItemsCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->createMonitoredItemsCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->modifyMonitoredItemsCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_modifyMonitoredItemsCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->modifyMonitoredItemsCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->setMonitoringModeCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_setMonitoringModeCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->setMonitoringModeCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->setTriggeringCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_setTriggeringCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->setTriggeringCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->deleteMonitoredItemsCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_deleteMonitoredItemsCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->deleteMonitoredItemsCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->createSubscriptionCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_createSubscriptionCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->createSubscriptionCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->modifySubscriptionCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_modifySubscriptionCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->modifySubscriptionCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->setPublishingModeCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_setPublishingModeCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->setPublishingModeCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->publishCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_publishCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->publishCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->republishCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_republishCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->republishCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->transferSubscriptionsCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_transferSubscriptionsCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->transferSubscriptionsCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->deleteSubscriptionsCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_deleteSubscriptionsCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->deleteSubscriptionsCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->addNodesCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_addNodesCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->addNodesCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->addReferencesCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_addReferencesCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->addReferencesCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->deleteNodesCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_deleteNodesCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->deleteNodesCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->deleteReferencesCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_deleteReferencesCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->deleteReferencesCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->browseCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_browseCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->browseCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->browseNextCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_browseNextCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->browseNextCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->translateBrowsePathsToNodeIdsCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_translateBrowsePathsToNodeIdsCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->translateBrowsePathsToNodeIdsCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->queryFirstCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_queryFirstCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->queryFirstCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->queryNextCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_queryNextCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->queryNextCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->registerNodesCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_registerNodesCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->registerNodesCount);
 
 	sv = newSV(0);
-	XS_pack_UA_ServiceCounterDataType(sv, in->unregisterNodesCount);
 	hv_stores(hv, "SessionDiagnosticsDataType_unregisterNodesCount", sv);
+	pack_UA_ServiceCounterDataType(sv, &in->unregisterNodesCount);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_SessionDiagnosticsDataType(UA_SessionDiagnosticsDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_SessionDiagnosticsDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_sessionId", 0);
 	if (svp != NULL)
-		out->sessionId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->sessionId, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_sessionName", 0);
 	if (svp != NULL)
-		out->sessionName = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->sessionName, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_clientDescription", 0);
 	if (svp != NULL)
-		out->clientDescription = XS_unpack_UA_ApplicationDescription(*svp);
+		unpack_UA_ApplicationDescription(&out->clientDescription, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_serverUri", 0);
 	if (svp != NULL)
-		out->serverUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->serverUri, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_endpointUrl", 0);
 	if (svp != NULL)
-		out->endpointUrl = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->endpointUrl, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_localeIds", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for SessionDiagnosticsDataType_localeIds");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->localeIds = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->localeIds == NULL) {
+		if (out->localeIds == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->localeIdsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->localeIds[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->localeIds[i], *svp);
 		}
-		out->localeIdsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_actualSessionTimeout", 0);
 	if (svp != NULL)
-		out->actualSessionTimeout = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->actualSessionTimeout, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_maxResponseMessageSize", 0);
 	if (svp != NULL)
-		out->maxResponseMessageSize = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxResponseMessageSize, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_clientConnectionTime", 0);
 	if (svp != NULL)
-		out->clientConnectionTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->clientConnectionTime, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_clientLastContactTime", 0);
 	if (svp != NULL)
-		out->clientLastContactTime = XS_unpack_UA_DateTime(*svp);
+		unpack_UA_DateTime(&out->clientLastContactTime, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_currentSubscriptionsCount", 0);
 	if (svp != NULL)
-		out->currentSubscriptionsCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->currentSubscriptionsCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_currentMonitoredItemsCount", 0);
 	if (svp != NULL)
-		out->currentMonitoredItemsCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->currentMonitoredItemsCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_currentPublishRequestsInQueue", 0);
 	if (svp != NULL)
-		out->currentPublishRequestsInQueue = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->currentPublishRequestsInQueue, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_totalRequestCount", 0);
 	if (svp != NULL)
-		out->totalRequestCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->totalRequestCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_unauthorizedRequestCount", 0);
 	if (svp != NULL)
-		out->unauthorizedRequestCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->unauthorizedRequestCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_readCount", 0);
 	if (svp != NULL)
-		out->readCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->readCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_historyReadCount", 0);
 	if (svp != NULL)
-		out->historyReadCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->historyReadCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_writeCount", 0);
 	if (svp != NULL)
-		out->writeCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->writeCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_historyUpdateCount", 0);
 	if (svp != NULL)
-		out->historyUpdateCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->historyUpdateCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_callCount", 0);
 	if (svp != NULL)
-		out->callCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->callCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_createMonitoredItemsCount", 0);
 	if (svp != NULL)
-		out->createMonitoredItemsCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->createMonitoredItemsCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_modifyMonitoredItemsCount", 0);
 	if (svp != NULL)
-		out->modifyMonitoredItemsCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->modifyMonitoredItemsCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_setMonitoringModeCount", 0);
 	if (svp != NULL)
-		out->setMonitoringModeCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->setMonitoringModeCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_setTriggeringCount", 0);
 	if (svp != NULL)
-		out->setTriggeringCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->setTriggeringCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_deleteMonitoredItemsCount", 0);
 	if (svp != NULL)
-		out->deleteMonitoredItemsCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->deleteMonitoredItemsCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_createSubscriptionCount", 0);
 	if (svp != NULL)
-		out->createSubscriptionCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->createSubscriptionCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_modifySubscriptionCount", 0);
 	if (svp != NULL)
-		out->modifySubscriptionCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->modifySubscriptionCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_setPublishingModeCount", 0);
 	if (svp != NULL)
-		out->setPublishingModeCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->setPublishingModeCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_publishCount", 0);
 	if (svp != NULL)
-		out->publishCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->publishCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_republishCount", 0);
 	if (svp != NULL)
-		out->republishCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->republishCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_transferSubscriptionsCount", 0);
 	if (svp != NULL)
-		out->transferSubscriptionsCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->transferSubscriptionsCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_deleteSubscriptionsCount", 0);
 	if (svp != NULL)
-		out->deleteSubscriptionsCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->deleteSubscriptionsCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_addNodesCount", 0);
 	if (svp != NULL)
-		out->addNodesCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->addNodesCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_addReferencesCount", 0);
 	if (svp != NULL)
-		out->addReferencesCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->addReferencesCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_deleteNodesCount", 0);
 	if (svp != NULL)
-		out->deleteNodesCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->deleteNodesCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_deleteReferencesCount", 0);
 	if (svp != NULL)
-		out->deleteReferencesCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->deleteReferencesCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_browseCount", 0);
 	if (svp != NULL)
-		out->browseCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->browseCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_browseNextCount", 0);
 	if (svp != NULL)
-		out->browseNextCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->browseNextCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_translateBrowsePathsToNodeIdsCount", 0);
 	if (svp != NULL)
-		out->translateBrowsePathsToNodeIdsCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->translateBrowsePathsToNodeIdsCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_queryFirstCount", 0);
 	if (svp != NULL)
-		out->queryFirstCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->queryFirstCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_queryNextCount", 0);
 	if (svp != NULL)
-		out->queryNextCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->queryNextCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_registerNodesCount", 0);
 	if (svp != NULL)
-		out->registerNodesCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->registerNodesCount, *svp);
 
 	svp = hv_fetchs(hv, "SessionDiagnosticsDataType_unregisterNodesCount", 0);
 	if (svp != NULL)
-		out->unregisterNodesCount = XS_unpack_UA_ServiceCounterDataType(*svp);
+		unpack_UA_ServiceCounterDataType(&out->unregisterNodesCount, *svp);
 
-
+	return;
 }
 #endif
 
 /* EnumDescription */
 #ifdef UA_TYPES_ENUMDESCRIPTION
-static void XS_pack_UA_EnumDescription(SV *out, UA_EnumDescription in)  __attribute__((unused));
-static UA_EnumDescription XS_unpack_UA_EnumDescription(SV *in)  __attribute__((unused));
 static void pack_UA_EnumDescription(SV *out, UA_EnumDescription *in);
 static void unpack_UA_EnumDescription(UA_EnumDescription *out, SV *in);
 
@@ -23217,65 +22433,65 @@ pack_UA_EnumDescription(SV *out, UA_EnumDescription *in)
 {
 	dTHX;
 	SV *sv;
-	HV *hv = newHV();
+	HV *hv;
 
-	sv = newSV(0);
-	XS_pack_UA_NodeId(sv, in->dataTypeId);
-	hv_stores(hv, "EnumDescription_dataTypeId", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_QualifiedName(sv, in->name);
-	hv_stores(hv, "EnumDescription_name", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_EnumDefinition(sv, in->enumDefinition);
-	hv_stores(hv, "EnumDescription_enumDefinition", sv);
-
-	sv = newSV(0);
-	XS_pack_UA_Byte(sv, in->builtInType);
-	hv_stores(hv, "EnumDescription_builtInType", sv);
-
+	hv = newHV();
 	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumDescription_dataTypeId", sv);
+	pack_UA_NodeId(sv, &in->dataTypeId);
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumDescription_name", sv);
+	pack_UA_QualifiedName(sv, &in->name);
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumDescription_enumDefinition", sv);
+	pack_UA_EnumDefinition(sv, &in->enumDefinition);
+
+	sv = newSV(0);
+	hv_stores(hv, "EnumDescription_builtInType", sv);
+	pack_UA_Byte(sv, &in->builtInType);
+
+	return;
 }
 
 static void
 unpack_UA_EnumDescription(UA_EnumDescription *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_EnumDescription_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "EnumDescription_dataTypeId", 0);
 	if (svp != NULL)
-		out->dataTypeId = XS_unpack_UA_NodeId(*svp);
+		unpack_UA_NodeId(&out->dataTypeId, *svp);
 
 	svp = hv_fetchs(hv, "EnumDescription_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_QualifiedName(*svp);
+		unpack_UA_QualifiedName(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "EnumDescription_enumDefinition", 0);
 	if (svp != NULL)
-		out->enumDefinition = XS_unpack_UA_EnumDefinition(*svp);
+		unpack_UA_EnumDefinition(&out->enumDefinition, *svp);
 
 	svp = hv_fetchs(hv, "EnumDescription_builtInType", 0);
 	if (svp != NULL)
-		out->builtInType = XS_unpack_UA_Byte(*svp);
+		unpack_UA_Byte(&out->builtInType, *svp);
 
-
+	return;
 }
 #endif
 
 /* UABinaryFileDataType */
 #ifdef UA_TYPES_UABINARYFILEDATATYPE
-static void XS_pack_UA_UABinaryFileDataType(SV *out, UA_UABinaryFileDataType in)  __attribute__((unused));
-static UA_UABinaryFileDataType XS_unpack_UA_UABinaryFileDataType(SV *in)  __attribute__((unused));
 static void pack_UA_UABinaryFileDataType(SV *out, UA_UABinaryFileDataType *in);
 static void unpack_UA_UABinaryFileDataType(UA_UABinaryFileDataType *out, SV *in);
 
@@ -23286,196 +22502,181 @@ pack_UA_UABinaryFileDataType(SV *out, UA_UABinaryFileDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "UABinaryFileDataType_namespaces", newRV_noinc((SV*)av));
 	av_extend(av, in->namespacesSize);
 	for (i = 0; i < in->namespacesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->namespaces[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->namespaces[i]);
 	}
-	hv_stores(hv, "UABinaryFileDataType_namespaces", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "UABinaryFileDataType_structureDataTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->structureDataTypesSize);
 	for (i = 0; i < in->structureDataTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StructureDescription(sv, in->structureDataTypes[i]);
 		av_push(av, sv);
+		pack_UA_StructureDescription(sv, &in->structureDataTypes[i]);
 	}
-	hv_stores(hv, "UABinaryFileDataType_structureDataTypes", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "UABinaryFileDataType_enumDataTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->enumDataTypesSize);
 	for (i = 0; i < in->enumDataTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EnumDescription(sv, in->enumDataTypes[i]);
 		av_push(av, sv);
+		pack_UA_EnumDescription(sv, &in->enumDataTypes[i]);
 	}
-	hv_stores(hv, "UABinaryFileDataType_enumDataTypes", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "UABinaryFileDataType_simpleDataTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->simpleDataTypesSize);
 	for (i = 0; i < in->simpleDataTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_SimpleTypeDescription(sv, in->simpleDataTypes[i]);
 		av_push(av, sv);
+		pack_UA_SimpleTypeDescription(sv, &in->simpleDataTypes[i]);
 	}
-	hv_stores(hv, "UABinaryFileDataType_simpleDataTypes", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->schemaLocation);
 	hv_stores(hv, "UABinaryFileDataType_schemaLocation", sv);
+	pack_UA_String(sv, &in->schemaLocation);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "UABinaryFileDataType_fileHeader", newRV_noinc((SV*)av));
 	av_extend(av, in->fileHeaderSize);
 	for (i = 0; i < in->fileHeaderSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_KeyValuePair(sv, in->fileHeader[i]);
 		av_push(av, sv);
+		pack_UA_KeyValuePair(sv, &in->fileHeader[i]);
 	}
-	hv_stores(hv, "UABinaryFileDataType_fileHeader", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->body);
 	hv_stores(hv, "UABinaryFileDataType_body", sv);
+	pack_UA_Variant(sv, &in->body);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_UABinaryFileDataType(UA_UABinaryFileDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_UABinaryFileDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "UABinaryFileDataType_namespaces", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UABinaryFileDataType_namespaces");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->namespaces = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->namespaces == NULL) {
+		if (out->namespaces == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->namespacesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->namespaces[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->namespaces[i], *svp);
 		}
-		out->namespacesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "UABinaryFileDataType_structureDataTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UABinaryFileDataType_structureDataTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->structureDataTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRUCTUREDESCRIPTION]);
-		if (out->structureDataTypes == NULL) {
+		if (out->structureDataTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->structureDataTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->structureDataTypes[i] = XS_unpack_UA_StructureDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StructureDescription(&out->structureDataTypes[i], *svp);
 		}
-		out->structureDataTypesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "UABinaryFileDataType_enumDataTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UABinaryFileDataType_enumDataTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->enumDataTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENUMDESCRIPTION]);
-		if (out->enumDataTypes == NULL) {
+		if (out->enumDataTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->enumDataTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->enumDataTypes[i] = XS_unpack_UA_EnumDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EnumDescription(&out->enumDataTypes[i], *svp);
 		}
-		out->enumDataTypesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "UABinaryFileDataType_simpleDataTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UABinaryFileDataType_simpleDataTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->simpleDataTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIMPLETYPEDESCRIPTION]);
-		if (out->simpleDataTypes == NULL) {
+		if (out->simpleDataTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->simpleDataTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->simpleDataTypes[i] = XS_unpack_UA_SimpleTypeDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_SimpleTypeDescription(&out->simpleDataTypes[i], *svp);
 		}
-		out->simpleDataTypesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "UABinaryFileDataType_schemaLocation", 0);
 	if (svp != NULL)
-		out->schemaLocation = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->schemaLocation, *svp);
 
 	svp = hv_fetchs(hv, "UABinaryFileDataType_fileHeader", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for UABinaryFileDataType_fileHeader");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->fileHeader = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-		if (out->fileHeader == NULL) {
+		if (out->fileHeader == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->fileHeaderSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->fileHeader[i] = XS_unpack_UA_KeyValuePair(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_KeyValuePair(&out->fileHeader[i], *svp);
 		}
-		out->fileHeaderSize = i;
 	}
 
 	svp = hv_fetchs(hv, "UABinaryFileDataType_body", 0);
 	if (svp != NULL)
-		out->body = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->body, *svp);
 
-
+	return;
 }
 #endif
 
 /* DataSetMetaDataType */
 #ifdef UA_TYPES_DATASETMETADATATYPE
-static void XS_pack_UA_DataSetMetaDataType(SV *out, UA_DataSetMetaDataType in)  __attribute__((unused));
-static UA_DataSetMetaDataType XS_unpack_UA_DataSetMetaDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetMetaDataType(SV *out, UA_DataSetMetaDataType *in);
 static void unpack_UA_DataSetMetaDataType(UA_DataSetMetaDataType *out, SV *in);
 
@@ -23486,212 +22687,197 @@ pack_UA_DataSetMetaDataType(SV *out, UA_DataSetMetaDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "DataSetMetaDataType_namespaces", newRV_noinc((SV*)av));
 	av_extend(av, in->namespacesSize);
 	for (i = 0; i < in->namespacesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->namespaces[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->namespaces[i]);
 	}
-	hv_stores(hv, "DataSetMetaDataType_namespaces", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataSetMetaDataType_structureDataTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->structureDataTypesSize);
 	for (i = 0; i < in->structureDataTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StructureDescription(sv, in->structureDataTypes[i]);
 		av_push(av, sv);
+		pack_UA_StructureDescription(sv, &in->structureDataTypes[i]);
 	}
-	hv_stores(hv, "DataSetMetaDataType_structureDataTypes", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataSetMetaDataType_enumDataTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->enumDataTypesSize);
 	for (i = 0; i < in->enumDataTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EnumDescription(sv, in->enumDataTypes[i]);
 		av_push(av, sv);
+		pack_UA_EnumDescription(sv, &in->enumDataTypes[i]);
 	}
-	hv_stores(hv, "DataSetMetaDataType_enumDataTypes", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataSetMetaDataType_simpleDataTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->simpleDataTypesSize);
 	for (i = 0; i < in->simpleDataTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_SimpleTypeDescription(sv, in->simpleDataTypes[i]);
 		av_push(av, sv);
+		pack_UA_SimpleTypeDescription(sv, &in->simpleDataTypes[i]);
 	}
-	hv_stores(hv, "DataSetMetaDataType_simpleDataTypes", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "DataSetMetaDataType_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_LocalizedText(sv, in->description);
 	hv_stores(hv, "DataSetMetaDataType_description", sv);
+	pack_UA_LocalizedText(sv, &in->description);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataSetMetaDataType_fields", newRV_noinc((SV*)av));
 	av_extend(av, in->fieldsSize);
 	for (i = 0; i < in->fieldsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_FieldMetaData(sv, in->fields[i]);
 		av_push(av, sv);
+		pack_UA_FieldMetaData(sv, &in->fields[i]);
 	}
-	hv_stores(hv, "DataSetMetaDataType_fields", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_Guid(sv, in->dataSetClassId);
 	hv_stores(hv, "DataSetMetaDataType_dataSetClassId", sv);
+	pack_UA_Guid(sv, &in->dataSetClassId);
 
 	sv = newSV(0);
-	XS_pack_UA_ConfigurationVersionDataType(sv, in->configurationVersion);
 	hv_stores(hv, "DataSetMetaDataType_configurationVersion", sv);
+	pack_UA_ConfigurationVersionDataType(sv, &in->configurationVersion);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DataSetMetaDataType(UA_DataSetMetaDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DataSetMetaDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DataSetMetaDataType_namespaces", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataSetMetaDataType_namespaces");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->namespaces = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->namespaces == NULL) {
+		if (out->namespaces == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->namespacesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->namespaces[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->namespaces[i], *svp);
 		}
-		out->namespacesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataSetMetaDataType_structureDataTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataSetMetaDataType_structureDataTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->structureDataTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRUCTUREDESCRIPTION]);
-		if (out->structureDataTypes == NULL) {
+		if (out->structureDataTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->structureDataTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->structureDataTypes[i] = XS_unpack_UA_StructureDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StructureDescription(&out->structureDataTypes[i], *svp);
 		}
-		out->structureDataTypesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataSetMetaDataType_enumDataTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataSetMetaDataType_enumDataTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->enumDataTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENUMDESCRIPTION]);
-		if (out->enumDataTypes == NULL) {
+		if (out->enumDataTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->enumDataTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->enumDataTypes[i] = XS_unpack_UA_EnumDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EnumDescription(&out->enumDataTypes[i], *svp);
 		}
-		out->enumDataTypesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataSetMetaDataType_simpleDataTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataSetMetaDataType_simpleDataTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->simpleDataTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIMPLETYPEDESCRIPTION]);
-		if (out->simpleDataTypes == NULL) {
+		if (out->simpleDataTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->simpleDataTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->simpleDataTypes[i] = XS_unpack_UA_SimpleTypeDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_SimpleTypeDescription(&out->simpleDataTypes[i], *svp);
 		}
-		out->simpleDataTypesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataSetMetaDataType_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "DataSetMetaDataType_description", 0);
 	if (svp != NULL)
-		out->description = XS_unpack_UA_LocalizedText(*svp);
+		unpack_UA_LocalizedText(&out->description, *svp);
 
 	svp = hv_fetchs(hv, "DataSetMetaDataType_fields", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataSetMetaDataType_fields");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->fields = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_FIELDMETADATA]);
-		if (out->fields == NULL) {
+		if (out->fields == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->fieldsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->fields[i] = XS_unpack_UA_FieldMetaData(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_FieldMetaData(&out->fields[i], *svp);
 		}
-		out->fieldsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataSetMetaDataType_dataSetClassId", 0);
 	if (svp != NULL)
-		out->dataSetClassId = XS_unpack_UA_Guid(*svp);
+		unpack_UA_Guid(&out->dataSetClassId, *svp);
 
 	svp = hv_fetchs(hv, "DataSetMetaDataType_configurationVersion", 0);
 	if (svp != NULL)
-		out->configurationVersion = XS_unpack_UA_ConfigurationVersionDataType(*svp);
+		unpack_UA_ConfigurationVersionDataType(&out->configurationVersion, *svp);
 
-
+	return;
 }
 #endif
 
 /* PublishedDataSetDataType */
 #ifdef UA_TYPES_PUBLISHEDDATASETDATATYPE
-static void XS_pack_UA_PublishedDataSetDataType(SV *out, UA_PublishedDataSetDataType in)  __attribute__((unused));
-static UA_PublishedDataSetDataType XS_unpack_UA_PublishedDataSetDataType(SV *in)  __attribute__((unused));
 static void pack_UA_PublishedDataSetDataType(SV *out, UA_PublishedDataSetDataType *in);
 static void unpack_UA_PublishedDataSetDataType(UA_PublishedDataSetDataType *out, SV *in);
 
@@ -23702,117 +22888,111 @@ pack_UA_PublishedDataSetDataType(SV *out, UA_PublishedDataSetDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "PublishedDataSetDataType_name", sv);
+	pack_UA_String(sv, &in->name);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PublishedDataSetDataType_dataSetFolder", newRV_noinc((SV*)av));
 	av_extend(av, in->dataSetFolderSize);
 	for (i = 0; i < in->dataSetFolderSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->dataSetFolder[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->dataSetFolder[i]);
 	}
-	hv_stores(hv, "PublishedDataSetDataType_dataSetFolder", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_DataSetMetaDataType(sv, in->dataSetMetaData);
 	hv_stores(hv, "PublishedDataSetDataType_dataSetMetaData", sv);
+	pack_UA_DataSetMetaDataType(sv, &in->dataSetMetaData);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PublishedDataSetDataType_extensionFields", newRV_noinc((SV*)av));
 	av_extend(av, in->extensionFieldsSize);
 	for (i = 0; i < in->extensionFieldsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_KeyValuePair(sv, in->extensionFields[i]);
 		av_push(av, sv);
+		pack_UA_KeyValuePair(sv, &in->extensionFields[i]);
 	}
-	hv_stores(hv, "PublishedDataSetDataType_extensionFields", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->dataSetSource);
 	hv_stores(hv, "PublishedDataSetDataType_dataSetSource", sv);
+	pack_UA_ExtensionObject(sv, &in->dataSetSource);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_PublishedDataSetDataType(UA_PublishedDataSetDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_PublishedDataSetDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "PublishedDataSetDataType_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "PublishedDataSetDataType_dataSetFolder", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PublishedDataSetDataType_dataSetFolder");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataSetFolder = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->dataSetFolder == NULL) {
+		if (out->dataSetFolder == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataSetFolderSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataSetFolder[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->dataSetFolder[i], *svp);
 		}
-		out->dataSetFolderSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PublishedDataSetDataType_dataSetMetaData", 0);
 	if (svp != NULL)
-		out->dataSetMetaData = XS_unpack_UA_DataSetMetaDataType(*svp);
+		unpack_UA_DataSetMetaDataType(&out->dataSetMetaData, *svp);
 
 	svp = hv_fetchs(hv, "PublishedDataSetDataType_extensionFields", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PublishedDataSetDataType_extensionFields");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->extensionFields = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-		if (out->extensionFields == NULL) {
+		if (out->extensionFields == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->extensionFieldsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->extensionFields[i] = XS_unpack_UA_KeyValuePair(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_KeyValuePair(&out->extensionFields[i], *svp);
 		}
-		out->extensionFieldsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PublishedDataSetDataType_dataSetSource", 0);
 	if (svp != NULL)
-		out->dataSetSource = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->dataSetSource, *svp);
 
-
+	return;
 }
 #endif
 
 /* DataSetReaderDataType */
 #ifdef UA_TYPES_DATASETREADERDATATYPE
-static void XS_pack_UA_DataSetReaderDataType(SV *out, UA_DataSetReaderDataType in)  __attribute__((unused));
-static UA_DataSetReaderDataType XS_unpack_UA_DataSetReaderDataType(SV *in)  __attribute__((unused));
 static void pack_UA_DataSetReaderDataType(SV *out, UA_DataSetReaderDataType *in);
 static void unpack_UA_DataSetReaderDataType(UA_DataSetReaderDataType *out, SV *in);
 
@@ -23823,213 +23003,207 @@ pack_UA_DataSetReaderDataType(SV *out, UA_DataSetReaderDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "DataSetReaderDataType_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->enabled);
 	hv_stores(hv, "DataSetReaderDataType_enabled", sv);
+	pack_UA_Boolean(sv, &in->enabled);
 
 	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->publisherId);
 	hv_stores(hv, "DataSetReaderDataType_publisherId", sv);
+	pack_UA_Variant(sv, &in->publisherId);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt16(sv, in->writerGroupId);
 	hv_stores(hv, "DataSetReaderDataType_writerGroupId", sv);
+	pack_UA_UInt16(sv, &in->writerGroupId);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt16(sv, in->dataSetWriterId);
 	hv_stores(hv, "DataSetReaderDataType_dataSetWriterId", sv);
+	pack_UA_UInt16(sv, &in->dataSetWriterId);
 
 	sv = newSV(0);
-	XS_pack_UA_DataSetMetaDataType(sv, in->dataSetMetaData);
 	hv_stores(hv, "DataSetReaderDataType_dataSetMetaData", sv);
+	pack_UA_DataSetMetaDataType(sv, &in->dataSetMetaData);
 
 	sv = newSV(0);
-	XS_pack_UA_DataSetFieldContentMask(sv, in->dataSetFieldContentMask);
 	hv_stores(hv, "DataSetReaderDataType_dataSetFieldContentMask", sv);
+	pack_UA_DataSetFieldContentMask(sv, &in->dataSetFieldContentMask);
 
 	sv = newSV(0);
-	XS_pack_UA_Double(sv, in->messageReceiveTimeout);
 	hv_stores(hv, "DataSetReaderDataType_messageReceiveTimeout", sv);
+	pack_UA_Double(sv, &in->messageReceiveTimeout);
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->keyFrameCount);
 	hv_stores(hv, "DataSetReaderDataType_keyFrameCount", sv);
+	pack_UA_UInt32(sv, &in->keyFrameCount);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->headerLayoutUri);
 	hv_stores(hv, "DataSetReaderDataType_headerLayoutUri", sv);
+	pack_UA_String(sv, &in->headerLayoutUri);
 
 	sv = newSV(0);
-	XS_pack_UA_MessageSecurityMode(sv, in->securityMode);
 	hv_stores(hv, "DataSetReaderDataType_securityMode", sv);
+	pack_UA_MessageSecurityMode(sv, &in->securityMode);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->securityGroupId);
 	hv_stores(hv, "DataSetReaderDataType_securityGroupId", sv);
+	pack_UA_String(sv, &in->securityGroupId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataSetReaderDataType_securityKeyServices", newRV_noinc((SV*)av));
 	av_extend(av, in->securityKeyServicesSize);
 	for (i = 0; i < in->securityKeyServicesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EndpointDescription(sv, in->securityKeyServices[i]);
 		av_push(av, sv);
+		pack_UA_EndpointDescription(sv, &in->securityKeyServices[i]);
 	}
-	hv_stores(hv, "DataSetReaderDataType_securityKeyServices", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataSetReaderDataType_dataSetReaderProperties", newRV_noinc((SV*)av));
 	av_extend(av, in->dataSetReaderPropertiesSize);
 	for (i = 0; i < in->dataSetReaderPropertiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_KeyValuePair(sv, in->dataSetReaderProperties[i]);
 		av_push(av, sv);
+		pack_UA_KeyValuePair(sv, &in->dataSetReaderProperties[i]);
 	}
-	hv_stores(hv, "DataSetReaderDataType_dataSetReaderProperties", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->transportSettings);
 	hv_stores(hv, "DataSetReaderDataType_transportSettings", sv);
+	pack_UA_ExtensionObject(sv, &in->transportSettings);
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->messageSettings);
 	hv_stores(hv, "DataSetReaderDataType_messageSettings", sv);
+	pack_UA_ExtensionObject(sv, &in->messageSettings);
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->subscribedDataSet);
 	hv_stores(hv, "DataSetReaderDataType_subscribedDataSet", sv);
+	pack_UA_ExtensionObject(sv, &in->subscribedDataSet);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DataSetReaderDataType(UA_DataSetReaderDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DataSetReaderDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_enabled", 0);
 	if (svp != NULL)
-		out->enabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->enabled, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_publisherId", 0);
 	if (svp != NULL)
-		out->publisherId = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->publisherId, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_writerGroupId", 0);
 	if (svp != NULL)
-		out->writerGroupId = XS_unpack_UA_UInt16(*svp);
+		unpack_UA_UInt16(&out->writerGroupId, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_dataSetWriterId", 0);
 	if (svp != NULL)
-		out->dataSetWriterId = XS_unpack_UA_UInt16(*svp);
+		unpack_UA_UInt16(&out->dataSetWriterId, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_dataSetMetaData", 0);
 	if (svp != NULL)
-		out->dataSetMetaData = XS_unpack_UA_DataSetMetaDataType(*svp);
+		unpack_UA_DataSetMetaDataType(&out->dataSetMetaData, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_dataSetFieldContentMask", 0);
 	if (svp != NULL)
-		out->dataSetFieldContentMask = XS_unpack_UA_DataSetFieldContentMask(*svp);
+		unpack_UA_DataSetFieldContentMask(&out->dataSetFieldContentMask, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_messageReceiveTimeout", 0);
 	if (svp != NULL)
-		out->messageReceiveTimeout = XS_unpack_UA_Double(*svp);
+		unpack_UA_Double(&out->messageReceiveTimeout, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_keyFrameCount", 0);
 	if (svp != NULL)
-		out->keyFrameCount = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->keyFrameCount, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_headerLayoutUri", 0);
 	if (svp != NULL)
-		out->headerLayoutUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->headerLayoutUri, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_securityMode", 0);
 	if (svp != NULL)
-		out->securityMode = XS_unpack_UA_MessageSecurityMode(*svp);
+		unpack_UA_MessageSecurityMode(&out->securityMode, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_securityGroupId", 0);
 	if (svp != NULL)
-		out->securityGroupId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->securityGroupId, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_securityKeyServices", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataSetReaderDataType_securityKeyServices");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->securityKeyServices = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
-		if (out->securityKeyServices == NULL) {
+		if (out->securityKeyServices == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->securityKeyServicesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->securityKeyServices[i] = XS_unpack_UA_EndpointDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EndpointDescription(&out->securityKeyServices[i], *svp);
 		}
-		out->securityKeyServicesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_dataSetReaderProperties", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataSetReaderDataType_dataSetReaderProperties");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataSetReaderProperties = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-		if (out->dataSetReaderProperties == NULL) {
+		if (out->dataSetReaderProperties == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataSetReaderPropertiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataSetReaderProperties[i] = XS_unpack_UA_KeyValuePair(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_KeyValuePair(&out->dataSetReaderProperties[i], *svp);
 		}
-		out->dataSetReaderPropertiesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_transportSettings", 0);
 	if (svp != NULL)
-		out->transportSettings = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->transportSettings, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_messageSettings", 0);
 	if (svp != NULL)
-		out->messageSettings = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->messageSettings, *svp);
 
 	svp = hv_fetchs(hv, "DataSetReaderDataType_subscribedDataSet", 0);
 	if (svp != NULL)
-		out->subscribedDataSet = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->subscribedDataSet, *svp);
 
-
+	return;
 }
 #endif
 
 /* TargetVariablesDataType */
 #ifdef UA_TYPES_TARGETVARIABLESDATATYPE
-static void XS_pack_UA_TargetVariablesDataType(SV *out, UA_TargetVariablesDataType in)  __attribute__((unused));
-static UA_TargetVariablesDataType XS_unpack_UA_TargetVariablesDataType(SV *in)  __attribute__((unused));
 static void pack_UA_TargetVariablesDataType(SV *out, UA_TargetVariablesDataType *in);
 static void unpack_UA_TargetVariablesDataType(UA_TargetVariablesDataType *out, SV *in);
 
@@ -24040,64 +23214,61 @@ pack_UA_TargetVariablesDataType(SV *out, UA_TargetVariablesDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "TargetVariablesDataType_targetVariables", newRV_noinc((SV*)av));
 	av_extend(av, in->targetVariablesSize);
 	for (i = 0; i < in->targetVariablesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_FieldTargetDataType(sv, in->targetVariables[i]);
 		av_push(av, sv);
+		pack_UA_FieldTargetDataType(sv, &in->targetVariables[i]);
 	}
-	hv_stores(hv, "TargetVariablesDataType_targetVariables", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_TargetVariablesDataType(UA_TargetVariablesDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_TargetVariablesDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "TargetVariablesDataType_targetVariables", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for TargetVariablesDataType_targetVariables");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->targetVariables = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_FIELDTARGETDATATYPE]);
-		if (out->targetVariables == NULL) {
+		if (out->targetVariables == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->targetVariablesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->targetVariables[i] = XS_unpack_UA_FieldTargetDataType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_FieldTargetDataType(&out->targetVariables[i], *svp);
 		}
-		out->targetVariablesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* DataTypeSchemaHeader */
 #ifdef UA_TYPES_DATATYPESCHEMAHEADER
-static void XS_pack_UA_DataTypeSchemaHeader(SV *out, UA_DataTypeSchemaHeader in)  __attribute__((unused));
-static UA_DataTypeSchemaHeader XS_unpack_UA_DataTypeSchemaHeader(SV *in)  __attribute__((unused));
 static void pack_UA_DataTypeSchemaHeader(SV *out, UA_DataTypeSchemaHeader *in);
 static void unpack_UA_DataTypeSchemaHeader(UA_DataTypeSchemaHeader *out, SV *in);
 
@@ -24108,151 +23279,139 @@ pack_UA_DataTypeSchemaHeader(SV *out, UA_DataTypeSchemaHeader *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "DataTypeSchemaHeader_namespaces", newRV_noinc((SV*)av));
 	av_extend(av, in->namespacesSize);
 	for (i = 0; i < in->namespacesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_String(sv, in->namespaces[i]);
 		av_push(av, sv);
+		pack_UA_String(sv, &in->namespaces[i]);
 	}
-	hv_stores(hv, "DataTypeSchemaHeader_namespaces", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataTypeSchemaHeader_structureDataTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->structureDataTypesSize);
 	for (i = 0; i < in->structureDataTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_StructureDescription(sv, in->structureDataTypes[i]);
 		av_push(av, sv);
+		pack_UA_StructureDescription(sv, &in->structureDataTypes[i]);
 	}
-	hv_stores(hv, "DataTypeSchemaHeader_structureDataTypes", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataTypeSchemaHeader_enumDataTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->enumDataTypesSize);
 	for (i = 0; i < in->enumDataTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EnumDescription(sv, in->enumDataTypes[i]);
 		av_push(av, sv);
+		pack_UA_EnumDescription(sv, &in->enumDataTypes[i]);
 	}
-	hv_stores(hv, "DataTypeSchemaHeader_enumDataTypes", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "DataTypeSchemaHeader_simpleDataTypes", newRV_noinc((SV*)av));
 	av_extend(av, in->simpleDataTypesSize);
 	for (i = 0; i < in->simpleDataTypesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_SimpleTypeDescription(sv, in->simpleDataTypes[i]);
 		av_push(av, sv);
+		pack_UA_SimpleTypeDescription(sv, &in->simpleDataTypes[i]);
 	}
-	hv_stores(hv, "DataTypeSchemaHeader_simpleDataTypes", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_DataTypeSchemaHeader(UA_DataTypeSchemaHeader *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_DataTypeSchemaHeader_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "DataTypeSchemaHeader_namespaces", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataTypeSchemaHeader_namespaces");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->namespaces = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRING]);
-		if (out->namespaces == NULL) {
+		if (out->namespaces == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->namespacesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->namespaces[i] = XS_unpack_UA_String(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_String(&out->namespaces[i], *svp);
 		}
-		out->namespacesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataTypeSchemaHeader_structureDataTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataTypeSchemaHeader_structureDataTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->structureDataTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_STRUCTUREDESCRIPTION]);
-		if (out->structureDataTypes == NULL) {
+		if (out->structureDataTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->structureDataTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->structureDataTypes[i] = XS_unpack_UA_StructureDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_StructureDescription(&out->structureDataTypes[i], *svp);
 		}
-		out->structureDataTypesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataTypeSchemaHeader_enumDataTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataTypeSchemaHeader_enumDataTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->enumDataTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENUMDESCRIPTION]);
-		if (out->enumDataTypes == NULL) {
+		if (out->enumDataTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->enumDataTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->enumDataTypes[i] = XS_unpack_UA_EnumDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EnumDescription(&out->enumDataTypes[i], *svp);
 		}
-		out->enumDataTypesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "DataTypeSchemaHeader_simpleDataTypes", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for DataTypeSchemaHeader_simpleDataTypes");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->simpleDataTypes = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_SIMPLETYPEDESCRIPTION]);
-		if (out->simpleDataTypes == NULL) {
+		if (out->simpleDataTypes == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->simpleDataTypesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->simpleDataTypes[i] = XS_unpack_UA_SimpleTypeDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_SimpleTypeDescription(&out->simpleDataTypes[i], *svp);
 		}
-		out->simpleDataTypesSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* ReaderGroupDataType */
 #ifdef UA_TYPES_READERGROUPDATATYPE
-static void XS_pack_UA_ReaderGroupDataType(SV *out, UA_ReaderGroupDataType in)  __attribute__((unused));
-static UA_ReaderGroupDataType XS_unpack_UA_ReaderGroupDataType(SV *in)  __attribute__((unused));
 static void pack_UA_ReaderGroupDataType(SV *out, UA_ReaderGroupDataType *in);
 static void unpack_UA_ReaderGroupDataType(UA_ReaderGroupDataType *out, SV *in);
 
@@ -24263,178 +23422,169 @@ pack_UA_ReaderGroupDataType(SV *out, UA_ReaderGroupDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "ReaderGroupDataType_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->enabled);
 	hv_stores(hv, "ReaderGroupDataType_enabled", sv);
+	pack_UA_Boolean(sv, &in->enabled);
 
 	sv = newSV(0);
-	XS_pack_UA_MessageSecurityMode(sv, in->securityMode);
 	hv_stores(hv, "ReaderGroupDataType_securityMode", sv);
+	pack_UA_MessageSecurityMode(sv, &in->securityMode);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->securityGroupId);
 	hv_stores(hv, "ReaderGroupDataType_securityGroupId", sv);
+	pack_UA_String(sv, &in->securityGroupId);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ReaderGroupDataType_securityKeyServices", newRV_noinc((SV*)av));
 	av_extend(av, in->securityKeyServicesSize);
 	for (i = 0; i < in->securityKeyServicesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_EndpointDescription(sv, in->securityKeyServices[i]);
 		av_push(av, sv);
+		pack_UA_EndpointDescription(sv, &in->securityKeyServices[i]);
 	}
-	hv_stores(hv, "ReaderGroupDataType_securityKeyServices", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_UInt32(sv, in->maxNetworkMessageSize);
 	hv_stores(hv, "ReaderGroupDataType_maxNetworkMessageSize", sv);
+	pack_UA_UInt32(sv, &in->maxNetworkMessageSize);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ReaderGroupDataType_groupProperties", newRV_noinc((SV*)av));
 	av_extend(av, in->groupPropertiesSize);
 	for (i = 0; i < in->groupPropertiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_KeyValuePair(sv, in->groupProperties[i]);
 		av_push(av, sv);
+		pack_UA_KeyValuePair(sv, &in->groupProperties[i]);
 	}
-	hv_stores(hv, "ReaderGroupDataType_groupProperties", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->transportSettings);
 	hv_stores(hv, "ReaderGroupDataType_transportSettings", sv);
+	pack_UA_ExtensionObject(sv, &in->transportSettings);
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->messageSettings);
 	hv_stores(hv, "ReaderGroupDataType_messageSettings", sv);
+	pack_UA_ExtensionObject(sv, &in->messageSettings);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "ReaderGroupDataType_dataSetReaders", newRV_noinc((SV*)av));
 	av_extend(av, in->dataSetReadersSize);
 	for (i = 0; i < in->dataSetReadersSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_DataSetReaderDataType(sv, in->dataSetReaders[i]);
 		av_push(av, sv);
+		pack_UA_DataSetReaderDataType(sv, &in->dataSetReaders[i]);
 	}
-	hv_stores(hv, "ReaderGroupDataType_dataSetReaders", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_ReaderGroupDataType(UA_ReaderGroupDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_ReaderGroupDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_enabled", 0);
 	if (svp != NULL)
-		out->enabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->enabled, *svp);
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_securityMode", 0);
 	if (svp != NULL)
-		out->securityMode = XS_unpack_UA_MessageSecurityMode(*svp);
+		unpack_UA_MessageSecurityMode(&out->securityMode, *svp);
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_securityGroupId", 0);
 	if (svp != NULL)
-		out->securityGroupId = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->securityGroupId, *svp);
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_securityKeyServices", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ReaderGroupDataType_securityKeyServices");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->securityKeyServices = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
-		if (out->securityKeyServices == NULL) {
+		if (out->securityKeyServices == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->securityKeyServicesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->securityKeyServices[i] = XS_unpack_UA_EndpointDescription(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_EndpointDescription(&out->securityKeyServices[i], *svp);
 		}
-		out->securityKeyServicesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_maxNetworkMessageSize", 0);
 	if (svp != NULL)
-		out->maxNetworkMessageSize = XS_unpack_UA_UInt32(*svp);
+		unpack_UA_UInt32(&out->maxNetworkMessageSize, *svp);
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_groupProperties", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ReaderGroupDataType_groupProperties");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->groupProperties = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-		if (out->groupProperties == NULL) {
+		if (out->groupProperties == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->groupPropertiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->groupProperties[i] = XS_unpack_UA_KeyValuePair(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_KeyValuePair(&out->groupProperties[i], *svp);
 		}
-		out->groupPropertiesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_transportSettings", 0);
 	if (svp != NULL)
-		out->transportSettings = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->transportSettings, *svp);
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_messageSettings", 0);
 	if (svp != NULL)
-		out->messageSettings = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->messageSettings, *svp);
 
 	svp = hv_fetchs(hv, "ReaderGroupDataType_dataSetReaders", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for ReaderGroupDataType_dataSetReaders");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->dataSetReaders = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_DATASETREADERDATATYPE]);
-		if (out->dataSetReaders == NULL) {
+		if (out->dataSetReaders == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->dataSetReadersSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->dataSetReaders[i] = XS_unpack_UA_DataSetReaderDataType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_DataSetReaderDataType(&out->dataSetReaders[i], *svp);
 		}
-		out->dataSetReadersSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* PubSubConnectionDataType */
 #ifdef UA_TYPES_PUBSUBCONNECTIONDATATYPE
-static void XS_pack_UA_PubSubConnectionDataType(SV *out, UA_PubSubConnectionDataType in)  __attribute__((unused));
-static UA_PubSubConnectionDataType XS_unpack_UA_PubSubConnectionDataType(SV *in)  __attribute__((unused));
 static void pack_UA_PubSubConnectionDataType(SV *out, UA_PubSubConnectionDataType *in);
 static void unpack_UA_PubSubConnectionDataType(UA_PubSubConnectionDataType *out, SV *in);
 
@@ -24445,170 +23595,161 @@ pack_UA_PubSubConnectionDataType(SV *out, UA_PubSubConnectionDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
+
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->name);
 	hv_stores(hv, "PubSubConnectionDataType_name", sv);
+	pack_UA_String(sv, &in->name);
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->enabled);
 	hv_stores(hv, "PubSubConnectionDataType_enabled", sv);
+	pack_UA_Boolean(sv, &in->enabled);
 
 	sv = newSV(0);
-	XS_pack_UA_Variant(sv, in->publisherId);
 	hv_stores(hv, "PubSubConnectionDataType_publisherId", sv);
+	pack_UA_Variant(sv, &in->publisherId);
 
 	sv = newSV(0);
-	XS_pack_UA_String(sv, in->transportProfileUri);
 	hv_stores(hv, "PubSubConnectionDataType_transportProfileUri", sv);
+	pack_UA_String(sv, &in->transportProfileUri);
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->address);
 	hv_stores(hv, "PubSubConnectionDataType_address", sv);
+	pack_UA_ExtensionObject(sv, &in->address);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PubSubConnectionDataType_connectionProperties", newRV_noinc((SV*)av));
 	av_extend(av, in->connectionPropertiesSize);
 	for (i = 0; i < in->connectionPropertiesSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_KeyValuePair(sv, in->connectionProperties[i]);
 		av_push(av, sv);
+		pack_UA_KeyValuePair(sv, &in->connectionProperties[i]);
 	}
-	hv_stores(hv, "PubSubConnectionDataType_connectionProperties", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_ExtensionObject(sv, in->transportSettings);
 	hv_stores(hv, "PubSubConnectionDataType_transportSettings", sv);
+	pack_UA_ExtensionObject(sv, &in->transportSettings);
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PubSubConnectionDataType_writerGroups", newRV_noinc((SV*)av));
 	av_extend(av, in->writerGroupsSize);
 	for (i = 0; i < in->writerGroupsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_WriterGroupDataType(sv, in->writerGroups[i]);
 		av_push(av, sv);
+		pack_UA_WriterGroupDataType(sv, &in->writerGroups[i]);
 	}
-	hv_stores(hv, "PubSubConnectionDataType_writerGroups", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PubSubConnectionDataType_readerGroups", newRV_noinc((SV*)av));
 	av_extend(av, in->readerGroupsSize);
 	for (i = 0; i < in->readerGroupsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_ReaderGroupDataType(sv, in->readerGroups[i]);
 		av_push(av, sv);
+		pack_UA_ReaderGroupDataType(sv, &in->readerGroups[i]);
 	}
-	hv_stores(hv, "PubSubConnectionDataType_readerGroups", newRV_inc((SV*)av));
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_PubSubConnectionDataType(UA_PubSubConnectionDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_PubSubConnectionDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "PubSubConnectionDataType_name", 0);
 	if (svp != NULL)
-		out->name = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->name, *svp);
 
 	svp = hv_fetchs(hv, "PubSubConnectionDataType_enabled", 0);
 	if (svp != NULL)
-		out->enabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->enabled, *svp);
 
 	svp = hv_fetchs(hv, "PubSubConnectionDataType_publisherId", 0);
 	if (svp != NULL)
-		out->publisherId = XS_unpack_UA_Variant(*svp);
+		unpack_UA_Variant(&out->publisherId, *svp);
 
 	svp = hv_fetchs(hv, "PubSubConnectionDataType_transportProfileUri", 0);
 	if (svp != NULL)
-		out->transportProfileUri = XS_unpack_UA_String(*svp);
+		unpack_UA_String(&out->transportProfileUri, *svp);
 
 	svp = hv_fetchs(hv, "PubSubConnectionDataType_address", 0);
 	if (svp != NULL)
-		out->address = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->address, *svp);
 
 	svp = hv_fetchs(hv, "PubSubConnectionDataType_connectionProperties", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PubSubConnectionDataType_connectionProperties");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->connectionProperties = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_KEYVALUEPAIR]);
-		if (out->connectionProperties == NULL) {
+		if (out->connectionProperties == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->connectionPropertiesSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->connectionProperties[i] = XS_unpack_UA_KeyValuePair(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_KeyValuePair(&out->connectionProperties[i], *svp);
 		}
-		out->connectionPropertiesSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PubSubConnectionDataType_transportSettings", 0);
 	if (svp != NULL)
-		out->transportSettings = XS_unpack_UA_ExtensionObject(*svp);
+		unpack_UA_ExtensionObject(&out->transportSettings, *svp);
 
 	svp = hv_fetchs(hv, "PubSubConnectionDataType_writerGroups", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PubSubConnectionDataType_writerGroups");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->writerGroups = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_WRITERGROUPDATATYPE]);
-		if (out->writerGroups == NULL) {
+		if (out->writerGroups == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->writerGroupsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->writerGroups[i] = XS_unpack_UA_WriterGroupDataType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_WriterGroupDataType(&out->writerGroups[i], *svp);
 		}
-		out->writerGroupsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PubSubConnectionDataType_readerGroups", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PubSubConnectionDataType_readerGroups");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->readerGroups = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_READERGROUPDATATYPE]);
-		if (out->readerGroups == NULL) {
+		if (out->readerGroups == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->readerGroupsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->readerGroups[i] = XS_unpack_UA_ReaderGroupDataType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_ReaderGroupDataType(&out->readerGroups[i], *svp);
 		}
-		out->readerGroupsSize = i;
 	}
 
-
+	return;
 }
 #endif
 
 /* PubSubConfigurationDataType */
 #ifdef UA_TYPES_PUBSUBCONFIGURATIONDATATYPE
-static void XS_pack_UA_PubSubConfigurationDataType(SV *out, UA_PubSubConfigurationDataType in)  __attribute__((unused));
-static UA_PubSubConfigurationDataType XS_unpack_UA_PubSubConfigurationDataType(SV *in)  __attribute__((unused));
 static void pack_UA_PubSubConfigurationDataType(SV *out, UA_PubSubConfigurationDataType *in);
 static void unpack_UA_PubSubConfigurationDataType(UA_PubSubConfigurationDataType *out, SV *in);
 
@@ -24619,93 +23760,89 @@ pack_UA_PubSubConfigurationDataType(SV *out, UA_PubSubConfigurationDataType *in)
 	SV *sv;
 	AV *av;
 	size_t i;
-	HV *hv = newHV();
+	HV *hv;
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	hv = newHV();
+	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+
+	av = newAV();
+	hv_stores(hv, "PubSubConfigurationDataType_publishedDataSets", newRV_noinc((SV*)av));
 	av_extend(av, in->publishedDataSetsSize);
 	for (i = 0; i < in->publishedDataSetsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_PublishedDataSetDataType(sv, in->publishedDataSets[i]);
 		av_push(av, sv);
+		pack_UA_PublishedDataSetDataType(sv, &in->publishedDataSets[i]);
 	}
-	hv_stores(hv, "PubSubConfigurationDataType_publishedDataSets", newRV_inc((SV*)av));
 
-	av = (AV*)sv_2mortal((SV*)newAV());
+	av = newAV();
+	hv_stores(hv, "PubSubConfigurationDataType_connections", newRV_noinc((SV*)av));
 	av_extend(av, in->connectionsSize);
 	for (i = 0; i < in->connectionsSize; i++) {
 		sv = newSV(0);
-		XS_pack_UA_PubSubConnectionDataType(sv, in->connections[i]);
 		av_push(av, sv);
+		pack_UA_PubSubConnectionDataType(sv, &in->connections[i]);
 	}
-	hv_stores(hv, "PubSubConfigurationDataType_connections", newRV_inc((SV*)av));
 
 	sv = newSV(0);
-	XS_pack_UA_Boolean(sv, in->enabled);
 	hv_stores(hv, "PubSubConfigurationDataType_enabled", sv);
+	pack_UA_Boolean(sv, &in->enabled);
 
-	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
+	return;
 }
 
 static void
 unpack_UA_PubSubConfigurationDataType(UA_PubSubConfigurationDataType *out, SV *in)
 {
 	dTHX;
-SV **svp;
+	SV **svp;
 	AV *av;
 	ssize_t i, top;
 	HV *hv;
 
 	SvGETMAGIC(in);
-	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 		CROAK("Not a HASH reference");
-	}
 	UA_PubSubConfigurationDataType_init(out);
 	hv = (HV*)SvRV(in);
 
 	svp = hv_fetchs(hv, "PubSubConfigurationDataType_publishedDataSets", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PubSubConfigurationDataType_publishedDataSets");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->publishedDataSets = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_PUBLISHEDDATASETDATATYPE]);
-		if (out->publishedDataSets == NULL) {
+		if (out->publishedDataSets == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->publishedDataSetsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->publishedDataSets[i] = XS_unpack_UA_PublishedDataSetDataType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_PublishedDataSetDataType(&out->publishedDataSets[i], *svp);
 		}
-		out->publishedDataSetsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PubSubConfigurationDataType_connections", 0);
 	if (svp != NULL) {
-		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 			CROAK("No ARRAY reference for PubSubConfigurationDataType_connections");
-		}
 		av = (AV*)SvRV(*svp);
 		top = av_top_index(av);
 		out->connections = UA_Array_new(top + 1, &UA_TYPES[UA_TYPES_PUBSUBCONNECTIONDATATYPE]);
-		if (out->connections == NULL) {
+		if (out->connections == NULL)
 			CROAKE("UA_Array_new");
-		}
+		out->connectionsSize = top + 1;
 		for (i = 0; i <= top; i++) {
 			svp = av_fetch(av, i, 0);
-			if (svp != NULL) {
-				out->connections[i] = XS_unpack_UA_PubSubConnectionDataType(*svp);
-			}
+			if (svp != NULL)
+				unpack_UA_PubSubConnectionDataType(&out->connections[i], *svp);
 		}
-		out->connectionsSize = i;
 	}
 
 	svp = hv_fetchs(hv, "PubSubConfigurationDataType_enabled", 0);
 	if (svp != NULL)
-		out->enabled = XS_unpack_UA_Boolean(*svp);
+		unpack_UA_Boolean(&out->enabled, *svp);
 
-
+	return;
 }
 #endif

--- a/script/packed-type.pl
+++ b/script/packed-type.pl
@@ -6,7 +6,7 @@ use warnings;
 
 open(my $in, '<', "Open62541-packed.xsh")
     or die "Open 'Open62541-packed.xsh' for reading failed: $!";
-my @types = map { m{^static UA_(\w+) XS_unpack_UA_\w+} } <$in>
+my @types = map { m{^static void pack_UA_(\w+)\(} } <$in>
     or die "No types found";
 
 local $\ = "\n";
@@ -35,14 +35,12 @@ XS_unpack_UA_$type(SV *in)
 static void
 table_pack_UA_$type(SV *sv, void *p)
 {
-	UA_$type *data = p;
-	XS_pack_UA_$type(sv, *data);
+	pack_UA_$type(sv, p);
 }
 static void
 table_unpack_UA_$type(SV *sv, void *p)
 {
-	UA_$type *data = p;
-	*data = XS_unpack_UA_$type(sv);
+	unpack_UA_$type(p, sv);
 }
 #endif
 EOF

--- a/script/patch-tools_generate_datatypes_py
+++ b/script/patch-tools_generate_datatypes_py
@@ -26,9 +26,9 @@ Index: tools/generate_datatypes.py
          return "typedef UA_" + self.baseType + " UA_%s;" % self.name
  
 +    def conversion2perl(self):
-+        return "\tXS_pack_UA_%s(out, *in);" % self.baseType
++        return "\tpack_UA_%s(out, in);" % self.baseType
 +    def conversion2c(self):
-+        return "\t*out = XS_unpack_UA_%s(in);" % self.baseType
++        return "\tunpack_UA_%s(out, in);" % self.baseType
 +
  class StructType(Type):
      def __init__(self, outname, xml, namespace):
@@ -47,12 +47,16 @@ Index: tools/generate_datatypes.py
 +                hasArray = True
 +                break
 +
-+        returnstr = "	SV *sv;\n"
++        returnstr = """	SV *sv;
++"""
 +        if hasArray:
 +            returnstr += """	AV *av;
 +	size_t i;
 +"""
-+        returnstr += """	HV *hv = newHV();
++        returnstr += """	HV *hv;
++
++	hv = newHV();
++	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));
 +
 +"""
 +        for member in self.members:
@@ -60,24 +64,23 @@ Index: tools/generate_datatypes.py
 +            fieldp = "%s_%s" % (self.name, field)
 +            type = makeCIdentifier(member.memberType.name)
 +            if member.isArray:
-+                returnstr += """	av = (AV*)sv_2mortal((SV*)newAV());
++                returnstr += """	av = newAV();
++	hv_stores(hv, "%s", newRV_noinc((SV*)av));
 +	av_extend(av, in->%sSize);
 +	for (i = 0; i < in->%sSize; i++) {
 +		sv = newSV(0);
-+		XS_pack_UA_%s(sv, in->%s[i]);
 +		av_push(av, sv);
++		pack_UA_%s(sv, &in->%s[i]);
 +	}
-+	hv_stores(hv, "%s", newRV_inc((SV*)av));
 +
-+""" % (field, field, type, field, fieldp)
++""" % (fieldp, field, field, type, field)
 +            else:
 +                returnstr += """	sv = newSV(0);
-+	XS_pack_UA_%s(sv, in->%s);
 +	hv_stores(hv, "%s", sv);
++	pack_UA_%s(sv, &in->%s);
 +
-+""" % (type, field, fieldp)
-+
-+        returnstr += """	sv_setsv(out, sv_2mortal(newRV_noinc((SV*)hv)));"""
++""" % (fieldp, type, field)
++        returnstr += "	return;"
 +        return returnstr
 +
 +    def conversion2c(self):
@@ -90,7 +93,7 @@ Index: tools/generate_datatypes.py
 +                hasArray = True
 +                break
 +
-+        returnstr = """SV **svp;
++        returnstr = """	SV **svp;
 +"""
 +        if hasArray:
 +            returnstr += """	AV *av;
@@ -99,9 +102,8 @@ Index: tools/generate_datatypes.py
 +        returnstr += """	HV *hv;
 +
 +	SvGETMAGIC(in);
-+	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV) {
++	if (!SvROK(in) || SvTYPE(SvRV(in)) != SVt_PVHV)
 +		CROAK("Not a HASH reference");
-+	}
 +	UA_%s_init(out);
 +	hv = (HV*)SvRV(in);
 +
@@ -114,32 +116,30 @@ Index: tools/generate_datatypes.py
 +            if member.isArray:
 +                returnstr += """	svp = hv_fetchs(hv, "%s", 0);
 +	if (svp != NULL) {
-+		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV) {
++		if (!SvROK(*svp) || SvTYPE(SvRV(*svp)) != SVt_PVAV)
 +			CROAK("No ARRAY reference for %s");
-+		}
 +		av = (AV*)SvRV(*svp);
 +		top = av_top_index(av);
 +		out->%s = UA_Array_new(top + 1, &UA_TYPES[%s]);
-+		if (out->%s == NULL) {
++		if (out->%s == NULL)
 +			CROAKE("UA_Array_new");
-+		}
++		out->%sSize = top + 1;
 +		for (i = 0; i <= top; i++) {
 +			svp = av_fetch(av, i, 0);
-+			if (svp != NULL) {
-+				out->%s[i] = XS_unpack_UA_%s(*svp);
-+			}
++			if (svp != NULL)
++				unpack_UA_%s(&out->%s[i], *svp);
 +		}
-+		out->%sSize = i;
 +	}
 +
 +""" % (fieldp, fieldp, field, index, field, field, type, field)
 +            else:
 +                returnstr += """	svp = hv_fetchs(hv, "%s", 0);
 +	if (svp != NULL)
-+		out->%s = XS_unpack_UA_%s(*svp);
++		unpack_UA_%s(&out->%s, *svp);
 +
-+""" % (fieldp, field, type)
-+        return returnstr
++""" % (fieldp, type, field)
++        returnstr += "	return;"
++        return returnstr 
 +
  #########################
  # Parse Typedefinitions #
@@ -161,7 +161,7 @@ Index: tools/generate_datatypes.py
  
  def iter_types(v):
      l = None
-@@ -628,6 +745,49 @@ _UA_END_DECLS
+@@ -628,6 +745,45 @@ _UA_END_DECLS
  
  #endif /* %s_GENERATED_H_ */''' % outname.upper())
  
@@ -175,8 +175,6 @@ Index: tools/generate_datatypes.py
 +    tn = t.name
 +    printp("/* %s */" % tn)
 +    printp("#ifdef UA_TYPES_%s" % tn.upper())
-+    printp("static void XS_pack_UA_%s(SV *out, UA_%s in)  __attribute__((unused));" % (tn, tn))
-+    printp("static UA_%s XS_unpack_UA_%s(SV *in)  __attribute__((unused));" % (tn, tn))
 +    printp("static void pack_UA_%s(SV *out, UA_%s *in);" % (tn, tn))
 +    printp("static void unpack_UA_%s(UA_%s *out, SV *in);" % (tn, tn))
 +    if type(t) != BuiltinType:
@@ -184,16 +182,14 @@ Index: tools/generate_datatypes.py
 +static void
 +pack_UA_%s(SV *out, UA_%s *in)
 +{
-+\tdTHX;"""
-+               % (tn, tn))
++\tdTHX;""" % (tn, tn))
 +        printp(t.conversion2perl())
 +        printp("}")
 +        printp("""
 +static void
 +unpack_UA_%s(UA_%s *out, SV *in)
 +{
-+\tdTHX;"""
-+               % (tn, tn))
++\tdTHX;""" % (tn, tn))
 +        printp(t.conversion2c())
 +        printp("}")
 +    else:
@@ -211,7 +207,7 @@ Index: tools/generate_datatypes.py
  ##################
  # Print Handling #
  ##################
-@@ -709,3 +869,4 @@ fh.close()
+@@ -709,3 +865,4 @@ fh.close()
  ff.close()
  fc.close()
  fe.close()

--- a/t/variant-array.t
+++ b/t/variant-array.t
@@ -93,11 +93,11 @@ ok($variant->hasArrayType(TYPES_BOOLEAN), "TYPES_BOOLEAN variant");
 is($variant->getType(), TYPES_BOOLEAN, "TYPES_BOOLEAN type");
 
 $variant->setArray([0, -128, 127], TYPES_SBYTE);
-throws_ok { $variant->setArray([-129, 128], TYPES_SBYTE) }
+throws_ok { $variant->setArray([1, -129, 128], TYPES_SBYTE) }
     (qr/Integer value /, "TYPES_SBYTE croak");
-no_leaks_ok { eval { $variant->setArray([-129, 128], TYPES_SBYTE) } }
+no_leaks_ok { eval { $variant->setArray([1, -129, 128], TYPES_SBYTE) } }
     "TYPES_SBYTE leak";
-is_deeply($variant->getArray(), [0, -128, 127], "TYPES_SBYTE array");
+is_deeply($variant->getArray(), [1, 127, 0], "TYPES_SBYTE array");
 ok($variant->hasArrayType(TYPES_SBYTE), "TYPES_SBYTE variant");
 is($variant->getType(), TYPES_SBYTE, "TYPES_SBYTE type");
 
@@ -106,7 +106,7 @@ throws_ok { $variant->setArray([256], TYPES_BYTE) }
     (qr/Unsigned value /, "TYPES_BYTE croak");
 no_leaks_ok { eval { $variant->setArray([256], TYPES_BYTE) } }
     "TYPES_BYTE leak";
-is_deeply($variant->getArray(), [0, 255], "TYPES_BYTE array");
+is_deeply($variant->getArray(), [0], "TYPES_BYTE array");
 ok($variant->hasArrayType(TYPES_BYTE), "TYPES_BYTE variant");
 is($variant->getType(), TYPES_BYTE, "TYPES_BYTE type");
 

--- a/typemap
+++ b/typemap
@@ -182,8 +182,7 @@ T_PTROBJ_PACKED
 		DPRINTF(\"${(my $ntt=lc($ntype))=~s/.*_//g;\$ntt} %p\", $var);
 		sv_setref_pv(svm_$var,
 		    \"${(my $ntt=$ntype)=~s/_/::/g;\$ntt}\", $var);
-		*$var =
-		    XS_unpack_UA_${(my $ntt=$ntype)=~s/.*_//g;\$ntt}($arg);
+		unpack_UA_${(my $ntt=$ntype)=~s/.*_//g;\$ntt}($var, $arg);
 	} else {
 		CROAK(\"Parameter %s is not scalar or array or hash\",
 		    \"$var\");
@@ -229,7 +228,7 @@ T_PTROBJ_SPECIAL
 #############################################################################
 OUTPUT
 T_RETVAL_PACKED
-	XS_pack_$ntype($arg, $var);
+	pack_$ntype($arg, &$var);
 	UA_${(my $ntt=$ntype)=~s/.*_//g;\$ntt}_clear(&$var);
 T_PTROBJ_PACKED
 	sv_setref_pv($arg, \"${(my $ntt=$ntype)=~s/_/::/g;\$ntt}\", $var);


### PR DESCRIPTION
The non XS packers allow manipulation of half constructed object. Always link the objects before packing them.  Then a half created object will free its subobjects during croak.