### PR TITLE
Fix Subscriptions_create memory leak

### DIFF
--- a/Open62541.xs
+++ b/Open62541.xs
@@ -4806,8 +4806,8 @@ UA_Client_Subscriptions_create(client, request, subscriptionContext, \
 	 * introduced in 2d5355b7be11233e67d5ff6be6b2a34e971e1814 does
 	 * it in most cases.
 	 */
-	if (RETVAL.responseHeader.serviceResult ==
-	    UA_STATUSCODE_BADOUTOFMEMORY) {
+	if (RETVAL.responseHeader.serviceResult !=
+	    UA_STATUSCODE_GOOD) {
 		if (sub->sc_delete)
 			deleteClientCallbackData(sub->sc_delete);
 		if (sub->sc_change)

--- a/t/client-subscription.t
+++ b/t/client-subscription.t
@@ -293,19 +293,15 @@ is($response->{CreateSubscriptionResponse_responseHeader}{ResponseHeader_service
    "BadTooManySubscriptions",
    "subscription create response too many");
 
-$client->stop();
-
 ($deleted, $context) = (undef, undef);
 no_leaks_ok {
-    $client->{client}->connect($client->{url});
     $response = $client->{client}->Subscriptions_create(
 	$request,
 	$context,
 	sub {},
 	sub {$deleted = 1; $context = "foo"},
     );
-    # open52651 1.3 disconnect calls the callback that frees the context
-    $client->{client}->disconnect();
 } "Subscriptions create too many callback leak";
 
+$client->stop();
 $server->stop();


### PR DESCRIPTION
In open62541 1.3 and master the subscription is only created in UA_Client_Subscriptions_create() if the service request was successful. The delete callback is only called later if a subscription was created.

But in Open62541.xs we only did the cleanup of our custom data in case of STATUSCODE_BADOUTOFMEMORY (behaviour in open62541 may have changed in newer versions). Instead we now always do the cleanup if the status code is not STATUSCODE_GOOD.

The already existing leak test for this case was flawed because of explicitly calling stop() before and disconnect() inside of the test.