### PR TITLE
UA_ClientConfig_setUsernamePassword: anonymous

### DIFF
--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -738,6 +738,16 @@ In scalar context return 1.0 API compatible $client_state.
 
 =item $logger = $client_config->getLogger()
 
+=item $client_config->setUsernamePassword($userName, $password)
+
+With this method a username and password can be set for the OPC UA connection.
+If $userName is an empty string or undef, username and password are cleared in
+the client configuration.
+Calling this method will also clear endpoint and userTokenPolicy data in the
+client configuration that may exist from previous connection.
+If a previous connection was made, the client will again try to get and match
+the endpoints and policies from the server.
+
 =back
 
 =head3 Logger

--- a/t/client-config-userpass.t
+++ b/t/client-config-userpass.t
@@ -5,7 +5,7 @@ use OPCUA::Open62541 qw(:STATUSCODE);
 use OPCUA::Open62541::Test::Server;
 use OPCUA::Open62541::Test::Client;
 
-use Test::More tests => 30;
+use Test::More tests => 39;
 
 use Test::Exception;
 use Test::LeakTrace;
@@ -24,7 +24,25 @@ no_leaks_ok {
 } "setUserNamePassword user/pass";
 
 is($client->{client}->connect($client->url()), STATUSCODE_BADUSERACCESSDENIED,
-    "client connect denied");
+    "client connect bad user denied");
+$client->stop;
 
+$config->setUsernamePassword(undef, undef);
+note("client connect anon");
+is($client->{client}->connect($client->url()), STATUSCODE_GOOD,
+    "client connect anonymous success (undef)");
 $client->stop();
+
+$config->setUsernamePassword("", undef);
+note("client connect anon");
+is($client->{client}->connect($client->url()), STATUSCODE_GOOD,
+    "client connect anonymous success (empty string)");
+$client->stop();
+
+$config->setUsernamePassword({}, undef);
+note("client connect anon");
+is($client->{client}->connect($client->url()), STATUSCODE_BADUSERACCESSDENIED,
+    "client connect bad user denied (non string)");
+$client->stop();
+
 $server->stop();


### PR DESCRIPTION
* If an empty string is given to UA_ClientConfig_setUsernamePassword(), the username/password data in the userIdentityToken of the client config is now cleared.
* Additionally the endpoint and userTokenPolicy data of the client config is cleared. This is necessary because open62541 will otherwise reuse the policy from a previous connection, which might be wrong (e. g. if the client switches from anonymous to user authentication).
* Because of this the client will make a new additional GetEndpoints request for the next connection (if the client already connected previously).