### PR TITLE
Allow new error code in encrytion test.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         config:
           - {v: 'v1.3.17'}
+          - {v: 'v1.3.18'}
           - {v: '1.3'}
 # logger in 1.4 does not compile due to different storage life time
 #          - {v: '1.4'}

--- a/t/encryption.t
+++ b/t/encryption.t
@@ -277,7 +277,8 @@ SKIP: {
 	server_trustList      => [$ca->{certs}{ca_server}{cert_pem}],
     );
 
-    like($client->{client}->connect($client->url()), qr/^BadTimeout|BadConnectionClosed$/,
+    like($client->{client}->connect($client->url()),
+	qr/^(BadTimeout|BadConnectionClosed|BadCertificateChainIncomplete)$/,
        'client connect validation server not trusted fail');
 
     # https://github.com/open62541/open62541/commit/19ecf3e5627ae1d0c20ce661aee8e0164b03d86c


### PR DESCRIPTION
Library open62541 1.3.18 returns the precise statuscode when triggering a reconnect.  Adjust expected test result.  Run tests with v1.3.18 on github pipeline.