### PR TITLE
CRLs in Tests

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -26,11 +26,13 @@ script/constant.pl
 script/destroy.pl
 script/packed-type.pl
 script/patch-tools_generate_datatypes_py
+t/CA.pm
 t/client-browse-async.t
 t/client-browse.t
 t/client-browsenext-async.t
 t/client-config-context.t
 t/client-config-default.t
+t/client-config-encryption.t
 t/client-config-userpass.t
 t/client-config.t
 t/client-connect-async-refcount.t

--- a/t/CA.pm
+++ b/t/CA.pm
@@ -1,0 +1,152 @@
+package OPCUA::Open62541::Test::CA;
+
+use autodie;
+use strict;
+use warnings;
+
+use Cwd qw(abs_path);
+use File::Path qw(make_path remove_tree);
+use IO::Socket::SSL::Utils;
+
+
+sub new {
+    my ($class, %args) = @_;
+
+    my $dir = delete($args{dir}) || './t/ca';
+    $dir = abs_path($dir)
+	or die "no directory";
+
+    my $config = delete($args{config})
+	|| _default_openssl_config($dir);
+
+    my $self = bless {
+	config => $config,
+	dir => $dir,
+    }, $class;
+
+    return $self;
+}
+
+sub setup {
+    my ($self) = @_;
+    my $dir = $self->{dir};
+
+    remove_tree($dir);
+    make_path($dir);
+
+    for (
+	["$dir/crlnumber",   "01\n"],
+	["$dir/index.txt",   ""],
+	["$dir/openssl.cnf", $self->{config}],
+	["$dir/serial",      "01\n"],
+    ) {
+	open(my $fh, '>', $_->[0]);
+	print $fh $_->[1];
+    }
+}
+
+sub create_cert_root {
+    my ($self, %args) = @_;
+
+    $self->create_cert(
+	name => "root",
+	%args,
+    );
+}
+
+sub create_cert_client {
+    my ($self, %args) = @_;
+
+    $self->create_cert(
+	name => "client",
+	create_args => {
+	    ext => [{sn => "subjectAltName", data => "URI:urn:client.p5-opcua-open65241"}],
+	},
+	%args,
+    );
+}
+
+sub create_cert_server {
+    my ($self, %args) = @_;
+
+    $self->create_cert(
+	name => "server",
+	create_args => {
+	    ext => [{sn => "subjectAltName", data => "URI:urn:server.p5-opcua-open65241"}],
+	},
+	%args,
+    );
+}
+
+sub create_cert {
+    my ($self, %args) = @_;
+    my $issuer      = delete($args{issuer});
+    my $name        = delete($args{name}) || die "no name for cert";
+    my $subject     = delete($args{subject}) // {commonName => $name};
+    my $create_args = delete($args{create_args}) // {};
+    my $dir         = $self->{dir};
+
+    if ($issuer and not ref $issuer) {
+	$issuer = [@{$self->{certs}{$issuer}}{qw(cert key)}];
+    } elsif ($issuer and ref($issuer) eq 'HASH') {
+	$issuer = [@$issuer{qw(cert key)}];
+    }
+
+    my $is_ca = !$issuer;
+    my ($cert, $key) = CERT_create(
+	not_after => time() + 365*24*60*60,
+	subject => $subject,
+	$issuer ? (issuer => $issuer) : (),
+	$is_ca ? (CA => 1, purpose => 'sslCA,cRLSign') : (),
+	%$create_args,
+    );
+
+    my $path_cert = "$dir/$name.cert";
+    my $path_crl = "$dir/$name.crl";
+    my $path_key = "$dir/$name.key";
+
+    PEM_cert2file($cert, $path_cert);
+    PEM_key2file($key, $path_key);
+
+    my $crl;
+    if ($is_ca) {
+	$crl = qx(openssl ca -config "$dir/openssl.cnf" -cert "$path_cert" -keyfile "$path_key" -gencrl 2>&1);
+
+	open my $fh, ">", $path_crl;
+	print $fh $crl;
+	close $fh;
+    }
+
+    $self->{certs}{$name} = {
+	cert     => $cert,
+	cert_pem => PEM_cert2string($cert),
+	key      => $key,
+	key_pem  => PEM_key2string($key),
+	$is_ca ? (crl_pem => $crl) : (),
+    };
+}
+
+sub _default_openssl_config {
+    my $dir = shift;
+    my $config = << 'CONF';
+[ ca ]
+default_ca  = CA_default
+
+[ CA_default ]
+dir         = %DIR%
+database    = $dir/index.txt
+serial      = $dir/serial
+crlnumber   = $dir/crlnumber
+
+default_days     = 365
+default_crl_days = 30
+default_md  = sha256
+CONF
+
+    $config =~ s/%DIR%/$dir/g;
+
+    return $config;
+}
+
+
+1;

