### PR TITLE
Allow empty userTokenPolicyUri.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -3573,6 +3573,14 @@ UA_ServerConfig_setAccessControl_default(config, allowAnonymous, \
 	UA_UsernamePasswordLogin *		loginList;
 	size_t					loginSize;
     CODE:
+	/* Use fallback like UA_ServerConfig_setDefaultWithSecurityPolicies */
+	if (optUserTokenPolicyUri == NULL &&
+	    config->svc_serverconfig->securityPoliciesSize > 0) {
+		optUserTokenPolicyUri =
+		    &config->svc_serverconfig->securityPolicies
+		    [config->svc_serverconfig->securityPoliciesSize - 1].
+		    policyUri;
+	}
 	if (optVerifyX509 && optUserTokenPolicyUri == NULL)
 		CROAK("VerifyX509 needs userTokenPolicyUri");
 	unpack_UA_UsernamePasswordLogin_List(&loginList, &loginSize,
@@ -3604,6 +3612,14 @@ UA_ServerConfig_setAccessControl_defaultWithLoginCallback(config, \
 	UA_UsernamePasswordLoginCallback	callback;
 	void *					context;
     CODE:
+	/* Use fallback like UA_ServerConfig_setDefaultWithSecurityPolicies */
+	if (optUserTokenPolicyUri == NULL &&
+	    config->svc_serverconfig->securityPoliciesSize > 0) {
+		optUserTokenPolicyUri =
+		    &config->svc_serverconfig->securityPolicies
+		    [config->svc_serverconfig->securityPoliciesSize - 1].
+		    policyUri;
+	}
 	if (optVerifyX509 && optUserTokenPolicyUri == NULL)
 		CROAK("VerifyX509 needs userTokenPolicyUri");
 	unpack_UA_UsernamePasswordLogin_List(&loginList, &loginSize,

--- a/t/server-config-accesscontrol.t
+++ b/t/server-config-accesscontrol.t
@@ -156,8 +156,7 @@ $server = OPCUA::Open62541::Test::Server->new(
 );
 $serverconfig = $server->{server}->getConfig();
 $server->start();
-my $policy = "http://opcfoundation.org/UA/SecurityPolicy#None";
-is($serverconfig->setAccessControl_default(0, undef, $policy, \@login),
+is($serverconfig->setAccessControl_default(0, undef, undef, \@login),
     STATUSCODE_GOOD, "set login");
 
 note "client with default passowrd";
@@ -217,8 +216,7 @@ $server = OPCUA::Open62541::Test::Server->new(
 );
 $serverconfig = $server->{server}->getConfig();
 $server->start();
-$policy = "http://opcfoundation.org/UA/SecurityPolicy#None";
-is($serverconfig->setAccessControl_default(1, undef, $policy, []),
+is($serverconfig->setAccessControl_default(1, undef, undef, []),
     STATUSCODE_GOOD, "set login empty");
 
 note "client with default passowrd";


### PR DESCRIPTION
UA_AccessControl_default() requires a non-NULL userTokenPolicyUri if verifyX509 or usernamePasswordLoginSize is set. UA_ServerConfig_setDefaultWithSecurityPolicies() uses the last of the securityPolicies from the server config.  Try this as a fallback in UA_ServerConfig_setAccessControl_default() XS wrapper.