### PR TITLE
Implement MonitoredItems_createDataChanges_async

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -46,11 +46,13 @@ t/client-findservers.t
 t/client-getendpoints.t
 t/client-highlevel.t
 t/client-leak.t
+t/client-monitoreditems-multiple-async.t
 t/client-monitoreditems-multiple.t
 t/client-monitoreditems.t
 t/client-read-async.t
 t/client-server-read-write.t
 t/client-statecallback.t
+t/client-subscription-async.t
 t/client-subscription.t
 t/client-variant.t
 t/client.t

--- a/Open62541.xs
+++ b/Open62541.xs
@@ -2199,6 +2199,20 @@ clientAsyncCreateSubscriptionCallback(UA_Client *ua_client, void *userdata,
 }
 
 static void
+clientAsyncCreateMonitoredItemsCallback(UA_Client *ua_client, void *userdata,
+    UA_UInt32 requestId, UA_CreateMonitoredItemsResponse *response)
+{
+	dTHX;
+	SV *sv;
+
+	sv = newSV(0);
+	if (response != NULL)
+		pack_UA_CreateMonitoredItemsResponse(sv, response);
+
+	clientCallbackPerl(ua_client, userdata, requestId, sv);
+}
+
+static void
 clientDeleteSubscriptionCallback(UA_Client *ua_client, UA_UInt32 subId,
     void *subContext)
 {
@@ -5089,6 +5103,167 @@ UA_Client_MonitoredItems_createDataChanges(client, request, contextsSV, \
 			SvREFCNT_dec(marr->ma_mon[i].mc_arrays);
 		}
 	}
