### PR TITLE
Open62541 1.4

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -48,6 +48,17 @@ check_lib(
 check_lib(
     function		=> "
 	UA_ServerConfig serverConfig;
+	UA_Logger logger;
+	serverConfig.logging = &logger;",
+    not_execute		=> 1,
+    lib			=> 'open62541',
+    header		=> 'open62541/server.h',
+    libpath		=> '/usr/local/lib',
+    incpath		=> '/usr/local/include',
+) and push @have, uc('UA_ServerConfig_logging');
+check_lib(
+    function		=> "
+	UA_ServerConfig serverConfig;
 	UA_CertificateVerification verifyX509;
 	(void)UA_AccessControl_default(&serverConfig,
 	    0, &verifyX509, NULL, 0, NULL);",

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -5183,6 +5183,8 @@ UA_Logger_setCallback(logger, log, context, clear)
 		CROAK("Clear '%s' is not a CODE reference",
 		    SvPV_nolen(clear));
     CODE:
+	if (logger->lg_logger->clear)
+		logger->lg_logger->clear(logger->lg_logger->context);
 	logger->lg_logger->context = logger;
 	logger->lg_logger->log = SvOK(log) ? loggerLogCallback : NULL;
 	logger->lg_logger->clear = SvOK(clear) ? loggerClearCallback : NULL;

--- a/t/logger-client-multi.t
+++ b/t/logger-client-multi.t
@@ -45,13 +45,13 @@ sub clear {
 	is($log_calls, 2, "second log call");
 	is($log_context, "second", "second context");
     }
-    is($clear_calls, 0, "logger scope");
+    is($clear_calls, 1, "logger scope");
 
     is($log_calls, 2, "logger begin");
     $client->connect("opc.tcp://localhost:");
     isnt($log_calls, 2, "logger end");
 }
-is($clear_calls, 1, "client scope");
+is($clear_calls, 2, "client scope");
 is($clear_context, "second", "clear context");
 
 $log_calls = $clear_calls = 0;
@@ -80,13 +80,13 @@ $log_context = $clear_context = undef;
 	is($log_calls, 3, "two logger: second log call");
 	is($log_context, "second", "two logger: second context");
     }
-    is($clear_calls, 0, "two logger: logger scope");
+    is($clear_calls, 1, "two logger: logger scope");
 
     is($log_calls, 3, "two logger: logger begin");
     $client->connect("opc.tcp://localhost:");
     isnt($log_calls, 3, "two logger: logger end");
 }
-is($clear_calls, 1, "two logger: client scope");
+is($clear_calls, 2, "two logger: client scope");
 is($clear_context, "second", "two logger: clear context");
 
 $log_calls = $clear_calls = 0;
@@ -116,13 +116,13 @@ $log_context = $clear_context = undef;
 	is($log_calls, 3, "two config: second log call");
 	is($log_context, "second", "two config: second context");
     }
-    is($clear_calls, 0, "two config: logger scope");
+    is($clear_calls, 1, "two config: logger scope");
 
     is($log_calls, 3, "two config: logger begin");
     $client->connect("opc.tcp://localhost:");
     isnt($log_calls, 3, "two config: logger end");
 }
-is($clear_calls, 1, "two config: client scope");
+is($clear_calls, 2, "two config: client scope");
 is($clear_context, "second", "two config: clear context");
 
 $log_calls = $clear_calls = 0;
@@ -154,13 +154,13 @@ $log_context = $clear_context = undef;
 	is($log_calls, 3, "two scope: second log call");
 	is($log_context, "second", "two scope: second context");
     }
-    is($clear_calls, 0, "two scope: logger scope");
+    is($clear_calls, 1, "two scope: logger scope");
 
     is($log_calls, 3, "two scope: logger begin");
     $client->connect("opc.tcp://localhost:");
     isnt($log_calls, 3, "two scope: logger end");
 }
-is($clear_calls, 1, "two scope: client scope");
+is($clear_calls, 2, "two scope: client scope");
 is($clear_context, "second", "two scope: clear context");
 
 $log_calls = $clear_calls = 0;
@@ -192,13 +192,13 @@ $log_context = $clear_context = undef;
 	is($log_calls, 3, "two logger scope: second log call");
 	is($log_context, "second", "two logger scope: second context");
     }
-    is($clear_calls, 0, "two logger scope: logger scope");
+    is($clear_calls, 1, "two logger scope: logger scope");
 
     is($log_calls, 3, "two logger scope: logger begin");
     $client->connect("opc.tcp://localhost:");
     isnt($log_calls, 3, "two logger scope: logger end");
 }
-is($clear_calls, 1, "two logger scope: client scope");
+is($clear_calls, 2, "two logger scope: client scope");
 is($clear_context, "second", "two logger scope: clear context");
 
 $log_calls = $clear_calls = 0;
@@ -233,11 +233,11 @@ $log_context = $clear_context = undef;
     $logger2->logWarning(1, "two config scope: second callback");
     is($log_calls, 3, "two config scope: second log call");
     is($log_context, "second", "two config scope: second context");
-    is($clear_calls, 0, "two config scope: logger scope");
+    is($clear_calls, 1, "two config scope: logger scope");
 
     is($log_calls, 3, "two config scope: logger begin");
     $client->connect("opc.tcp://localhost:");
     isnt($log_calls, 3, "two config scope: logger end");
 }
