### PR TITLE
Add session context to login callback.

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -2701,7 +2701,7 @@ unpack_UA_UsernamePasswordLogin_List(UA_UsernamePasswordLogin **outList,
 static UA_StatusCode
 loginCryptCheckpassCallback(const UA_String *userName, const UA_ByteString
     *password, size_t loginSize, const UA_UsernamePasswordLogin *loginList,
-    void *loginContext)
+    void **sessionContext, void *loginContext)
 {
 	char *pass;
 	size_t i;


### PR DESCRIPTION
Discussing the API of open62541 with upstream concluded that the session context should be added to the login callback.  Although not commited yet, make p5-opcua-open62541 compatible with future changes.  https://github.com/open62541/open62541/pull/5935