+    OUTPUT:
+	RETVAL
+
+UA_StatusCode
+UA_Client_MonitoredItems_createDataChanges_async(client, request, contextsSV, \
+    callbacksSV, deleteCallbacksSV, createCallbackSV, data, outoptReqId)
+	OPCUA_Open62541_Client				client
+	OPCUA_Open62541_CreateMonitoredItemsRequest	request
+	SV *						contextsSV
+	SV *						callbacksSV
+	SV *						deleteCallbacksSV
+	SV *						createCallbackSV
+	SV *						data
+	OPCUA_Open62541_UInt32				outoptReqId
+    PREINIT:
+	size_t						itemsToCreateSize;
+	size_t						i;
+	ssize_t						top;
+	AV *						contextsAV;
+	AV *						callbacksAV;
+	AV *						deleteCallbacksAV;
+	SV **						contextSV;
+	SV **						callbackSV;
+	SV **						deleteCallbackSV;
+	OPCUA_Open62541_MonitoredItemArrays		marr;
+	SV *						marrSV;
+	SV *						sv;
+	ClientCallbackData				ccd;
+    CODE:
+	itemsToCreateSize = request->itemsToCreateSize;
+
+	if (SvOK(contextsSV)) {
+		if (!SvROK(contextsSV) || SvTYPE(SvRV(contextsSV)) != SVt_PVAV)
+			CROAK("Not an ARRAY reference for contexts");
+
+		contextsAV = (AV*)SvRV(contextsSV);
+
+		top = av_top_index(contextsAV);
+		if (top == -1)
+			CROAK("No elements in contexts");
+		if ((size_t)(top + 1) != itemsToCreateSize)
+			CROAK("Not enough elements in contexts");
+	} else {
+		contextsAV = NULL;
+	}
+	if (SvOK(callbacksSV)) {
+		if (!SvROK(callbacksSV) ||
+		    SvTYPE(SvRV(callbacksSV)) != SVt_PVAV) {
+			CROAK("Not an ARRAY reference for callbacks");
+		}
+		callbacksAV = (AV*)SvRV(callbacksSV);
+
+		top = av_top_index(callbacksAV);
+		if (top == -1)
+			CROAK("No elements in callbacks");
+		if ((size_t)(top + 1) != itemsToCreateSize)
+			CROAK("Not enough elements in callbacks");
+	} else {
+		callbacksAV = NULL;
+	}
+	if (SvOK(deleteCallbacksSV)) {
+		if (!SvROK(deleteCallbacksSV) ||
+		    SvTYPE(SvRV(deleteCallbacksSV)) != SVt_PVAV) {
+			CROAK("Not an ARRAY reference for deleteCallbacks");
+		}
+		deleteCallbacksAV = (AV*)SvRV(deleteCallbacksSV);
+
+		top = av_top_index(deleteCallbacksAV);
+		if (top == -1)
+			CROAK("No elements in deleteCallbacks");
+		if ((size_t)(top + 1) != itemsToCreateSize)
+			CROAK("Not enough elements in deleteCallbacks");
+	} else {
+		deleteCallbacksAV = NULL;
+	}
+
+	marr = calloc(1, sizeof(*marr));
+	if (marr == NULL)
+		CROAKE("calloc");
+	/*
+	 * Convert struct MonitoredItemArrays into a PV.  This
+	 * allows to use Perl's ref counting for memory management.
+	 * The destroy function will free everything.  Leaks can
+	 * be found with Test::LeakTrace.
+	 */
+	marrSV = sv_2mortal(sv_setref_pv(newSV(0),
+	    "OPCUA::Open62541::MonitoredItemArrays", marr));
+
+	marr->ma_mon = calloc(itemsToCreateSize, sizeof(*marr->ma_mon));
+	marr->ma_context = calloc(itemsToCreateSize, sizeof(*marr->ma_context));
+	marr->ma_change = calloc(itemsToCreateSize, sizeof(*marr->ma_change));
+	marr->ma_delete = calloc(itemsToCreateSize, sizeof(*marr->ma_delete));
+	if (marr->ma_mon == NULL || marr->ma_context == NULL ||
+	    marr->ma_change == NULL || marr->ma_delete == NULL) {
+		/* The destroy function of the mortal marrSV will free. */
+		CROAKE("calloc");
+	}
+
+	for (i = 0; i < itemsToCreateSize; i++) {
+		if (contextsAV != NULL)
+			contextSV = av_fetch(contextsAV, i, 0);
+		else {
+			sv = sv_2mortal(newSV(0));
+			contextSV = &sv;
+		}
+
+		if (callbacksAV != NULL)
+			callbackSV = av_fetch(callbacksAV, i, 0);
+		else
+			callbackSV = NULL;
+
+		if (deleteCallbacksAV != NULL)
+			deleteCallbackSV = av_fetch(deleteCallbacksAV, i, 0);
+		else
+			deleteCallbackSV = NULL;
+
+		if (callbackSV != NULL && SvOK(*callbackSV))
+			marr->ma_mon[i].mc_change = newClientCallbackData(
+			    *callbackSV, ST(0), *contextSV);
+		if (deleteCallbackSV != NULL && SvOK(*deleteCallbackSV))
+			marr->ma_mon[i].mc_delete = newClientCallbackData(
+			    *deleteCallbackSV, ST(0), *contextSV);
+		marr->ma_mon[i].mc_arrays = SvREFCNT_inc(marrSV);
+
+		marr->ma_context[i] = &marr->ma_mon[i];
+		marr->ma_change[i] = clientDataChangeNotificationCallback;
+		marr->ma_delete[i] = clientDeleteMonitoredItemCallback;
+	}
+
+	ccd = newClientCallbackData(createCallbackSV, ST(0), data);
+
+	DPRINTF("client %p, items %zu, marr %p, ma_mon %p, ma_context %p, "
+	    "ma_change %p, ma_delete %p, ccd %p",
+	    client, itemsToCreateSize, marr, marr->ma_mon, marr->ma_context,
+	    marr->ma_change, marr->ma_delete, ccd);
+
+	RETVAL = UA_Client_MonitoredItems_createDataChanges_async(
+	    client->cl_client, *request, marr->ma_context, marr->ma_change,
+	    marr->ma_delete,
+	    (UA_ClientAsyncServiceCallback)clientAsyncCreateMonitoredItemsCallback,
+	    ccd, outoptReqId);
+
+	if (RETVAL != UA_STATUSCODE_GOOD)
+		deleteClientCallbackData(ccd);
+	if (SvREFCNT(marrSV) > 1 && RETVAL != UA_STATUSCODE_GOOD) {
+		for (i = 0; i < itemsToCreateSize; i++) {
+			if (marr->ma_mon[i].mc_delete)
+				deleteClientCallbackData(
+				    marr->ma_mon[i].mc_delete);
+			if (marr->ma_mon[i].mc_change)
+				deleteClientCallbackData(
+				    marr->ma_mon[i].mc_change);
+			/*
+			 * When mc_arrays ref count reaches 0, Perl will free
+			 * everything in MonitoredItemArrays destroy function.
+			 */
+			SvREFCNT_dec(marr->ma_mon[i].mc_arrays);
+		}
+	}
+	if (outoptReqId != NULL)
+		pack_UA_UInt32(SvRV(ST(7)), outoptReqId);
     OUTPUT:
 	RETVAL
 