-is($clear_calls, 1, "two config scope: client scope");
+is($clear_calls, 2, "two config scope: client scope");
 is($clear_context, "second", "two config scope: clear context");

--- a/t/logger-server-multi.t
+++ b/t/logger-server-multi.t
@@ -40,7 +40,7 @@ sub clear {
 	is($log_calls, 2, "second log call");
 	is($log_context, "second", "second context");
     }
-    is($clear_calls, 0, "logger scope");
+    is($clear_calls, 1, "logger scope");
 
     is($log_calls, 2, "logger begin");
     $server->run_startup();
@@ -48,7 +48,7 @@ sub clear {
     $server->run_shutdown();
     isnt($log_calls, 2, "logger end");
 }
-is($clear_calls, 1, "server scope");
+is($clear_calls, 2, "server scope");
 is($clear_context, "second", "clear context");
 
 $log_calls = $clear_calls = 0;
@@ -76,7 +76,7 @@ $log_context = $clear_context = undef;
 	is($log_calls, 3, "two logger: second log call");
 	is($log_context, "second", "two logger: second context");
     }
-    is($clear_calls, 0, "two logger: logger scope");
+    is($clear_calls, 1, "two logger: logger scope");
 
     is($log_calls, 3, "two logger: logger begin");
     $server->run_startup();
@@ -84,7 +84,7 @@ $log_context = $clear_context = undef;
     $server->run_shutdown();
     isnt($log_calls, 3, "two logger: logger end");
 }
-is($clear_calls, 1, "two logger: server scope");
+is($clear_calls, 2, "two logger: server scope");
 is($clear_context, "second", "two logger: clear context");
 
 $log_calls = $clear_calls = 0;
@@ -113,7 +113,7 @@ $log_context = $clear_context = undef;
 	is($log_calls, 3, "two config: second log call");
 	is($log_context, "second", "two config: second context");
     }
-    is($clear_calls, 0, "two config: logger scope");
+    is($clear_calls, 1, "two config: logger scope");
 
     is($log_calls, 3, "two config: logger begin");
     $server->run_startup();
@@ -121,7 +121,7 @@ $log_context = $clear_context = undef;
     $server->run_shutdown();
     isnt($log_calls, 3, "two config: logger end");
 }
-is($clear_calls, 1, "two config: server scope");
+is($clear_calls, 2, "two config: server scope");
 is($clear_context, "second", "two config: clear context");
 
 $log_calls = $clear_calls = 0;
@@ -152,7 +152,7 @@ $log_context = $clear_context = undef;
 	is($log_calls, 3, "two scope: second log call");
 	is($log_context, "second", "two scope: second context");
     }
-    is($clear_calls, 0, "two scope: logger scope");
+    is($clear_calls, 1, "two scope: logger scope");
 
     is($log_calls, 3, "two scope: logger begin");
     $server->run_startup();
@@ -160,7 +160,7 @@ $log_context = $clear_context = undef;
     $server->run_shutdown();
     isnt($log_calls, 3, "two scope: logger end");
 }
-is($clear_calls, 1, "two scope: server scope");
+is($clear_calls, 2, "two scope: server scope");
 is($clear_context, "second", "two scope: clear context");
 
 $log_calls = $clear_calls = 0;
@@ -191,7 +191,7 @@ $log_context = $clear_context = undef;
 	is($log_calls, 3, "two logger scope: second log call");
 	is($log_context, "second", "two logger scope: second context");
     }
-    is($clear_calls, 0, "two logger scope: logger scope");
+    is($clear_calls, 1, "two logger scope: logger scope");
 
     is($log_calls, 3, "two logger scope: logger begin");
     $server->run_startup();
@@ -199,7 +199,7 @@ $log_context = $clear_context = undef;
     $server->run_shutdown();
     isnt($log_calls, 3, "two logger scope: logger end");
 }
-is($clear_calls, 1, "two logger scope: server scope");
+is($clear_calls, 2, "two logger scope: server scope");
 is($clear_context, "second", "two logger scope: clear context");
 
 $log_calls = $clear_calls = 0;
@@ -233,7 +233,7 @@ $log_context = $clear_context = undef;
     $logger2->logWarning(1, "two config scope: second callback");
     is($log_calls, 3, "two config scope: second log call");
     is($log_context, "second", "two config scope: second context");
-    is($clear_calls, 0, "two config scope: logger scope");
+    is($clear_calls, 1, "two config scope: logger scope");
 
     is($log_calls, 3, "two config scope: logger begin");
     $server->run_startup();
@@ -241,5 +241,5 @@ $log_context = $clear_context = undef;
     $server->run_shutdown();
     isnt($log_calls, 3, "two config scope: logger end");
 }
-is($clear_calls, 1, "two config scope: server scope");
+is($clear_calls, 2, "two config scope: server scope");
 is($clear_context, "second", "two config scope: clear context");


### PR DESCRIPTION
Open62541 version 1.4 uses a logging pointer instead of a logger
struct within the client and server config.  The logger clean
function is now called with the logger as parameter instead of the
context.  The Perl callback still uses the context argument.

This change allows OPCUA::Open62541 to compile with Open62541 1.4,
but the tests still fail.