### PR TITLE
OPCUA::Open62541::Test::CA - Better certificates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,7 @@ jobs:
         apt-get install --yes \
         libdevel-checklib-perl \
         libio-socket-ssl-perl \
+        libsocket6-perl \
         libtest-deep-perl \
         libtest-eol-perl \
         libtest-exception-perl \


### PR DESCRIPTION
Make the generated Application Instance Certificates more compliant to OPC UA Part 6 6.2.2 by
* adding serverAuth / clientAuth to extendedKeyUsage
* adding nonRepudiation to keyUsage
* adding 'OPCUA::Open62541' to the default subject CN
* adding 'host' argument for servers to be used as subjectAltName