### PR TITLE
More encryption

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,7 @@ Changes
 lib/OPCUA/Open62541.pm
 lib/OPCUA/Open62541/Constant.pm
 lib/OPCUA/Open62541/Constant.pod
+lib/OPCUA/Open62541/Test/CA.pm
 lib/OPCUA/Open62541/Test/Client.pm
 lib/OPCUA/Open62541/Test/Logger.pm
 lib/OPCUA/Open62541/Test/Server.pm
@@ -26,7 +27,6 @@ script/constant.pl
 script/destroy.pl
 script/packed-type.pl
 script/patch-tools_generate_datatypes_py
-t/CA.pm
 t/client-browse-async.t
 t/client-browse.t
 t/client-browsenext-async.t

--- a/lib/OPCUA/Open62541/Test/Server.pm
+++ b/lib/OPCUA/Open62541/Test/Server.pm
@@ -66,7 +66,8 @@ sub start {
     if ($self->{certificate} and $self->{privateKey}) {
 	is(
 	    $self->{config}->setDefaultWithSecurityPolicies(
-		$self->{port}, $self->{certificate}, $self->{privateKey}
+		$self->{port}, $self->{certificate}, $self->{privateKey},
+		$self->{trustList}, $self->{issuerList}, $self->{revocationList},
 	    ),
 	    STATUSCODE_GOOD,
 	    "server: set security config"
@@ -512,6 +513,19 @@ configured with the relevant security policies.
 =item $args{privateKey}
 
 Private key in DER format that has to match the certificate.
+
+=item $args{trustList}
+
+Array reference with a list of trusted certificates in PEM or DER format.
+
+=item $args{issuerList}
+
+Array reference with a list of additional trusted certificates in PEM or DER format.
+
+=item $args{revocationList}
+
+Array reference with a list of certificate revocation lists (CRL) in PEM or DER
+format.
 
 =item $args{logfile}
 


### PR DESCRIPTION
* Move CA.pm to lib/OPCUA/Open62541/Test/CA.pm
* Use IPC::Open3 instead of qx to catch STDERR without shell invocation
* Use File::Temp for temporary test directories. If a directory is given in new(), it will not be removed afterwards.
* Use more consistent paranthesis and quotation coding style