### PR TITLE
Implement timeout accessors for client config

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -5077,6 +5077,21 @@ UA_ClientConfig_setSecurityMode(config, securityMode)
 	UA_MessageSecurityMode_copy(securityMode,
 	    &config->clc_clientconfig->securityMode);
 
+UA_UInt32
+UA_ClientConfig_getTimeout(config)
+	OPCUA_Open62541_ClientConfig	config
+    CODE:
+	RETVAL = config->clc_clientconfig->timeout;
+    OUTPUT:
+	RETVAL
+
+void
+UA_ClientConfig_setTimeout(config, timeout)
+	OPCUA_Open62541_ClientConfig	config
+	UA_UInt32			timeout
+    CODE:
+	config->clc_clientconfig->timeout = timeout;
+
 #ifdef HAVE_UA_CLIENTCONFIG_APPLICATIONURI
 
 SV *

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -740,6 +740,10 @@ If no trust or revocation list is set, the client will accept all certificates.
 
 =item $client_config->setSecurityMode($securityMode)
 
+=item $timeout = $client_config->getTimeout()
+
+=item $client_config->setTimeout($timeout)
+
 =item $clientDescription = $client_config->getClientDescription()
 
 =item $client_config->setClientDescription($clientDescription)


### PR DESCRIPTION
The default timeout for the client is 5 seconds.
This makes this configurable via the client config.