### PR TITLE
CI: switch to actions/checkout@v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: ubuntu:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: apt update
       run: apt-get update
     - name: Install base packages


### PR DESCRIPTION
* Since node12 has been deprecated in github actions, the workflow should use checkout@v3 now.