--- a/lib/OPCUA/Open62541.pm
+++ b/lib/OPCUA/Open62541.pm
@@ -739,6 +739,32 @@ In scalar context croak due to 1.0 API incompatibility.
 =item $response = $client->MonitoredItems_createDataChanges(\%request,
 	\@monitoredContexts, \@dataChangeCallbacks, \@deleteCallbacks)
 
+=over 8
+
+=item $dataChangeCallback = sub { my ($client, $subscriptionId,
+	$subscriptionContext, $monitoredId, $monitoredContext, $value) = @_ }
+
+=item $deleteCallback = sub { my ($client, $subscriptionId,
+	$subscriptionContext, $monitoredId, $monitoredContext) = @_ }
+
+=back
+
+=item $status_code = $client->MonitoredItems_createDataChanges_async(\%request,
+	\@monitoredContexts, \@dataChangeCallbacks, \@deleteCallbacks,
+	\&createCallback, $data, \$reqId)
+
+=over 8
+
+=item $dataChangeCallback = sub { my ($client, $subscriptionId,
+	$subscriptionContext, $monitoredId, $monitoredContext, $value) = @_ }
+
+=item $deleteCallback = sub { my ($client, $subscriptionId,
+	$subscriptionContext, $monitoredId, $monitoredContext) = @_ }
+
+=item $createCallback = sub { my ($client, $userdata, $requestId, \%response) = @_ }
+
+=back
+
 =item $response  = $client->MonitoredItems_delete(\%request)
 
 =item $status_code  = $client->MonitoredItems_deleteSingle($subscriptionId, $monitoredItemId)

