### PR TITLE
Before setting build info, clear existing strings.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -3505,6 +3505,7 @@ UA_ServerConfig_setBuildInfo(config, buildinfo)
 	OPCUA_Open62541_ServerConfig	config
 	OPCUA_Open62541_BuildInfo	buildinfo
     CODE:
+	UA_BuildInfo_clear(&config->svc_serverconfig->buildInfo);
 	UA_BuildInfo_copy(buildinfo, &config->svc_serverconfig->buildInfo);
 
 # Limits for SecureChannels


### PR DESCRIPTION
Set minimal server config fills the build info with UA strings. Set build info in server config must clear the existing build info before copy new build info which allocates new UA strings.