### PR TITLE
OPCUA::Open62541::Test::CA - Better purpose

### DIFF
--- a/t/client-config-encryption.t
+++ b/t/client-config-encryption.t
@@ -35,7 +35,8 @@ use Test::NoWarnings;
 my $ca = OPCUA::Open62541::Test::CA->new();
 $ca->setup();
 
-my ($cert_pem, $key_pem, $crl_pem) = @{$ca->create_cert_client()}{qw(cert_pem key_pem crl_pem)};
+my ($cert_pem, $key_pem) = @{$ca->create_cert_client()}{qw(cert_pem key_pem)};
+my ($crl_pem) = @{$ca->create_cert_ca()}{qw(crl_pem)};
 
 # open62541 logs errors if security policies are set multiple times for a client
 # config. For this reason we create clients and configs in separate blocks for

--- a/t/encryption.t
+++ b/t/encryption.t
@@ -29,7 +29,7 @@ BEGIN {
 
     plan tests =>
 	OPCUA::Open62541::Test::Server::planning() +
-	OPCUA::Open62541::Test::Client::planning() + 243;
+	OPCUA::Open62541::Test::Client::planning() + 242;
 }
 use Test::LeakTrace;
 use Test::NoWarnings;
@@ -37,8 +37,8 @@ use Test::NoWarnings;
 my $ca = OPCUA::Open62541::Test::CA->new();
 $ca->setup();
 
-$ca->create_cert_client(issuer => $ca->create_cert_root(name => "ca_client"));
-$ca->create_cert_server(issuer => $ca->create_cert_root(name => "ca_server"));
+$ca->create_cert_client(issuer => $ca->create_cert_ca(name => "ca_client"));
+$ca->create_cert_server(issuer => $ca->create_cert_ca(name => "ca_server"));
 
 $ca->create_cert_server(name => "server_selfsigned");
 


### PR DESCRIPTION
* Rename create_cert_root() to create_cert_ca() since it can also be used to create intermediate CA certificates.
* Selfsigned non-root certificates don't need the CA flag. A new 'ca' parameter is now checked in create_cert() and create_cert_ca() is setting this parameter by default to true.
* Non CA certificates additionally now have the 'dataEncipherment' key usage (besides the 'digitalSignature' and 'keyEncipherment' defaults).
* t/client-config-encryption.t had to be fixed because the self signed certificate generates not a CRL anymore.