### PR TITLE
NodeId contains printable string as identifier.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -573,6 +573,7 @@ pack_UA_NodeId(SV *out, const UA_NodeId *in)
 	dTHX;
 	SV *sv;
 	UA_Int32 type;
+	UA_String print;
 	HV *hv;
 
 	hv = newHV();
@@ -605,6 +606,18 @@ pack_UA_NodeId(SV *out, const UA_NodeId *in)
 		break;
 	default:
 		CROAK("NodeId_identifierType %d unknown", in->identifierType);
+	}
+
+	/*
+	 * For convenience add printable string based on XML encoding format.
+	 * https://reference.opcfoundation.org/Core/Part6/v105/docs/5.3.1.10
+	 */
+	UA_String_init(&print);
+	if (UA_NodeId_print(in, &print) == UA_STATUSCODE_GOOD) {
+		sv = newSV(0);
+		hv_stores(hv, "NodeId_print", sv);
+		pack_UA_String(sv, &print);
+		UA_String_clear(&print);
 	}
 }
 

--- a/lib/OPCUA/Open62541/Test/Server.pm
+++ b/lib/OPCUA/Open62541/Test/Server.pm
@@ -105,17 +105,22 @@ sub setup_complex_objects {
 	    NodeId_namespaceIndex	=> $namespace,
 	    NodeId_identifierType	=> NODEIDTYPE_STRING,
 	    NodeId_identifier		=> "SOME_VARIABLE_TYPE",
+	    NodeId_print		=> "ns=$namespace;s=SOME_VARIABLE_TYPE",
 	},
 	parentNodeId => {
 	    NodeId_namespaceIndex	=> 0,
 	    NodeId_identifierType	=> NODEIDTYPE_NUMERIC,
 	    NodeId_identifier		=>
 		OPCUA::Open62541::NS0ID_BASEDATAVARIABLETYPE,
+	    NodeId_print		=> "i=".
+		OPCUA::Open62541::NS0ID_BASEDATAVARIABLETYPE,
 	},
 	referenceTypeId => {
 	    NodeId_namespaceIndex	=> 0,
 	    NodeId_identifierType	=> NODEIDTYPE_NUMERIC,
 	    NodeId_identifier		=> OPCUA::Open62541::NS0ID_HASSUBTYPE,
+	    NodeId_print		=> "i=".
+		OPCUA::Open62541::NS0ID_HASSUBTYPE,
 	},
 	browseName => {
 	    QualifiedName_namespaceIndex	=> $namespace,
@@ -125,6 +130,7 @@ sub setup_complex_objects {
 	    NodeId_namespaceIndex	=> 0,
 	    NodeId_identifierType	=> NODEIDTYPE_NUMERIC,
 	    NodeId_identifier		=> 0,
+	    NodeId_print		=> "i=0",
 	},
 	attributes => {
 	    VariableTypeAttributes_dataType	=> TYPES_INT32,
@@ -142,17 +148,22 @@ sub setup_complex_objects {
 	    NodeId_namespaceIndex	=> $namespace,
 	    NodeId_identifierType	=> NODEIDTYPE_STRING,
 	    NodeId_identifier		=> "SOME_OBJECT_TYPE",
+	    NodeId_print		=> "ns=$namespace;s=SOME_OBJECT_TYPE",
 	},
 	parentNodeId => {
 	    NodeId_namespaceIndex	=> 0,
 	    NodeId_identifierType	=> NODEIDTYPE_NUMERIC,
 	    NodeId_identifier		=>
 		OPCUA::Open62541::NS0ID_BASEOBJECTTYPE,
+	    NodeId_print		=> "i=".
+		OPCUA::Open62541::NS0ID_BASEOBJECTTYPE,
 	},
 	referenceTypeId => {
 	    NodeId_namespaceIndex	=> 0,
 	    NodeId_identifierType	=> NODEIDTYPE_NUMERIC,
 	    NodeId_identifier		=> OPCUA::Open62541::NS0ID_HASSUBTYPE,
+	    NodeId_print		=> "i=".
+		OPCUA::Open62541::NS0ID_HASSUBTYPE,
 	},
 	browseName => {
 	    QualifiedName_namespaceIndex	=> $namespace,
@@ -172,12 +183,15 @@ sub setup_complex_objects {
 	    NodeId_namespaceIndex	=> $namespace,
 	    NodeId_identifierType	=> NODEIDTYPE_STRING,
 	    NodeId_identifier		=> "SOME_VARIABLE_0",
+	    NodeId_print		=> "ns=$namespace;s=SOME_VARIABLE_0",
 	},
 	parentNodeId			=> $nodes{some_object_type}{nodeId},
 	referenceTypeId => {
 	    NodeId_namespaceIndex	=> 0,
 	    NodeId_identifierType	=> NODEIDTYPE_NUMERIC,
 	    NodeId_identifier		=> OPCUA::Open62541::NS0ID_HASCOMPONENT,
+	    NodeId_print		=> "i=".
+		OPCUA::Open62541::NS0ID_HASCOMPONENT,
 	},
 	browseName => {
 	    QualifiedName_namespaceIndex	=> $namespace,
@@ -187,6 +201,7 @@ sub setup_complex_objects {
 	    NodeId_namespaceIndex	=> $namespace,
 	    NodeId_identifierType	=> NODEIDTYPE_STRING,
 	    NodeId_identifier		=> "SOME_VARIABLE_TYPE",
+	    NodeId_print		=> "ns=$namespace;s=SOME_VARIABLE_TYPE",
 	},
 	attributes => {
 	    VariableAttributes_dataType	=> TYPES_INT32,
@@ -210,17 +225,22 @@ sub setup_complex_objects {
 	    NodeId_namespaceIndex	=> $namespace,
 	    NodeId_identifierType	=> NODEIDTYPE_STRING,
 	    NodeId_identifier		=> "SOME_OBJECT_0",
+	    NodeId_print		=> "ns=$namespace;s=SOME_OBJECT_0",
 	},
 	parentNodeId => {
 	    NodeId_namespaceIndex	=> 0,
 	    NodeId_identifierType	=> NODEIDTYPE_NUMERIC,
 	    NodeId_identifier		=>
 		OPCUA::Open62541::NS0ID_OBJECTSFOLDER,
+	    NodeId_print		=> "i=".
+		OPCUA::Open62541::NS0ID_OBJECTSFOLDER,
 	},
 	referenceTypeId => {
 	    NodeId_namespaceIndex	=> 0,
 	    NodeId_identifierType	=> NODEIDTYPE_NUMERIC,
 	    NodeId_identifier		=> OPCUA::Open62541::NS0ID_ORGANIZES,
+	    NodeId_print		=> "i=".
+		OPCUA::Open62541::NS0ID_ORGANIZES,
 	},
 	browseName => {
 	    QualifiedName_namespaceIndex	=> $namespace,
@@ -230,6 +250,7 @@ sub setup_complex_objects {
 	    NodeId_namespaceIndex	=> $namespace,
 	    NodeId_identifierType	=> NODEIDTYPE_STRING,
 	    NodeId_identifier		=> "SOME_OBJECT_TYPE",
+	    NodeId_print		=> "ns=$namespace;s=SOME_OBJECT_TYPE",
 	},
 	attributes => {
 	    ObjectAttributes_description => {

--- a/t/client-browse-async.t
+++ b/t/client-browse-async.t
@@ -44,7 +44,8 @@ my $response = {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef
 	  },
@@ -57,13 +58,15 @@ my $response = {
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_identifier' => 40,
 	    'NodeId_identifierType' => 0,
-	    'NodeId_namespaceIndex' => 0
+	    'NodeId_namespaceIndex' => 0,
+	    'NodeId_print' => "i=40",
 	  },
 	  'ReferenceDescription_typeDefinition' => {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifierType' => 0,
 	      'NodeId_identifier' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=0",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef,
 	    'ExpandedNodeId_serverIndex' => 0
@@ -77,7 +80,8 @@ my $response = {
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_identifier' => 35,
 	    'NodeId_identifierType' => 0,
-	    'NodeId_namespaceIndex' => 0
+	    'NodeId_namespaceIndex' => 0,
+	    'NodeId_print' => "i=35",
 	  },
 	  'ReferenceDescription_typeDefinition' => {
 	    'ExpandedNodeId_serverIndex' => 0,
@@ -85,7 +89,8 @@ my $response = {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    }
 	  },
 	  'ReferenceDescription_browseName' => {
@@ -97,7 +102,8 @@ my $response = {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 85,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=85",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef
 	  },
@@ -116,7 +122,8 @@ my $response = {
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_identifierType' => 0,
 	    'NodeId_identifier' => 35,
-	    'NodeId_namespaceIndex' => 0
+	    'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=35",
 	  },
 	  'ReferenceDescription_typeDefinition' => {
 	    'ExpandedNodeId_serverIndex' => 0,
@@ -124,7 +131,8 @@ my $response = {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    }
 	  },
 	  'ReferenceDescription_isForward' => 1,
@@ -139,7 +147,8 @@ my $response = {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 86,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=86",
 	    }
 	  }
 	},
@@ -148,7 +157,8 @@ my $response = {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_namespaceIndex' => 0,
 	      'NodeId_identifier' => 87,
-	      'NodeId_identifierType' => 0
+	      'NodeId_identifierType' => 0,
+	      'NodeId_print' => "i=87",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef,
 	    'ExpandedNodeId_serverIndex' => 0
@@ -164,14 +174,16 @@ my $response = {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    },
 	    'ExpandedNodeId_serverIndex' => 0
 	  },
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_namespaceIndex' => 0,
 	    'NodeId_identifierType' => 0,
-	    'NodeId_identifier' => 35
+	    'NodeId_identifier' => 35,
+	    'NodeId_print' => "i=35",
 	  },
 	  'ReferenceDescription_browseName' => {
 	    'QualifiedName_name' => 'Views',
@@ -208,7 +220,8 @@ my $response = {
 	'ExtensionObject_content_typeId' => {
 	  'NodeId_identifier' => 0,
 	  'NodeId_identifierType' => 0,
-	  'NodeId_namespaceIndex' => 0
+	  'NodeId_namespaceIndex' => 0,
+	  'NodeId_print' => "i=0",
 	},
 	'ExtensionObject_content_body' => undef,
       },

--- a/t/client-browse.t
+++ b/t/client-browse.t
@@ -42,7 +42,8 @@ my %response = (
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef
 	  },
@@ -55,13 +56,15 @@ my %response = (
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_identifier' => 40,
 	    'NodeId_identifierType' => 0,
-	    'NodeId_namespaceIndex' => 0
+	    'NodeId_namespaceIndex' => 0,
+	    'NodeId_print' => "i=40",
 	  },
 	  'ReferenceDescription_typeDefinition' => {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifierType' => 0,
 	      'NodeId_identifier' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=0",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef,
 	    'ExpandedNodeId_serverIndex' => 0
@@ -75,7 +78,8 @@ my %response = (
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_identifier' => 35,
 	    'NodeId_identifierType' => 0,
-	    'NodeId_namespaceIndex' => 0
+	    'NodeId_namespaceIndex' => 0,
+	    'NodeId_print' => "i=35",
 	  },
 	  'ReferenceDescription_typeDefinition' => {
 	    'ExpandedNodeId_serverIndex' => 0,
@@ -83,7 +87,8 @@ my %response = (
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    }
 	  },
 	  'ReferenceDescription_browseName' => {
@@ -95,7 +100,8 @@ my %response = (
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 85,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=85",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef
 	  },
@@ -114,7 +120,8 @@ my %response = (
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_identifierType' => 0,
 	    'NodeId_identifier' => 35,
-	    'NodeId_namespaceIndex' => 0
+	    'NodeId_namespaceIndex' => 0,
+	    'NodeId_print' => "i=35",
 	  },
 	  'ReferenceDescription_typeDefinition' => {
 	    'ExpandedNodeId_serverIndex' => 0,
@@ -122,7 +129,8 @@ my %response = (
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    }
 	  },
 	  'ReferenceDescription_isForward' => 1,
@@ -137,7 +145,8 @@ my %response = (
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 86,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=86",
 	    }
 	  }
 	},
@@ -146,7 +155,8 @@ my %response = (
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_namespaceIndex' => 0,
 	      'NodeId_identifier' => 87,
-	      'NodeId_identifierType' => 0
+	      'NodeId_identifierType' => 0,
+	      'NodeId_print' => "i=87",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef,
 	    'ExpandedNodeId_serverIndex' => 0
@@ -162,14 +172,16 @@ my %response = (
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    },
 	    'ExpandedNodeId_serverIndex' => 0
 	  },
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_namespaceIndex' => 0,
 	    'NodeId_identifierType' => 0,
-	    'NodeId_identifier' => 35
+	    'NodeId_identifier' => 35,
+	    'NodeId_print' => "i=35",
 	  },
 	  'ReferenceDescription_browseName' => {
 	    'QualifiedName_name' => 'Views',
@@ -206,7 +218,8 @@ my %response = (
 	'ExtensionObject_content_typeId' => {
 	  'NodeId_identifier' => 0,
 	  'NodeId_identifierType' => 0,
-	  'NodeId_namespaceIndex' => 0
+	  'NodeId_namespaceIndex' => 0,
+	  'NodeId_print' => "i=0",
 	},
 	'ExtensionObject_content_body' => undef,
       },

--- a/t/client-browsenext-async.t
+++ b/t/client-browsenext-async.t
@@ -44,7 +44,8 @@ my $responses = [{
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef
 	  },
@@ -57,13 +58,15 @@ my $responses = [{
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_identifier' => 40,
 	    'NodeId_identifierType' => 0,
-	    'NodeId_namespaceIndex' => 0
+	    'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=40",
 	  },
 	  'ReferenceDescription_typeDefinition' => {
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifierType' => 0,
 	      'NodeId_identifier' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=0",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef,
 	    'ExpandedNodeId_serverIndex' => 0
@@ -103,7 +106,8 @@ my $responses = [{
 	'ExtensionObject_content_typeId' => {
 	  'NodeId_identifier' => 0,
 	  'NodeId_identifierType' => 0,
-	  'NodeId_namespaceIndex' => 0
+	  'NodeId_namespaceIndex' => 0,
+	  'NodeId_print' => "i=0",
 	},
 	'ExtensionObject_content_body' => undef,
       },
@@ -119,7 +123,8 @@ my $responses = [{
 	  'ReferenceDescription_referenceTypeId' => {
 	    'NodeId_identifier' => 35,
 	    'NodeId_identifierType' => 0,
-	    'NodeId_namespaceIndex' => 0
+	    'NodeId_namespaceIndex' => 0,
+	    'NodeId_print' => "i=35",
 	  },
 	  'ReferenceDescription_typeDefinition' => {
 	    'ExpandedNodeId_serverIndex' => 0,
@@ -127,7 +132,8 @@ my $responses = [{
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 61,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=61",
 	    }
 	  },
 	  'ReferenceDescription_browseName' => {
@@ -139,7 +145,8 @@ my $responses = [{
 	    'ExpandedNodeId_nodeId' => {
 	      'NodeId_identifier' => 85,
 	      'NodeId_identifierType' => 0,
-	      'NodeId_namespaceIndex' => 0
+	      'NodeId_namespaceIndex' => 0,
+	      'NodeId_print' => "i=85",
 	    },
 	    'ExpandedNodeId_namespaceUri' => undef
 	  },
@@ -180,7 +187,8 @@ my $responses = [{
 	'ExtensionObject_content_typeId' => {
 	  'NodeId_identifier' => 0,
 	  'NodeId_identifierType' => 0,
-	  'NodeId_namespaceIndex' => 0
+	  'NodeId_namespaceIndex' => 0,
+	  'NodeId_print' => "i=0",
 	},
 	'ExtensionObject_content_body' => undef,
       },

--- a/t/client-monitoreditems.t
+++ b/t/client-monitoreditems.t
@@ -61,7 +61,8 @@ my $expected_request = {
 	ReadValueId_nodeId => {
 	    NodeId_identifier => NS0ID_SERVER_SERVERSTATUS_CURRENTTIME,
 	    NodeId_identifierType => 0,
-	    NodeId_namespaceIndex => 0
+	    NodeId_namespaceIndex => 0,
+	    NodeId_print => "i=".NS0ID_SERVER_SERVERSTATUS_CURRENTTIME,
 	},
 	ReadValueId_attributeId => ATTRIBUTEID_VALUE,
 	ReadValueId_dataEncoding => ignore(),

--- a/t/client-read-async.t
+++ b/t/client-read-async.t
@@ -67,7 +67,8 @@ my $response = {
 	      'ExtensionObject_content_typeId' => {
 		'NodeId_identifier' => 0,
 		'NodeId_identifierType' => 0,
-		'NodeId_namespaceIndex' => 0
+		'NodeId_namespaceIndex' => 0,
+		'NodeId_print' => "i=0",
 	      },
 	      'ExtensionObject_content_body' => undef,
 	    },

--- a/t/server-browse.t
+++ b/t/server-browse.t
@@ -108,6 +108,7 @@ my $expected_reference = [{
 	    NodeId_identifier => 0,
 	    NodeId_namespaceIndex => 0,
 	    NodeId_identifierType => 0,
+	    NodeId_print => "i=0",
 	},
 	ExpandedNodeId_namespaceUri => undef,
 	ExpandedNodeId_serverIndex => 0,
@@ -116,13 +117,15 @@ my $expected_reference = [{
     ReferenceDescription_referenceTypeId => {
 	NodeId_identifier => 0,
 	NodeId_namespaceIndex => 0,
-	NodeId_identifierType => 0
+	NodeId_identifierType => 0,
+	NodeId_print => "i=0",
     },
     ReferenceDescription_nodeId => {
 	ExpandedNodeId_nodeId => {
 	    NodeId_namespaceIndex => 0,
 	    NodeId_identifierType => 0,
-	    NodeId_identifier => 85
+	    NodeId_identifier => 85,
+	    NodeId_print => "i=85",
 	},
 	ExpandedNodeId_serverIndex => 0,
 	ExpandedNodeId_namespaceUri => undef
@@ -149,6 +152,8 @@ for (['Types', 86], ['Views', 87]) {
 	{QualifiedName_name} = $_->[0];
     $expected_reference->[0]{ReferenceDescription_nodeId}
 	{ExpandedNodeId_nodeId}{NodeId_identifier} = $_->[1];
+    $expected_reference->[0]{ReferenceDescription_nodeId}
+	{ExpandedNodeId_nodeId}{NodeId_print} = "i=$_->[1]";
 
     is_deeply($references, $expected_reference, "reference");
 }

--- a/t/server-node-lifecycle.t
+++ b/t/server-node-lifecycle.t
@@ -81,6 +81,7 @@ my %admin_session_guid = (
     NodeId_namespaceIndex	=> 0,
     NodeId_identifierType	=> 4,
     NodeId_identifier		=> "00000001-0000-0000-0000-000000000000",
+    NodeId_print		=> "g=00000001-0000-0000-0000-000000000000",
 );
 
 $server->{config}->setGlobalNodeLifecycle({
@@ -512,6 +513,7 @@ my %target = (
 	$nodes{some_variable_0}{nodeId}{NodeId_namespaceIndex},
     NodeId_identifierType       => NODEIDTYPE_NUMERIC,
     NodeId_identifier           => 0,
+    NodeId_print		=> "ns=1;i=0",
 );
 
 $server->{config}->setGlobalNodeLifecycle({
@@ -537,6 +539,7 @@ $server->{config}->setGlobalNodeLifecycle({
 	# The node context of a generated node is undef.
 	return STATUSCODE_GOOD if defined($$nctx);
 	$target{NodeId_identifier} = 4711;
+	$target{NodeId_print} = "ns=1;i=4711";
 	is_deeply($nodeId, \%target, "generateChildNodeId NodeId");
 	return STATUSCODE_GOOD;
     }

--- a/t/server-read.t
+++ b/t/server-read.t
@@ -40,6 +40,7 @@ my %dataValue_datatype = (
 	    NodeId_identifier => NS0ID_UTCTIME,
 	    NodeId_identifierType => 0,
 	    NodeId_namespaceIndex => 0,
+	    NodeId_print => "i=".NS0ID_UTCTIME,
 	},
 	Variant_type => TYPES_NODEID,
     },

--- a/t/server-references.t
+++ b/t/server-references.t
@@ -25,6 +25,7 @@ my $node_organizes = {
     NodeId_namespaceIndex	=> 0,
     NodeId_identifierType	=> NODEIDTYPE_NUMERIC,
     NodeId_identifier		=> NS0ID_ORGANIZES,
+    NodeId_print		=> "i=".NS0ID_ORGANIZES,
 };
 
 sub get_objecttypes_reference {

--- a/t/server-variable.t
+++ b/t/server-variable.t
@@ -68,6 +68,7 @@ no_leaks_ok {
 } "add variable node leak";
 
 $requestedNewNodeId{NodeId_identifier} = "enigma";
+$requestedNewNodeId{NodeId_print} = "ns=1;s=enigma";
 $attr{VariableAttributes_value}{Variant_scalar} = 23;
 
 my $outNewNodeId;


### PR DESCRIPTION
To generate debugging output easier, add printable representation of NodeId into hash key NodeId_print.  This is always done in pack_UA_NodeId() so nodes received from open62541 can easily be printed.  Format is from OPC UA Part6 5.3.1.10 and looks like one of this:
i=13
ns=10;i=-1
ns=10;s=Hello:World
g=09087e75-8e5e-499b-954f-f2a9603db28a
ns=1;b=M/RbKBsRVkePCePcx24oRA==