--- a/t/client-monitoreditems-multiple-async.t
+++ b/t/client-monitoreditems-multiple-async.t
@@ -1,0 +1,241 @@
+use strict;
+use warnings;
+
+use OPCUA::Open62541 qw(:all);
+use OPCUA::Open62541::Test::Client;
+use OPCUA::Open62541::Test::Server;
+
+use Test::More tests =>
+    OPCUA::Open62541::Test::Server::planning() +
+    OPCUA::Open62541::Test::Client::planning() + 24;
+use Test::Deep;
+use Test::Exception;
+use Test::LeakTrace;
+use Test::NoWarnings;
+
+my $server = OPCUA::Open62541::Test::Server->new();
+$server->start();
+$server->run();
+
+my $client = OPCUA::Open62541::Test::Client->new(port => $server->port());
+$client->start();
+$client->run();
+
+# pre create subscription
+
+my $request = OPCUA::Open62541::Client->CreateSubscriptionRequest_default();
+my $response = $client->{client}->Subscriptions_create(
+    $request, undef, undef, undef);
+is($response->{CreateSubscriptionResponse_responseHeader}
+    {ResponseHeader_serviceResult},
+   "Good",
+   "subscription create response statuscode");
+my $subid = $response->{CreateSubscriptionResponse_subscriptionId};
+
+# MonitoredItems_createDataChanges_async
+
+my @nodes = map {{
+    NodeId_identifier => $_,
+    NodeId_identifierType => 0,
+    NodeId_namespaceIndex => 0,
+}} NS0ID_SERVER_SERVERSTATUS_STARTTIME, NS0ID_SERVER_SERVERSTATUS_CURRENTTIME;
+
+$request = {
+    CreateMonitoredItemsRequest_subscriptionId => $subid,
+    CreateMonitoredItemsRequest_timestampsToReturn => TIMESTAMPSTORETURN_BOTH,
+    CreateMonitoredItemsRequest_itemsToCreate => [ map {
+	OPCUA::Open62541::Client->MonitoredItemCreateRequest_default($_)
+    } @nodes ],
+};
+
+my $noop_create = sub {};
+
+# input validation
+
+throws_ok { $client->{client}->MonitoredItems_createDataChanges_async(
+    $request, 0, undef, undef, $noop_create, undef, undef) }
+    qr/Not an ARRAY reference for contexts/, "croak no array contexts";
+throws_ok { $client->{client}->MonitoredItems_createDataChanges_async(
+    $request, undef, 1, undef, $noop_create, undef, undef) }
+    qr/Not an ARRAY reference for callbacks/, "croak no array callbacks";
+throws_ok { $client->{client}->MonitoredItems_createDataChanges_async(
+    $request, undef, undef, {}, $noop_create, undef, undef) }
+    qr/Not an ARRAY reference for deleteCallbacks/,
+    "croak no array deleteCallbacks";
+throws_ok { $client->{client}->MonitoredItems_createDataChanges_async(
+    $request, [], [], [], $noop_create, undef, undef) }
+    qr/No elements in contexts/, "croak no elements contexts";
+throws_ok { $client->{client}->MonitoredItems_createDataChanges_async(
+    $request, [1, 2], [], [], $noop_create, undef, undef) }
+    qr/No elements in callbacks/, "croak no elements callbacks";
+throws_ok { $client->{client}->MonitoredItems_createDataChanges_async(
+    $request, [1, 2], [3, 4], [], $noop_create, undef, undef) }
+    qr/No elements in deleteCallbacks/, "croak no elements deleteCallbacks";
+throws_ok { $client->{client}->MonitoredItems_createDataChanges_async(
+    $request, undef, ['foo', 'bar'], undef, $noop_create, undef, undef) }
+    qr/Callback 'foo' is not a CODE reference/, "croak no coderef callbacks";
+throws_ok { $client->{client}->MonitoredItems_createDataChanges_async(
+    $request, undef, undef, [{}, {}], $noop_create, undef, undef) }
+    qr/Callback 'HASH\([0-9a-fx]+\)' is not a CODE reference/,
+    "croak no coderef deleteCallbacks";
+
+# happy path: create monitored items, verify callbacks fire, then delete them
+
+my $expected_response = {
+    CreateMonitoredItemsResponse_results => [
+	{
+	    MonitoredItemCreateResult_statusCode => 'Good',
+	    MonitoredItemCreateResult_filterResult => ignore(),
+	    MonitoredItemCreateResult_revisedSamplingInterval => 250,
+	    MonitoredItemCreateResult_revisedQueueSize => 1,
+	    MonitoredItemCreateResult_monitoredItemId => 1,
+	},
+	{
+	    MonitoredItemCreateResult_statusCode => 'Good',
+	    MonitoredItemCreateResult_filterResult => ignore(),
+	    MonitoredItemCreateResult_revisedSamplingInterval => 250,
+	    MonitoredItemCreateResult_revisedQueueSize => 1,
+	    MonitoredItemCreateResult_monitoredItemId => 2,
+	},
+    ],
+    CreateMonitoredItemsResponse_responseHeader => ignore(),
+    CreateMonitoredItemsResponse_diagnosticInfos => [],
+};
+
+my (@changed, @deleted, @monids);
+my $reqid;
+my $data = 'foo';
+my $monitored = 0;
+is($client->{client}->MonitoredItems_createDataChanges_async(
+    $request,
+    [0, 1],
+    [ map { sub {
+	my ($cl, $sid, $sctx, $mid, $mctx, $v) = @_;
+	$changed[$mctx]++;
+    } } @nodes ],
+    [ map { sub {
+	my ($cl, $sid, $sctx, $mid, $mctx) = @_;
+	$deleted[$mctx]++;
+    } } @nodes ],
+    sub {
+	my ($cl, $d, $r, $resp) = @_;
+	$$d = "bar";
+	$monitored = 1;
+	cmp_deeply($resp, $expected_response, "create response");
+	for my $result (@{$resp->{CreateMonitoredItemsResponse_results}}) {
+	    push @monids, $result->{MonitoredItemCreateResult_monitoredItemId};
+	}
+    },
+    \$data,
+    \$reqid,
+), STATUSCODE_GOOD, 'MonitoredItems_createDataChanges_async status');
+
+is($data, "foo", "data unchanged");
+$client->iterate(\$monitored, "async create monitored");
+like($reqid, qr/^\d+$/, "reqid number");
+is($data, 'bar', "data changed by create callback");
+
+# iterate long enough to receive the initial data change notifications
+
+my $i;
+$client->iterate(sub { sleep 1; ++$i > 2 });
+ok($changed[0] && $changed[1], "dataChangeCallback fired for each item");
+
+# delete items; verify delete callbacks fire
+
+$response = $client->{client}->MonitoredItems_delete({
+    DeleteMonitoredItemsRequest_subscriptionId => $subid,
+    DeleteMonitoredItemsRequest_monitoredItemIds => \@monids,
+});
+is($response->{DeleteMonitoredItemsResponse_responseHeader}
+    {ResponseHeader_serviceResult}, 'Good',
+    "monitored items delete serviceresult");
+
+$i = 0;
+$client->iterate(sub { sleep 1; ++$i > 1 });
+ok($deleted[0] && $deleted[1], "deleteCallback fired for each item");
+
+# failure path: invalid subscription id; async returns error synchronously,
+# createCallback is not invoked.
+
+{
+    my $called = 0;
+    my $bad_request = { %$request };
+    $bad_request->{CreateMonitoredItemsRequest_subscriptionId} = 999;
+    is($client->{client}->MonitoredItems_createDataChanges_async(
+	$bad_request,
+	undef, undef, undef,
+	sub { $called = 1 },
+	undef, undef,
+    ), 'BadSubscriptionIdInvalid', "async create bad sub returns error");
+    is($called, 0, "createCallback not called on bad sub");
+}
+
+# leak tests
+
+no_leaks_ok {
+    my $done = 0;
+    my @ids;
+    my $data = 'foo';
+    my $reqid;
+    $client->{client}->MonitoredItems_createDataChanges_async(
+	$request,
+	[0, 1],
+	[ map { sub {} } @nodes ],
+	[ map { sub {} } @nodes ],
+	sub {
+	    my ($cl, $d, $r, $resp) = @_;
+	    $done = 1;
+	    @ids = map { $_->{MonitoredItemCreateResult_monitoredItemId} }
+		@{$resp->{CreateMonitoredItemsResponse_results}};
+	},
+	\$data, \$reqid,
+    );
+    $client->iterate(\$done);
+    $client->{client}->MonitoredItems_delete({
+	DeleteMonitoredItemsRequest_subscriptionId => $subid,
+	DeleteMonitoredItemsRequest_monitoredItemIds => \@ids,
+    });
+} "async create delete leak";
+
+no_leaks_ok {
+    my $bad_request = { %$request };
+    $bad_request->{CreateMonitoredItemsRequest_subscriptionId} = 999;
+    my $data = 'foo';
+    my $reqid;
+    $client->{client}->MonitoredItems_createDataChanges_async(
+	$bad_request,
+	[0, 1],
+	[ map { sub {} } @nodes ],
+	[ map { sub {} } @nodes ],
+	sub {}, \$data, \$reqid,
+    );
+} "async create bad sub leak";
+
+no_leaks_ok {
+    my $done = 0;
+    my $bad_node_request = {
+	CreateMonitoredItemsRequest_subscriptionId => $subid,
+	CreateMonitoredItemsRequest_timestampsToReturn => TIMESTAMPSTORETURN_BOTH,
+	CreateMonitoredItemsRequest_itemsToCreate => [ map {
+	    OPCUA::Open62541::Client->MonitoredItemCreateRequest_default({
+		NodeId_identifier => 0,
+		NodeId_identifierType => 0,
+		NodeId_namespaceIndex => 0,
+	    })
+	} @nodes ],
+    };
+    my $data = 'foo';
+    my $reqid;
+    $client->{client}->MonitoredItems_createDataChanges_async(
+	$bad_node_request,
+	[0, 1],
+	[ map { sub {} } @nodes ],
+	[ map { sub {} } @nodes ],
+	sub { $done = 1 }, \$data, \$reqid,
+    );
+    $client->iterate(\$done);
+} "async create bad node leak";
+
+$client->stop();
+$server->stop();


### PR DESCRIPTION
UA_Client_MonitoredItems_createDataChanges_async() combines the functionality of UA_Client_MonitoredItems_createDataChanges() with the logic we use for the other asynchronous requests. As with UA_Client_Subscriptions_create_async() we cast to
UA_ClientAsyncServiceCallback for 1.3 compatibility.