### PR TITLE
Adapt to UA_AccessControl_defaultWithLoginCallback.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,13 +37,14 @@ check_lib(
 check_lib(
     function		=> "
 	UA_ServerConfig serverConfig;
-	(void)UA_AccessControl_setCallback(&serverConfig, NULL, NULL);",
+	(void)UA_AccessControl_defaultWithLoginCallback(&serverConfig,
+	    0, NULL, NULL, 0, NULL, NULL, NULL);",
     not_execute		=> 1,
     lib			=> 'open62541',
     header		=> 'open62541/plugin/accesscontrol_default.h',
     libpath		=> '/usr/local/lib',
     incpath		=> '/usr/local/include',
-) and push @have, uc('UA_AccessControl_setCallback');
+) and push @have, uc('UA_AccessControl_defaultWithLoginCallback');
 check_lib(
     function		=> 'crypt_checkpass("", "");',
     lib			=> 'c',

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -2694,7 +2694,7 @@ unpack_UA_UsernamePasswordLogin_List(UA_UsernamePasswordLogin **outList,
 	}
 }
 
-#ifdef HAVE_UA_ACCESSCONTROL_SETCALLBACK
+#ifdef HAVE_UA_ACCESSCONTROL_DEFAULTWITHLOGINCALLBACK
 
 #ifdef HAVE_CRYPT_CHECKPASS
 
@@ -2745,7 +2745,7 @@ loginCryptCheckpassCallback(const UA_String *userName, const UA_ByteString
 
 #endif /* HAVE_CRYPT_CHECKPASS */
 
-#endif /* HAVE_UA_ACCESSCONTROL_SETCALLBACK */
+#endif /* HAVE_UA_ACCESSCONTROL_DEFAULTWITHLOGINCALLBACK */
 
 /*#########################################################################*/
 MODULE = OPCUA::Open62541	PACKAGE = OPCUA::Open62541
@@ -3581,33 +3581,58 @@ UA_ServerConfig_setAccessControl_default(config, allowAnonymous, \
 		CROAK("UsernamePasswordLogin needs userTokenPolicyUri");
 	RETVAL = UA_AccessControl_default(config->svc_serverconfig,
 	    allowAnonymous, optVerifyX509, optUserTokenPolicyUri,
-	   loginSize, loginList);
+	    loginSize, loginList);
     OUTPUT:
 	RETVAL
 
-#ifdef HAVE_UA_ACCESSCONTROL_SETCALLBACK
+#ifdef HAVE_UA_ACCESSCONTROL_DEFAULTWITHLOGINCALLBACK
 
 UA_StatusCode
-UA_ServerConfig_setAccessControl_loginCheck(config, check)
-	OPCUA_Open62541_ServerConfig	config
-	SV *				check;
+UA_ServerConfig_setAccessControl_defaultWithLoginCallback(config, \
+    allowAnonymous, optVerifyX509, optUserTokenPolicyUri, \
+    usernamePasswordLogin, loginCallback, loginContext)
+	OPCUA_Open62541_ServerConfig		config
+	UA_Boolean				allowAnonymous
+	OPCUA_Open62541_CertificateVerification	optVerifyX509
+	OPCUA_Open62541_ByteString		optUserTokenPolicyUri
+	SV *					usernamePasswordLogin
+	SV *					loginCallback
+	SV *					loginContext
+    PREINIT:
+	UA_UsernamePasswordLogin *		loginList;
+	size_t					loginSize;
+	UA_UsernamePasswordLoginCallback	callback;
+	void *					context;
     CODE:
-	if (!SvOK(check)) {
-		RETVAL = UA_AccessControl_setCallback(config->svc_serverconfig,
-		    NULL, NULL);
+	if (optVerifyX509 && optUserTokenPolicyUri == NULL)
+		CROAK("VerifyX509 needs userTokenPolicyUri");
+	unpack_UA_UsernamePasswordLogin_List(&loginList, &loginSize,
+	    usernamePasswordLogin);
+	if (loginSize > 0 && optUserTokenPolicyUri == NULL)
+		CROAK("UsernamePasswordLogin needs userTokenPolicyUri");
+	if (!SvOK(loginCallback)) {
+		callback = NULL;
+		context = NULL;
+	} else if (SvROK(loginCallback) &&
+	    SvTYPE(SvRV(loginCallback)) == SVt_PVCV) {
+		(void)loginContext;
+		CROAK("Perl callback not implemented");
 #ifdef HAVE_CRYPT_CHECKPASS
-	} else if (strcmp(SvPV_nolen(check), "crypt_checkpass") == 0) {
-		RETVAL = UA_AccessControl_setCallback(config->svc_serverconfig,
-		    loginCryptCheckpassCallback, NULL);
+	} else if (strcmp(SvPV_nolen(loginCallback), "crypt_checkpass") == 0) {
+		callback = loginCryptCheckpassCallback;
+		context = NULL;
 #endif /* HAVE_CRYPT_CHECKPASS */
 	} else {
-		/* TODO: implement pure Perl callback */
-		RETVAL = UA_STATUSCODE_BADINVALIDARGUMENT;
+		CROAK("Callback '%s' is not CODE reference and unknown check",
+		    SvPV_nolen(loginCallback));
 	}
+	RETVAL = UA_AccessControl_defaultWithLoginCallback(
+	    config->svc_serverconfig, allowAnonymous, optVerifyX509,
+	    optUserTokenPolicyUri, loginSize, loginList, callback, context);
     OUTPUT:
 	RETVAL
 
-#endif /* HAVE_UA_ACCESSCONTROL_SETCALLBACK */
+#endif /* HAVE_UA_ACCESSCONTROL_DEFAULTWITHLOGINCALLBACK */
 
 #ifdef HAVE_CRYPT_CHECKPASS
 


### PR DESCRIPTION
Discussion with upstream open62541 revealed that a new function UA_AccessControl_defaultWithLoginCallback() is better than adding UA_AccessControl_setCallback() to set a single parameter.  Rework the Perl wrapper to reflect this change.  The server config method setAccessControl_defaultWithLoginCallback() works like setAccessControl_default(), but with an additional callback argument. Note that a pure Perl callback is not implemented, but only the string "crypt_checkpass" is supported.  This check is implemented using OpenBSD libC function.  A Perl callback would make it more complicated to use OpenBSD password hashes.