### PR TITLE
Implement some more missing client functions

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -4532,12 +4532,30 @@ UA_Client_sendAsyncBrowseNextRequest(client, request, callback, data, \
     OUTPUT:
 	RETVAL
 
+UA_ReadResponse
+UA_Client_Service_read(client, request)
+	OPCUA_Open62541_Client		client
+	OPCUA_Open62541_ReadRequest	request
+    CODE:
+	RETVAL = UA_Client_Service_read(client->cl_client, *request);
+    OUTPUT:
+	RETVAL
+
 UA_BrowseResponse
 UA_Client_Service_browse(client, request)
 	OPCUA_Open62541_Client		client
 	OPCUA_Open62541_BrowseRequest	request
     CODE:
 	RETVAL = UA_Client_Service_browse(client->cl_client, *request);
+    OUTPUT:
+	RETVAL
+
+UA_BrowseNextResponse
+UA_Client_Service_browseNext(client, request)
+	OPCUA_Open62541_Client			client
+	OPCUA_Open62541_BrowseNextRequest	request
+    CODE:
+	RETVAL = UA_Client_Service_browseNext(client->cl_client, *request);
     OUTPUT:
 	RETVAL
 

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -416,7 +416,11 @@ In scalar context croak due to 1.0 API incompatibility.
 
 =back
 
+=item $response = $client->Service_read(\%request)
+
 =item $response = $client->Service_browse(\%request)
+
+=item $response = $client->Service_browseNext(\%request)
 
 =item $status_code = $client->readAccessLevelAttribute(\%nodeId, \$outByte)
 

--- a/typemap
+++ b/typemap
@@ -27,6 +27,7 @@ OPCUA_Open62541_DataType		T_PACKED
 OPCUA_Open62541_GlobalNodeLifecycle	T_PACKED
 # these are used only as return value
 UA_ApplicationDescription		T_RETVAL_PACKED
+UA_BrowseNextResponse			T_RETVAL_PACKED
 UA_BrowseResponse			T_RETVAL_PACKED
 UA_BrowseResult				T_RETVAL_PACKED
 UA_BuildInfo				T_RETVAL_PACKED
@@ -40,6 +41,7 @@ UA_MessageSecurityMode			T_RETVAL_PACKED
 UA_ModifySubscriptionResponse		T_RETVAL_PACKED
 UA_MonitoredItemCreateRequest		T_RETVAL_PACKED
 UA_MonitoredItemCreateResult		T_RETVAL_PACKED
+UA_ReadResponse				T_RETVAL_PACKED
 UA_SetPublishingModeResponse		T_RETVAL_PACKED
 # these are needed to pass an output parameter
 OPCUA_Open62541_Boolean			T_PTROBJ_PACKED


### PR DESCRIPTION
* Service_browseNext() to browse continuation points
* Service_read() to specify the attributes with constants

Both functions were already implemented for their async variants.