### PR TITLE
Implement UA_Client_Subscriptions_create_async

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -2185,6 +2185,20 @@ clientAsyncReadCallback(UA_Client *ua_client, void *userdata,
 }
 
 static void
+clientAsyncCreateSubscriptionCallback(UA_Client *ua_client, void *userdata,
+    UA_UInt32 requestId, UA_CreateSubscriptionResponse *response)
+{
+	dTHX;
+	SV *sv;
+
+	sv = newSV(0);
+	if (response != NULL)
+		pack_UA_CreateSubscriptionResponse(sv, response);
+
+	clientCallbackPerl(ua_client, userdata, requestId, sv);
+}
+
+static void
 clientDeleteSubscriptionCallback(UA_Client *ua_client, UA_UInt32 subId,
     void *subContext)
 {
@@ -4816,6 +4830,57 @@ UA_Client_Subscriptions_create(client, request, subscriptionContext, \
 			SvREFCNT_dec(sub->sc_context);
 		free(sub);
 	}
+    OUTPUT:
+	RETVAL
+
+UA_StatusCode
+UA_Client_Subscriptions_create_async(client, request, subscriptionContext, \
+    statusChangeCallback, deleteCallback, callback, data, outoptReqId)
+	OPCUA_Open62541_Client				client
+	OPCUA_Open62541_CreateSubscriptionRequest	request
+	SV *						subscriptionContext
+	SV *						statusChangeCallback
+	SV *						deleteCallback
+	SV *						callback
+	SV *						data
+	OPCUA_Open62541_UInt32				outoptReqId
+    PREINIT:
+	ClientCallbackData	ccd;
+	SubscriptionContext	sub;
+    CODE:
+	sub = calloc(1, sizeof(*sub));
+	if (sub == NULL)
+		CROAKE("calloc");
+	if (SvOK(subscriptionContext))
+		sub->sc_context = SvREFCNT_inc(subscriptionContext);
+	if (SvOK(statusChangeCallback))
+		sub->sc_change = newClientCallbackData(
+		    statusChangeCallback, ST(0), subscriptionContext);
+	if (SvOK(deleteCallback))
+		sub->sc_delete = newClientCallbackData(
+		    deleteCallback, ST(0), subscriptionContext);
+	ccd = newClientCallbackData(callback, ST(0), data);
+
+	DPRINTF("client %p, sub %p, sc_change %p, sc_delete %p, ccd %p, data %p",
+	    client, sub, sub->sc_change, sub->sc_delete, ccd, data);
+
+	RETVAL = UA_Client_Subscriptions_create_async(client->cl_client,
+	    *request, sub, clientStatusChangeNotificationCallback,
+	    clientDeleteSubscriptionCallback,
+	    (UA_ClientAsyncServiceCallback)clientAsyncCreateSubscriptionCallback,
+	    ccd, outoptReqId);
+	if (RETVAL != UA_STATUSCODE_GOOD) {
+		deleteClientCallbackData(ccd);
+		if (sub->sc_context)
+			SvREFCNT_dec(sub->sc_context);
+		if (sub->sc_change)
+			deleteClientCallbackData(sub->sc_change);
+		if (sub->sc_delete)
+			deleteClientCallbackData(sub->sc_delete);
+		free(sub);
+	}
+	if (outoptReqId != NULL)
+		pack_UA_UInt32(SvRV(ST(7)), outoptReqId);
     OUTPUT:
 	RETVAL
 

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -700,6 +700,19 @@ In scalar context croak due to 1.0 API incompatibility.
 
 =back
 
+=item $status_code = $client->Subscriptions_create_async(\%request, $subscriptionContext, \&statusChangeCallback, \&deleteCallback, \&callback, $data, \$reqId)
+
+=over 8
+
+=item $statusChangeCallback = sub { my ($client, $subscriptionId, $subscriptionContext, $notification) = @_ }
+
+=item $deleteCallback = sub { my ($client, $subscriptionId, $subscriptionContext) = @_ }
+
+=item $callback = sub { my ($client, $userdata, $requestId, \%response) = @_ }
+
+=back
+
+
 =item $response = $client->Subscriptions_modify(\%request)
 
 =item $response = $client->Subscriptions_delete(\%request)

--- a/t/client-subscription-async.t
+++ b/t/client-subscription-async.t
@@ -1,0 +1,92 @@
+use strict;
+use warnings;
+use OPCUA::Open62541 qw(:STATUSCODE);
+
+use OPCUA::Open62541::Test::Server;
+use OPCUA::Open62541::Test::Client;
+use Test::More tests =>
+    OPCUA::Open62541::Test::Server::planning() +
+    OPCUA::Open62541::Test::Client::planning() + 11;
+use Test::Deep;
+use Test::Exception;
+use Test::NoWarnings;
+use Test::LeakTrace;
+
+
+my $server = OPCUA::Open62541::Test::Server->new();
+$server->start();
+my $client = OPCUA::Open62541::Test::Client->new(port => $server->port());
+$client->start();
+$server->run();
+$client->run();
+
+my $request = OPCUA::Open62541::Client->CreateSubscriptionRequest_default();
+my $response = {
+    CreateSubscriptionResponse_subscriptionId => 1,
+    CreateSubscriptionResponse_revisedPublishingInterval => '500',
+    CreateSubscriptionResponse_revisedMaxKeepAliveCount => 10,
+    CreateSubscriptionResponse_revisedLifetimeCount => 10000,
+    CreateSubscriptionResponse_responseHeader => ignore(),
+};
+
+### deep
+
+my ($deleted, $context, $reqid);
+my $data = "foo",
+my $subscribed = 0;
+is($client->{client}->Subscriptions_create_async(
+    $request,
+    \$context,
+    sub {$context++},
+    sub {
+	my ($client, $id, $ctx) = @_;
+	$deleted = 1;
+	$$ctx = $id;
+    },
+    sub {
+	my ($c, $d, $i, $r) = @_;
+
+	is($c, $client->{client}, "client");
+	is($$d, "foo", "data in");
+	$$d = "bar";
+	is($i, $reqid, "reqid");
+	cmp_deeply($r, $response, "response");
+
+	$subscribed = 1;
+    },
+    \$data,
+    \$reqid,
+), STATUSCODE_GOOD, "Subscriptions_create_async");
+is($data, "foo", "data unchanged");
+like($reqid, qr/^\d+$/, "reqid number");
+$client->iterate(\$subscribed, "subscribe deep");
+is($data, 'bar', "data out");
+
+my $subid;
+no_leaks_ok {
+    $subscribed = 0;
+    $client->{client}->Subscriptions_create_async(
+	$request,
+	\$context,
+	sub {$context++},
+	sub {
+	    my ($client, $id, $ctx) = @_;
+	    $deleted = 1;
+	    $$ctx = $id;
+	},
+	sub {
+	    my ($c, $d, $i, $r) = @_;
+	    $subscribed = 1;
+	    $subid = $r->{CreateSubscriptionResponse_subscriptionId};
+	},
+	$data,
+	\$reqid,
+    );
+    $client->iterate(\$subscribed);
+    $client->{client}->Subscriptions_delete({
+	DeleteSubscriptionsRequest_subscriptionIds => [$subid],
+    })
+} "Subscriptions_create_async leak";
+
+$client->stop();
+$server->stop();


### PR DESCRIPTION
UA_Client_Subscriptions_create_async() combines the functionality of UA_Client_Subscriptions_create() with the logic we use for the other asynchronous requests.

In earlier versions of open62541 the asynchronous callback is of type UA_ClientAsyncServiceCallback, while master has a dedicated callback function type UA_ClientAsyncCreateSubscriptionCallback. For now we just cast to UA_ClientAsyncServiceCallback, since we only support 1.3.