### PR TITLE
Actually install opcua-dump script.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension OPCUA::Open62541.
 
 2.08
+  * Actually ship opcua-dump script with the distribution.
 
 2.07 2025-07-03
   * New tool "opcua_dump" that recursively browses the OPC UA address

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,6 @@
 Changes
 lib/OPCUA/Open62541.pm
+lib/OPCUA/Open62541/Client.pm
 lib/OPCUA/Open62541/Constant.pm
 lib/OPCUA/Open62541/Constant.pod
 lib/OPCUA/Open62541/Test/CA.pm
@@ -25,6 +26,7 @@ README
 script/client-server-read-write.pl
 script/constant.pl
 script/destroy.pl
+script/opcua-dump
 script/packed-type.pl
 script/patch-tools_generate_datatypes_py
 t/client-browse-async.t
@@ -40,6 +42,9 @@ t/client-connect-async-refcount.t
 t/client-connect-async.t
 t/client-connect.t
 t/client-disconnect-async.t
+t/client-findservers.t
+t/client-getendpoints.t
+t/client-highlevel.t
 t/client-leak.t
 t/client-monitoreditems-multiple.t
 t/client-monitoreditems.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -122,6 +122,7 @@ WriteMakefile(
     CONFIGURE_REQUIRES	=> {
 	'Devel::CheckLib'	=> 0,
     },
+    EXE_FILES		=> [ 'script/opcua-dump' ],
     PREREQ_PM		=> {},
     ABSTRACT_FROM	=> 'lib/OPCUA/Open62541.pm',
     AUTHOR		=> [

--- a/script/opcua-dump
+++ b/script/opcua-dump
@@ -144,7 +144,6 @@ sub get_all {
 	    # ignore remote reference
 	    next;
 	}
-	my $nodeid = $expid->{ExpandedNodeId_nodeId};
 	push @{$data->{references}}, $_;
     }
 

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -36,6 +36,8 @@ severity = 2
 [InputOutput::RequireCheckedOpen]
 [InputOutput::RequireCheckedSyscalls]
 [Modules::ProhibitEvilModules]
+[Modules::ProhibitExcessMainComplexity]
+severity = 2
 [Modules::RequireExplicitPackage]
 severity = 2
 [Modules::RequireFilenameMatchesPackage]
@@ -64,5 +66,3 @@ severity = 2
 [Variables::ProhibitConditionalDeclarations]
 [Variables::RequireLocalizedPunctuationVars]
 severity = 2
-
-#[Modules::ProhibitExcessMainComplexity]


### PR DESCRIPTION
Rename dump script opcua-dump and move it to script directory.  Add it to exe files so it is installed with the distribution.  Fix perl critic to accept the new opcua-dump script.  Update manifest and change log.