### PR TITLE
Bump version number to 2.00 and update change log.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,22 @@
 Revision history for Perl extension OPCUA::Open62541.
 
-1.06
+2.00
+    - Remove support for open62541 1.0 and 1.1 API.  1.2 branch did
+      not work properly with OPCUA::Open62541 anyway.  Minimum
+      required version of the open62541 library is 1.3 now.  open62541
+      master branch has issues.  OPCUA::Open62541 tests currently
+      run and pass with open62541 version 1.3.4.
+    - A lot of backwards compatibility code in implementations and tests
+      has been removed.
+    - The 1.0 API compatibility of the client getState() method has
+      been removed.  It has to be called in list context now to
+      retrieve channel state, session state, and connect status.
+      Trying to retrieve the client state in scalar context will
+      result in a Perl die.  A client state does not exist anymore.
+    - Implement basic encryption for client and server.  Certificates
+      are not validated yet.
+    - Improve behavior of client config setUsernamePassword()
+      method.
 
 1.05 2022-10-27
     - Create correct SIGNATURE file.

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -7,7 +7,7 @@ require Exporter;
 use parent 'Exporter';
 use OPCUA::Open62541::Constant;
 
-our $VERSION = '1.06';
+our $VERSION = '2.00';
 
 our @EXPORT_OK = @OPCUA::Open62541::Constant::EXPORT_OK;
 our %EXPORT_TAGS = %OPCUA::Open62541::Constant::EXPORT_TAGS;


### PR DESCRIPTION
The removal of the open62541 1.0 and 1.1 API compatibility justifies a new major version.