--- a/t/client-config-encryption.t
+++ b/t/client-config-encryption.t
@@ -2,22 +2,27 @@ use strict;
 use warnings;
 use OPCUA::Open62541;
 
-use Test::More tests => 43;
+use Test::More;
+BEGIN {
+    if(not OPCUA::Open62541::ClientConfig->can('setDefaultEncryption')) {
+	plan skip_all => 'open62541 without UA_ENABLE_ENCRYPTION';
+    } elsif (not qx(openssl version 2> /dev/null) or $?) {
+	plan skip_all => 'no openssl for CRL generation';
+    } else {
+	plan tests => 43;
+    }
+}
 use Test::Exception;
 use Test::LeakTrace;
 use Test::NoWarnings;
 
-use IO::Socket::SSL::Utils;
+require './t/CA.pm';
 
-my ($cert, $key) = CERT_create(
-    CA => 1,
-    not_after => time() + 365*24*60*60,
-    subject => { commonName => 'OPCUA::Open62541 Test Client selfsigned' },
-    ext => [{sn => "subjectAltName", data => "URI:urn:client.p5-opcua-open65241"}],
-);
 
-my $cert_pem = PEM_cert2string($cert);
-my $key_pem  = PEM_key2string($key);
+my $ca = OPCUA::Open62541::Test::CA->new();
+$ca->setup();
+
+my ($cert_pem, $key_pem, $crl_pem) = @{$ca->create_cert_client()}{qw(cert_pem key_pem crl_pem)};
 
 # open62541 logs errors if security policies are set multiple times for a client
 # config. For this reason we create clients and configs in separate blocks for
@@ -34,10 +39,10 @@ my $key_pem  = PEM_key2string($key);
     no_leaks_ok { eval { OPCUA::Open62541::ClientConfig::setDefaultEncryption() } }
 	"config missing leak";
 
-    throws_ok { OPCUA::Open62541::ClientConfig::setDefaultEncryption(1, $cert, $key) }
+    throws_ok { OPCUA::Open62541::ClientConfig::setDefaultEncryption(1, $cert_pem, $key_pem) }
 	(qr/Self config is not a OPCUA::Open62541::ClientConfig /,
 	"config type");
-    no_leaks_ok { eval { OPCUA::Open62541::ClientConfig::setDefaultEncryption(1, $cert, $key) } }
+    no_leaks_ok { eval { OPCUA::Open62541::ClientConfig::setDefaultEncryption(1, $cert_pem, $key_pem) } }
 	"config type leak";
 }
 
@@ -139,33 +144,30 @@ no_leaks_ok {
     $config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem], [undef]);
 } "encryption invalid revocationList leak";
 
-# xxx at the moment we pass "foo" as a CRL until we can generate or read a
-#     correct CRL for tests. this causes a BadInternalError Statuscode
-
 # test setDefaultEncryption() - valid revocationList
 {
     ok(my $client = OPCUA::Open62541::Client->new(), "client new");
     ok(my $config = $client->getConfig(), "config get");
-    is($config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem, $cert_pem], ["foo"]), "BadInternalError", "encryption valid revocationList");
+    is($config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem, $cert_pem], [$crl_pem]), "Good", "encryption valid revocationList");
 }
 
 # test setDefaultEncryption() - valid revocationList leak
 no_leaks_ok {
     my $client = OPCUA::Open62541::Client->new();
     my $config = $client->getConfig();
-    $config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem, $cert_pem], ["foo"]);
+    $config->setDefaultEncryption($cert_pem, $key_pem, [$cert_pem, $cert_pem], [$crl_pem]);
 } "encryption valid revocationList leak";
 
 # test setDefaultEncryption() - valid revocationList no trustList
 {
     ok(my $client = OPCUA::Open62541::Client->new(), "client new");
     ok(my $config = $client->getConfig(), "config get");
-    is($config->setDefaultEncryption($cert_pem, $key_pem, undef, ["foo"]), "BadInternalError", "encryption valid revocationList");
+    is($config->setDefaultEncryption($cert_pem, $key_pem, undef, [$crl_pem]), "Good", "encryption valid revocationList");
 }
 
 # test setDefaultEncryption() - valid revocationList no trustList leak
 no_leaks_ok {
     my $client = OPCUA::Open62541::Client->new();
     my $config = $client->getConfig();
-    $config->setDefaultEncryption($cert_pem, $key_pem, undef, ["foo"]);
+    $config->setDefaultEncryption($cert_pem, $key_pem, undef, [$crl_pem]);
 } "encryption valid revocationList leak";


### PR DESCRIPTION
* New OPCUA::Open62541::Test::CA module in t/CA.pm that should only be used for tests. The module allows creation of certificates with IO::Socket::SSL::Utils and generating CRLs for these certificates with the openssl CLI.
* The module by default creates a directory "t/ca/" with some basic openssl stuff to create the CRLs.