### PR TITLE
ClientConfig - trust / revocation list

### DIFF
--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -730,7 +730,7 @@ In scalar context croak due to 1.0 API incompatibility.
 
 =item $status_code = $client_config->setDefaultEncryption($certificate, $privateKey, $trustList, $revocationList)
 
-$trustList and $revocationList are currently not supported and have to be undef.
+If no trust or revocation list is set, the client will accept all certificates.
 
 =item $context = $client_config->getClientContext()
 

--- a/lib/OPCUA/Open62541/Test/Client.pm
+++ b/lib/OPCUA/Open62541/Test/Client.pm
@@ -53,7 +53,8 @@ sub start {
     if ($self->{certificate} and $self->{privateKey}) {
 	is(
 	    $self->{config}->setDefaultEncryption(
-		$self->{certificate}, $self->{privateKey}
+		$self->{certificate}, $self->{privateKey},
+		$self->{trustList}, $self->{revocationList},
 	    ),
 	    "Good",
 	    "client: set default encryption config"
@@ -225,7 +226,7 @@ URL of the server. Overwrites host and port arguments.
 
 =item $args{certificate}
 
-Certificate in DER format for signing and encryption.
+Certificate in PEM or DER format for signing and encryption.
 If the I<certificate> and I<privateKey> parameters are set, the client config
 will be configured with the relevant security policies.
 
@@ -236,7 +237,16 @@ Set the security mode with
 
 =item $args{privateKey}
 
-Private key in DER format that has to match the certificate.
+Private key in PEM or DER format that has to match the certificate.
+
+=item $args{trustList}
+
+Array reference with a list of trusted certificates in PEM or DER format.
+
+=item $args{revocationList}
+
+Array reference with a list of certificate revocation lists (CRL) in PEM or DER
+format.
 
 =item $args{logfile}
 

--- a/t/client-config-encryption.t
+++ b/t/client-config-encryption.t
@@ -1,0 +1,171 @@
+use strict;
+use warnings;
+use OPCUA::Open62541;
+
+use Test::More tests => 43;
+use Test::Exception;
+use Test::LeakTrace;
+use Test::NoWarnings;
+
+use IO::Socket::SSL::Utils;
+
+my ($cert, $key) = CERT_create(
+    CA => 1,
+    not_after => time() + 365*24*60*60,
+    subject => { commonName => 'OPCUA::Open62541 Test Client selfsigned' },
+    ext => [{sn => "subjectAltName", data => "URI:urn:client.p5-opcua-open65241"}],
+);
+
+my $cert_pem = PEM_cert2string($cert);
+my $key_pem  = PEM_key2string($key);
+
+# open62541 logs errors if security policies are set multiple times for a client
+# config. For this reason we create clients and configs in separate blocks for
+# the sub tests.
+
+# test setDefaultEncryption() - fail
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+
+    throws_ok { OPCUA::Open62541::ClientConfig::setDefaultEncryption() }
+	(qr/OPCUA::Open62541::ClientConfig::setDefaultEncryption\(config, localCertificate, privateKey, .*\) /,
+	"config missing");
+    no_leaks_ok { eval { OPCUA::Open62541::ClientConfig::setDefaultEncryption() } }
+	"config missing leak";
+
+    throws_ok { OPCUA::Open62541::ClientConfig::setDefaultEncryption(1, $cert, $key) }
+	(qr/Self config is not a OPCUA::Open62541::ClientConfig /,
+	"config type");
+    no_leaks_ok { eval { OPCUA::Open62541::ClientConfig::setDefaultEncryption(1, $cert, $key) } }
+	"config type leak";
+}
+
+# test setDefaultEncryption() - invalid certificate
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+    is($config->setDefaultEncryption("foo", "bar"), "Good", "encryption invalid cert");
+}
+
+# test setDefaultEncryption() - invalid certificate leak
+no_leaks_ok {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setDefaultEncryption("foo", "bar");
+} "encryption invalid cert leak";
+
+# test setDefaultEncryption() - valid certificate
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+    is($config->setDefaultEncryption($cert_pem, $key_pem), "Good", "encryption valid");
+}
+
+# test setDefaultEncryption() - valid certificate leak
+no_leaks_ok {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setDefaultEncryption($cert_pem, $key_pem);
+} "encryption valid leak";
+
+# test setDefaultEncryption() - empty trustList
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+    is($config->setDefaultEncryption($cert_pem, $key_pem, []), "Good", "encryption empty trustList");
+}
+
+# test setDefaultEncryption() - empty trustList leak
+no_leaks_ok {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setDefaultEncryption($cert_pem, $key_pem, []);
+} "encryption empty trustList leak";
+
+# test setDefaultEncryption() - invalid trustList
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+    is($config->setDefaultEncryption($cert_pem, $key_pem, [undef]), "BadInternalError", "encryption invalid trustList");
+}
+
+# test setDefaultEncryption() - invalid trustList leak
+no_leaks_ok {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setDefaultEncryption($cert_pem, $key_pem, [undef]);
+} "encryption invalid trustList leak";
+
+# test setDefaultEncryption() - valid trustList
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+    is($config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem, $cert_pem]), "Good", "encryption valid trustList");
+}
+
+# test setDefaultEncryption() - valid trustList leak
+no_leaks_ok  {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem, $cert_pem]);
+} "encryption valid trustList leak";
+
+# test setDefaultEncryption() - empty revocationList
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+    is($config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem], []), "Good", "encryption empty revocationList");
+}
+
+# test setDefaultEncryption() - empty revocationList leak
+no_leaks_ok {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem], []);
+} "encryption empty revocationList leak";
+
+# test setDefaultEncryption() - invalid revocationList
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+    is($config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem], [undef]), "BadInternalError", "encryption invalid revocationList");
+}
+
+# test setDefaultEncryption() - invalid revocationList leak
+no_leaks_ok {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem], [undef]);
+} "encryption invalid revocationList leak";
+
+# xxx at the moment we pass "foo" as a CRL until we can generate or read a
+#     correct CRL for tests. this causes a BadInternalError Statuscode
+
+# test setDefaultEncryption() - valid revocationList
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+    is($config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem, $cert_pem], ["foo"]), "BadInternalError", "encryption valid revocationList");
+}
+
+# test setDefaultEncryption() - valid revocationList leak
+no_leaks_ok {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem, $cert_pem], ["foo"]);
+} "encryption valid revocationList leak";
+
+# test setDefaultEncryption() - valid revocationList no trustList
+{
+    ok(my $client = OPCUA::Open62541::Client->new(), "client new");
+    ok(my $config = $client->getConfig(), "config get");
+    is($config->setDefaultEncryption($cert_pem, $key_pem, undef, ["foo"]), "BadInternalError", "encryption valid revocationList");
+}
+
+# test setDefaultEncryption() - valid revocationList no trustList leak
+no_leaks_ok {
+    my $client = OPCUA::Open62541::Client->new();
+    my $config = $client->getConfig();
+    $config->setDefaultEncryption($cert_pem, $key_pem, undef, ["foo"]);
+} "encryption valid revocationList leak";


### PR DESCRIPTION
* ClientConfig::setDefaultEncryption() will now handle given array references for the trust and revocation list.
* The data for the UA_ByteString arrays is held in a mortal SV. if something croaks, perl itself can free the data.
* Since the trust / revocation list SVs will live longer than the UA_ByteString arrays (UA_ClientConfig_setDefaultEncryption copies the data into the relevant pki plugin data structures), we can directly reference the passed SV string data in the UA_ByteString structures.
* At the moment we dont have any valid CRLs for the tests yet.